### PR TITLE
Basic Mux and Demux blocks added

### DIFF
--- a/app/resources/blocks/logic/demux_1_2.iceb
+++ b/app/resources/blocks/logic/demux_1_2.iceb
@@ -1,0 +1,122 @@
+{
+  "image": "resources/images/demux.svg",
+  "state": {
+    "pan": {
+      "x": 104.8444188797269,
+      "y": 152.1580250587398
+    },
+    "zoom": 0.8586960434913635
+  },
+  "graph": {
+    "blocks": [
+      {
+        "id": "91e2ff2d-2430-41e5-9d21-bc9ec4082aaa",
+        "type": "basic.output",
+        "data": {
+          "label": "out0"
+        },
+        "position": {
+          "x": 720,
+          "y": 96
+        }
+      },
+      {
+        "id": "c6dc7002-dfc0-45fd-88e2-b5e5a75231f2",
+        "type": "basic.output",
+        "data": {
+          "label": "out1"
+        },
+        "position": {
+          "x": 720,
+          "y": 224
+        }
+      },
+      {
+        "id": "5fc9a8e9-d463-4c1f-b6a3-185d5cabb406",
+        "type": "basic.input",
+        "data": {
+          "label": "in0"
+        },
+        "position": {
+          "x": 0,
+          "y": 96
+        }
+      },
+      {
+        "id": "75cafe5a-1968-49ed-9e05-70d1bc3fbd0f",
+        "type": "basic.input",
+        "data": {
+          "label": "sel0"
+        },
+        "position": {
+          "x": 0,
+          "y": 224
+        }
+      },
+      {
+        "id": "c8fdb023-d458-4657-899c-5749a256be09",
+        "type": "basic.code",
+        "data": {
+          "code": "assign {out1,out0} = in0 << sel0;",
+          "ports": {
+            "in": [
+              "in0",
+              "sel0"
+            ],
+            "out": [
+              "out0",
+              "out1"
+            ]
+          }
+        },
+        "position": {
+          "x": 208,
+          "y": 64
+        }
+      }
+    ],
+    "wires": [
+      {
+        "source": {
+          "block": "c8fdb023-d458-4657-899c-5749a256be09",
+          "port": "out1"
+        },
+        "target": {
+          "block": "c6dc7002-dfc0-45fd-88e2-b5e5a75231f2",
+          "port": "in"
+        }
+      },
+      {
+        "source": {
+          "block": "c8fdb023-d458-4657-899c-5749a256be09",
+          "port": "out0"
+        },
+        "target": {
+          "block": "91e2ff2d-2430-41e5-9d21-bc9ec4082aaa",
+          "port": "in"
+        }
+      },
+      {
+        "source": {
+          "block": "5fc9a8e9-d463-4c1f-b6a3-185d5cabb406",
+          "port": "out"
+        },
+        "target": {
+          "block": "c8fdb023-d458-4657-899c-5749a256be09",
+          "port": "in0"
+        }
+      },
+      {
+        "source": {
+          "block": "75cafe5a-1968-49ed-9e05-70d1bc3fbd0f",
+          "port": "out"
+        },
+        "target": {
+          "block": "c8fdb023-d458-4657-899c-5749a256be09",
+          "port": "sel0"
+        }
+      }
+    ]
+  },
+  "deps": {}
+}

--- a/app/resources/blocks/logic/demux_1_4.iceb
+++ b/app/resources/blocks/logic/demux_1_4.iceb
@@ -1,0 +1,188 @@
+{
+  "image": "resources/images/demux.svg",
+  "state": {
+    "pan": {
+      "x": 75.84442855228853,
+      "y": 63.15803102316195
+    },
+    "zoom": 0.8586960434913635
+  },
+  "graph": {
+    "blocks": [
+      {
+        "id": "8a50b4e9-884d-49bb-98c3-3cd1e6cb3f4f",
+        "type": "basic.code",
+        "data": {
+          "code": "assign {out3,out2,out1,out0} = in0 << {sel1,sel0};",
+          "ports": {
+            "in": [
+              "in0",
+              "sel0",
+              "sel1"
+            ],
+            "out": [
+              "out0",
+              "out1",
+              "out2",
+              "out3"
+            ]
+          }
+        },
+        "position": {
+          "x": 208,
+          "y": 64
+        }
+      },
+      {
+        "id": "91e2ff2d-2430-41e5-9d21-bc9ec4082aaa",
+        "type": "basic.output",
+        "data": {
+          "label": "out0"
+        },
+        "position": {
+          "x": 760,
+          "y": 40
+        }
+      },
+      {
+        "id": "c6dc7002-dfc0-45fd-88e2-b5e5a75231f2",
+        "type": "basic.output",
+        "data": {
+          "label": "out1"
+        },
+        "position": {
+          "x": 760,
+          "y": 120
+        }
+      },
+      {
+        "id": "5e246f93-51ad-4d6f-83f1-4fcce69c5ae3",
+        "type": "basic.output",
+        "data": {
+          "label": "out2"
+        },
+        "position": {
+          "x": 760,
+          "y": 200
+        }
+      },
+      {
+        "id": "b9d764ea-538a-420f-a8d3-45af7a8e30a2",
+        "type": "basic.output",
+        "data": {
+          "label": "out3"
+        },
+        "position": {
+          "x": 760,
+          "y": 280
+        }
+      },
+      {
+        "id": "5fc9a8e9-d463-4c1f-b6a3-185d5cabb406",
+        "type": "basic.input",
+        "data": {
+          "label": "in0"
+        },
+        "position": {
+          "x": 16,
+          "y": 72
+        }
+      },
+      {
+        "id": "75cafe5a-1968-49ed-9e05-70d1bc3fbd0f",
+        "type": "basic.input",
+        "data": {
+          "label": "sel0"
+        },
+        "position": {
+          "x": 16,
+          "y": 160
+        }
+      },
+      {
+        "id": "657dab9e-6580-4f02-b54f-66477863f26a",
+        "type": "basic.input",
+        "data": {
+          "label": "sel1"
+        },
+        "position": {
+          "x": 16,
+          "y": 248
+        }
+      }
+    ],
+    "wires": [
+      {
+        "source": {
+          "block": "8a50b4e9-884d-49bb-98c3-3cd1e6cb3f4f",
+          "port": "out0"
+        },
+        "target": {
+          "block": "91e2ff2d-2430-41e5-9d21-bc9ec4082aaa",
+          "port": "in"
+        }
+      },
+      {
+        "source": {
+          "block": "8a50b4e9-884d-49bb-98c3-3cd1e6cb3f4f",
+          "port": "out1"
+        },
+        "target": {
+          "block": "c6dc7002-dfc0-45fd-88e2-b5e5a75231f2",
+          "port": "in"
+        }
+      },
+      {
+        "source": {
+          "block": "8a50b4e9-884d-49bb-98c3-3cd1e6cb3f4f",
+          "port": "out2"
+        },
+        "target": {
+          "block": "5e246f93-51ad-4d6f-83f1-4fcce69c5ae3",
+          "port": "in"
+        }
+      },
+      {
+        "source": {
+          "block": "8a50b4e9-884d-49bb-98c3-3cd1e6cb3f4f",
+          "port": "out3"
+        },
+        "target": {
+          "block": "b9d764ea-538a-420f-a8d3-45af7a8e30a2",
+          "port": "in"
+        }
+      },
+      {
+        "source": {
+          "block": "5fc9a8e9-d463-4c1f-b6a3-185d5cabb406",
+          "port": "out"
+        },
+        "target": {
+          "block": "8a50b4e9-884d-49bb-98c3-3cd1e6cb3f4f",
+          "port": "in0"
+        }
+      },
+      {
+        "source": {
+          "block": "75cafe5a-1968-49ed-9e05-70d1bc3fbd0f",
+          "port": "out"
+        },
+        "target": {
+          "block": "8a50b4e9-884d-49bb-98c3-3cd1e6cb3f4f",
+          "port": "sel0"
+        }
+      },
+      {
+        "source": {
+          "block": "657dab9e-6580-4f02-b54f-66477863f26a",
+          "port": "out"
+        },
+        "target": {
+          "block": "8a50b4e9-884d-49bb-98c3-3cd1e6cb3f4f",
+          "port": "sel1"
+        }
+      }
+    ]
+  },
+  "deps": {}
+}

--- a/app/resources/blocks/logic/demux_1_8.iceb
+++ b/app/resources/blocks/logic/demux_1_8.iceb
@@ -1,0 +1,352 @@
+{
+  "image": "resources/images/demux.svg",
+  "state": {
+    "pan": {
+      "x": 75.69774669071234,
+      "y": 148.91048230054443
+    },
+    "zoom": 0.63316672636209
+  },
+  "graph": {
+    "blocks": [
+      {
+        "id": "91e2ff2d-2430-41e5-9d21-bc9ec4082aaa",
+        "type": "basic.output",
+        "data": {
+          "label": "out0"
+        },
+        "position": {
+          "x": 784,
+          "y": -128
+        }
+      },
+      {
+        "id": "1b8510ac-d723-4226-bf28-c7329d0f73fb",
+        "type": "basic.output",
+        "data": {
+          "label": "out4"
+        },
+        "position": {
+          "x": 784,
+          "y": 208
+        }
+      },
+      {
+        "id": "c6dc7002-dfc0-45fd-88e2-b5e5a75231f2",
+        "type": "basic.output",
+        "data": {
+          "label": "out1"
+        },
+        "position": {
+          "x": 784,
+          "y": -48
+        }
+      },
+      {
+        "id": "65f31fca-d607-4d5c-82cc-878a93b8e580",
+        "type": "basic.output",
+        "data": {
+          "label": "out5"
+        },
+        "position": {
+          "x": 784,
+          "y": 304
+        }
+      },
+      {
+        "id": "5e246f93-51ad-4d6f-83f1-4fcce69c5ae3",
+        "type": "basic.output",
+        "data": {
+          "label": "out2"
+        },
+        "position": {
+          "x": 784,
+          "y": 32
+        }
+      },
+      {
+        "id": "c8fadd68-77e1-47be-a262-b076e878e6fd",
+        "type": "basic.output",
+        "data": {
+          "label": "out6"
+        },
+        "position": {
+          "x": 784,
+          "y": 384
+        }
+      },
+      {
+        "id": "b9d764ea-538a-420f-a8d3-45af7a8e30a2",
+        "type": "basic.output",
+        "data": {
+          "label": "out3"
+        },
+        "position": {
+          "x": 784,
+          "y": 112
+        }
+      },
+      {
+        "id": "99ca2a23-7e0d-4c34-9ab1-988c6bf69633",
+        "type": "basic.output",
+        "data": {
+          "label": "out7"
+        },
+        "position": {
+          "x": 784,
+          "y": 464
+        }
+      },
+      {
+        "id": "5fc9a8e9-d463-4c1f-b6a3-185d5cabb406",
+        "type": "basic.input",
+        "data": {
+          "label": "in0"
+        },
+        "position": {
+          "x": 16,
+          "y": 40
+        }
+      },
+      {
+        "id": "75cafe5a-1968-49ed-9e05-70d1bc3fbd0f",
+        "type": "basic.input",
+        "data": {
+          "label": "sel0"
+        },
+        "position": {
+          "x": 16,
+          "y": 120
+        }
+      },
+      {
+        "id": "657dab9e-6580-4f02-b54f-66477863f26a",
+        "type": "basic.input",
+        "data": {
+          "label": "sel1"
+        },
+        "position": {
+          "x": 16,
+          "y": 200
+        }
+      },
+      {
+        "id": "e1a156c8-5813-46f6-a4d4-c672857f3396",
+        "type": "basic.input",
+        "data": {
+          "label": "sel2"
+        },
+        "position": {
+          "x": 16,
+          "y": 280
+        }
+      },
+      {
+        "id": "1ea41d18-7010-42c0-932f-99d135efdb73",
+        "type": "basic.code",
+        "data": {
+          "code": "assign {out7,out6,out5,out4,out3,out2,out1,out0} = in0 << {sel2,sel1,sel0};",
+          "ports": {
+            "in": [
+              "in0",
+              "sel0",
+              "sel1",
+              "sel2"
+            ],
+            "out": [
+              "out0",
+              "out1",
+              "out2",
+              "out3",
+              "out4",
+              "out5",
+              "out6",
+              "out7"
+            ]
+          }
+        },
+        "position": {
+          "x": 208,
+          "y": 64
+        }
+      }
+    ],
+    "wires": [
+      {
+        "source": {
+          "block": "5fc9a8e9-d463-4c1f-b6a3-185d5cabb406",
+          "port": "out"
+        },
+        "target": {
+          "block": "1ea41d18-7010-42c0-932f-99d135efdb73",
+          "port": "in0"
+        }
+      },
+      {
+        "source": {
+          "block": "75cafe5a-1968-49ed-9e05-70d1bc3fbd0f",
+          "port": "out"
+        },
+        "target": {
+          "block": "1ea41d18-7010-42c0-932f-99d135efdb73",
+          "port": "sel0"
+        }
+      },
+      {
+        "source": {
+          "block": "657dab9e-6580-4f02-b54f-66477863f26a",
+          "port": "out"
+        },
+        "target": {
+          "block": "1ea41d18-7010-42c0-932f-99d135efdb73",
+          "port": "sel1"
+        }
+      },
+      {
+        "source": {
+          "block": "e1a156c8-5813-46f6-a4d4-c672857f3396",
+          "port": "out"
+        },
+        "target": {
+          "block": "1ea41d18-7010-42c0-932f-99d135efdb73",
+          "port": "sel2"
+        }
+      },
+      {
+        "source": {
+          "block": "1ea41d18-7010-42c0-932f-99d135efdb73",
+          "port": "out0"
+        },
+        "target": {
+          "block": "91e2ff2d-2430-41e5-9d21-bc9ec4082aaa",
+          "port": "in"
+        },
+        "vertices": [
+          {
+            "x": 664,
+            "y": -24
+          }
+        ]
+      },
+      {
+        "source": {
+          "block": "1ea41d18-7010-42c0-932f-99d135efdb73",
+          "port": "out7"
+        },
+        "target": {
+          "block": "99ca2a23-7e0d-4c34-9ab1-988c6bf69633",
+          "port": "in"
+        },
+        "vertices": [
+          {
+            "x": 664,
+            "y": 416
+          }
+        ]
+      },
+      {
+        "source": {
+          "block": "1ea41d18-7010-42c0-932f-99d135efdb73",
+          "port": "out1"
+        },
+        "target": {
+          "block": "c6dc7002-dfc0-45fd-88e2-b5e5a75231f2",
+          "port": "in"
+        },
+        "vertices": [
+          {
+            "x": 680,
+            "y": 32
+          }
+        ]
+      },
+      {
+        "source": {
+          "block": "1ea41d18-7010-42c0-932f-99d135efdb73",
+          "port": "out2"
+        },
+        "target": {
+          "block": "5e246f93-51ad-4d6f-83f1-4fcce69c5ae3",
+          "port": "in"
+        },
+        "vertices": [
+          {
+            "x": 696,
+            "y": 112
+          }
+        ]
+      },
+      {
+        "source": {
+          "block": "1ea41d18-7010-42c0-932f-99d135efdb73",
+          "port": "out3"
+        },
+        "target": {
+          "block": "b9d764ea-538a-420f-a8d3-45af7a8e30a2",
+          "port": "in"
+        },
+        "vertices": [
+          {
+            "x": 712,
+            "y": 176
+          }
+        ]
+      },
+      {
+        "source": {
+          "block": "1ea41d18-7010-42c0-932f-99d135efdb73",
+          "port": "out4"
+        },
+        "target": {
+          "block": "1b8510ac-d723-4226-bf28-c7329d0f73fb",
+          "port": "in"
+        }
+      },
+      {
+        "source": {
+          "block": "1ea41d18-7010-42c0-932f-99d135efdb73",
+          "port": "out5"
+        },
+        "target": {
+          "block": "65f31fca-d607-4d5c-82cc-878a93b8e580",
+          "port": "in"
+        },
+        "vertices": [
+          {
+            "x": 696,
+            "y": 288
+          }
+        ]
+      },
+      {
+        "source": {
+          "block": "1ea41d18-7010-42c0-932f-99d135efdb73",
+          "port": "out6"
+        },
+        "target": {
+          "block": "c8fadd68-77e1-47be-a262-b076e878e6fd",
+          "port": "in"
+        },
+        "vertices": [
+          {
+            "x": 680,
+            "y": 320
+          },
+          {
+            "x": 680,
+            "y": 360
+          },
+          {
+            "x": 680,
+            "y": 376
+          },
+          {
+            "x": 688,
+            "y": 416
+          }
+        ]
+      }
+    ]
+  },
+  "deps": {}
+}

--- a/app/resources/blocks/logic/mux_2_1.iceb
+++ b/app/resources/blocks/logic/mux_2_1.iceb
@@ -1,0 +1,122 @@
+{
+  "image": "resources/images/mux.svg",
+  "state": {
+    "pan": {
+      "x": -21.03752160981206,
+      "y": 29.479234822175684
+    },
+    "zoom": 1.000000683370386
+  },
+  "graph": {
+    "blocks": [
+      {
+        "id": "c3f73f68-1074-4355-b69f-6a20f7bea3e7",
+        "type": "basic.input",
+        "data": {
+          "label": "in0"
+        },
+        "position": {
+          "x": 80,
+          "y": 120
+        }
+      },
+      {
+        "id": "67ed5e09-486d-4f97-929f-aefea9c43951",
+        "type": "basic.input",
+        "data": {
+          "label": "sel0"
+        },
+        "position": {
+          "x": 80,
+          "y": 296
+        }
+      },
+      {
+        "id": "5fb29465-2ee7-45bb-afa4-9a3de895c774",
+        "type": "basic.input",
+        "data": {
+          "label": "in1"
+        },
+        "position": {
+          "x": 80,
+          "y": 208
+        }
+      },
+      {
+        "id": "061aa997-2f30-4591-8841-fb6abf5c3b2e",
+        "type": "basic.output",
+        "data": {
+          "label": "o"
+        },
+        "position": {
+          "x": 792,
+          "y": 208
+        }
+      },
+      {
+        "id": "ba573190-2ead-411a-a323-1b15a22d46db",
+        "type": "basic.code",
+        "data": {
+          "code": "reg _o;\n\nalways @(*) begin\n    case(sel0)\n        0: _o = in0;\n        1: _o = in1;\n        default: _o = in0;\n    endcase\nend\n\nassign o = _o;",
+          "ports": {
+            "in": [
+              "in0",
+              "in1",
+              "sel0"
+            ],
+            "out": [
+              "o"
+            ]
+          }
+        },
+        "position": {
+          "x": 312,
+          "y": 112
+        }
+      }
+    ],
+    "wires": [
+      {
+        "source": {
+          "block": "ba573190-2ead-411a-a323-1b15a22d46db",
+          "port": "o"
+        },
+        "target": {
+          "block": "061aa997-2f30-4591-8841-fb6abf5c3b2e",
+          "port": "in"
+        }
+      },
+      {
+        "source": {
+          "block": "c3f73f68-1074-4355-b69f-6a20f7bea3e7",
+          "port": "out"
+        },
+        "target": {
+          "block": "ba573190-2ead-411a-a323-1b15a22d46db",
+          "port": "in0"
+        }
+      },
+      {
+        "source": {
+          "block": "5fb29465-2ee7-45bb-afa4-9a3de895c774",
+          "port": "out"
+        },
+        "target": {
+          "block": "ba573190-2ead-411a-a323-1b15a22d46db",
+          "port": "in1"
+        }
+      },
+      {
+        "source": {
+          "block": "67ed5e09-486d-4f97-929f-aefea9c43951",
+          "port": "out"
+        },
+        "target": {
+          "block": "ba573190-2ead-411a-a323-1b15a22d46db",
+          "port": "sel0"
+        }
+      }
+    ]
+  },
+  "deps": {}
+}

--- a/app/resources/blocks/logic/mux_4_1.iceb
+++ b/app/resources/blocks/logic/mux_4_1.iceb
@@ -1,0 +1,200 @@
+{
+  "image": "resources/images/mux.svg",
+  "state": {
+    "pan": {
+      "x": 130.45308400685477,
+      "y": 53.21523989429495
+    },
+    "zoom": 0.7373588227849291
+  },
+  "graph": {
+    "blocks": [
+      {
+        "id": "e4eb896c-1039-4d73-aeb0-ce34b933f4c3",
+        "type": "basic.code",
+        "data": {
+          "code": "reg _o;\nwire [1:0] _sel;\n\nassign _sel = {sel1, sel0};\n\nalways @(*) begin\n    case(_sel)\n        0: _o = in0;\n        1: _o = in1;\n        2: _o = in2;\n        3: _o = in3;\n        default: _o = in0;\n    endcase\nend\n\nassign o = _o;",
+          "ports": {
+            "in": [
+              "in0",
+              "in1",
+              "in2",
+              "in3",
+              "sel0",
+              "sel1"
+            ],
+            "out": [
+              "o"
+            ]
+          }
+        },
+        "position": {
+          "x": 312,
+          "y": 112
+        }
+      },
+      {
+        "id": "1b7db016-c89a-4f65-b6f0-0f87c851c077",
+        "type": "basic.input",
+        "data": {
+          "label": "in0"
+        },
+        "position": {
+          "x": 56,
+          "y": 288
+        }
+      },
+      {
+        "id": "c3f73f68-1074-4355-b69f-6a20f7bea3e7",
+        "type": "basic.input",
+        "data": {
+          "label": "in1"
+        },
+        "position": {
+          "x": 56,
+          "y": -8
+        }
+      },
+      {
+        "id": "67ed5e09-486d-4f97-929f-aefea9c43951",
+        "type": "basic.input",
+        "data": {
+          "label": "in2"
+        },
+        "position": {
+          "x": 56,
+          "y": 144
+        }
+      },
+      {
+        "id": "a014971e-5470-490b-9058-b4b00f2dd125",
+        "type": "basic.input",
+        "data": {
+          "label": "in3"
+        },
+        "position": {
+          "x": 56,
+          "y": 360
+        }
+      },
+      {
+        "id": "5fb29465-2ee7-45bb-afa4-9a3de895c774",
+        "type": "basic.input",
+        "data": {
+          "label": "sel0"
+        },
+        "position": {
+          "x": 56,
+          "y": 64
+        }
+      },
+      {
+        "id": "8be9cded-6d06-4b23-b73c-94c7ff311dbc",
+        "type": "basic.input",
+        "data": {
+          "label": "sel1"
+        },
+        "position": {
+          "x": 56,
+          "y": 216
+        }
+      },
+      {
+        "id": "061aa997-2f30-4591-8841-fb6abf5c3b2e",
+        "type": "basic.output",
+        "data": {
+          "label": "o"
+        },
+        "position": {
+          "x": 792,
+          "y": 208
+        }
+      }
+    ],
+    "wires": [
+      {
+        "source": {
+          "block": "e4eb896c-1039-4d73-aeb0-ce34b933f4c3",
+          "port": "out0"
+        },
+        "target": {
+          "block": "061aa997-2f30-4591-8841-fb6abf5c3b2e",
+          "port": "in"
+        }
+      },
+      {
+        "source": {
+          "block": "a014971e-5470-490b-9058-b4b00f2dd125",
+          "port": "out"
+        },
+        "target": {
+          "block": "e4eb896c-1039-4d73-aeb0-ce34b933f4c3",
+          "port": "sel1"
+        }
+      },
+      {
+        "source": {
+          "block": "1b7db016-c89a-4f65-b6f0-0f87c851c077",
+          "port": "out"
+        },
+        "target": {
+          "block": "e4eb896c-1039-4d73-aeb0-ce34b933f4c3",
+          "port": "sel0"
+        }
+      },
+      {
+        "source": {
+          "block": "8be9cded-6d06-4b23-b73c-94c7ff311dbc",
+          "port": "out"
+        },
+        "target": {
+          "block": "e4eb896c-1039-4d73-aeb0-ce34b933f4c3",
+          "port": "in3"
+        }
+      },
+      {
+        "source": {
+          "block": "67ed5e09-486d-4f97-929f-aefea9c43951",
+          "port": "out"
+        },
+        "target": {
+          "block": "e4eb896c-1039-4d73-aeb0-ce34b933f4c3",
+          "port": "in2"
+        },
+        "vertices": [
+          {
+            "x": 208,
+            "y": 208
+          }
+        ]
+      },
+      {
+        "source": {
+          "block": "5fb29465-2ee7-45bb-afa4-9a3de895c774",
+          "port": "out"
+        },
+        "target": {
+          "block": "e4eb896c-1039-4d73-aeb0-ce34b933f4c3",
+          "port": "in1"
+        },
+        "vertices": [
+          {
+            "x": 240,
+            "y": 128
+          }
+        ]
+      },
+      {
+        "source": {
+          "block": "c3f73f68-1074-4355-b69f-6a20f7bea3e7",
+          "port": "out"
+        },
+        "target": {
+          "block": "e4eb896c-1039-4d73-aeb0-ce34b933f4c3",
+          "port": "in0"
+        }
+      }
+    ]
+  },
+  "deps": {}
+}

--- a/app/resources/images/demux.svg
+++ b/app/resources/images/demux.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1"
+	 id="svg2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" inkscape:output_extension="org.inkscape.output.svg.inkscape" sodipodi:docname="or.svg" inkscape:version="0.91 r13725" sodipodi:version="0.32"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="-252 400.9 90 40"
+	 style="enable-background:new -252 400.9 90 40;" xml:space="preserve">
+<defs>
+	
+	
+		<inkscape:perspective  id="perspective2714" inkscape:vp_z="50 : 15 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 15 : 1" sodipodi:type="inkscape:persp3d" inkscape:persp3d-origin="25 : 10 : 1">
+		</inkscape:perspective>
+	
+		<inkscape:perspective  id="perspective2806" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d" inkscape:persp3d-origin="0.5 : 0.33333333 : 1">
+		</inkscape:perspective>
+	
+		<inkscape:perspective  id="perspective2819" inkscape:vp_z="744.09448 : 526.18109 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 526.18109 : 1" sodipodi:type="inkscape:persp3d" inkscape:persp3d-origin="372.04724 : 350.78739 : 1">
+		</inkscape:perspective>
+	
+		<inkscape:perspective  id="perspective2777" inkscape:vp_z="150 : 60 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 60 : 1" sodipodi:type="inkscape:persp3d" inkscape:persp3d-origin="75 : 40 : 1">
+		</inkscape:perspective>
+	
+		<inkscape:perspective  id="perspective3275" inkscape:vp_z="100 : 50 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 50 : 1" sodipodi:type="inkscape:persp3d" inkscape:persp3d-origin="50 : 33.333333 : 1">
+		</inkscape:perspective>
+	
+		<inkscape:perspective  id="perspective5533" inkscape:vp_z="64 : 32 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 32 : 1" sodipodi:type="inkscape:persp3d" inkscape:persp3d-origin="32 : 21.333333 : 1">
+		</inkscape:perspective>
+	
+		<inkscape:perspective  id="perspective2557" inkscape:vp_z="50 : 25 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 25 : 1" sodipodi:type="inkscape:persp3d" inkscape:persp3d-origin="25 : 16.666667 : 1">
+		</inkscape:perspective>
+</defs>
+<sodipodi:namedview  fit-margin-left="0" fit-margin-top="0" gridtolerance="10000" showgrid="true" inkscape:cy="-39.925494" inkscape:cx="76.456495" inkscape:zoom="2.8284271" borderopacity="1.0" bordercolor="#666666" pagecolor="#ffffff" id="base" inkscape:window-maximized="0" fit-margin-bottom="0" fit-margin-right="0" inkscape:snap-bbox="true" inkscape:window-y="27" inkscape:window-x="33" inkscape:window-height="874" inkscape:window-width="1399" inkscape:grid-points="true" inkscape:grid-bbox="true" inkscape:current-layer="g2560" inkscape:document-units="px" inkscape:pageshadow="2" inkscape:pageopacity="0.0">
+	
+		<inkscape:grid  type="xygrid" color="#0000ff" enabled="true" visible="true" empspacing="5" empopacity="0.4" opacity="0.2" empcolor="#0000ff" spacingy="1px" spacingx="1px" originy="-4.9999904" originx="-15.03125" id="GridFromPre046Settings">
+		</inkscape:grid>
+</sodipodi:namedview>
+<path d="M-252,421.9h24v5.2v1.5v0.6l41,11.7V439v-7.1h25v-2h-25v-18h25v-2h-25v-7.1v-1.9l-41,11.8v2v5.2h-24V421.9z M-226,427.6
+	v-13.5l37-10.8v35L-226,427.6z"/>
+</svg>

--- a/app/resources/images/mux.svg
+++ b/app/resources/images/mux.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1"
+	 id="svg2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" inkscape:output_extension="org.inkscape.output.svg.inkscape" sodipodi:docname="or.svg" inkscape:version="0.91 r13725" sodipodi:version="0.32"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="-252 400.9 90 40"
+	 style="enable-background:new -252 400.9 90 40;" xml:space="preserve">
+<defs>
+	
+	
+		<inkscape:perspective  id="perspective2714" inkscape:vp_z="50 : 15 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 15 : 1" sodipodi:type="inkscape:persp3d" inkscape:persp3d-origin="25 : 10 : 1">
+		</inkscape:perspective>
+	
+		<inkscape:perspective  id="perspective2806" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d" inkscape:persp3d-origin="0.5 : 0.33333333 : 1">
+		</inkscape:perspective>
+	
+		<inkscape:perspective  id="perspective2819" inkscape:vp_z="744.09448 : 526.18109 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 526.18109 : 1" sodipodi:type="inkscape:persp3d" inkscape:persp3d-origin="372.04724 : 350.78739 : 1">
+		</inkscape:perspective>
+	
+		<inkscape:perspective  id="perspective2777" inkscape:vp_z="150 : 60 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 60 : 1" sodipodi:type="inkscape:persp3d" inkscape:persp3d-origin="75 : 40 : 1">
+		</inkscape:perspective>
+	
+		<inkscape:perspective  id="perspective3275" inkscape:vp_z="100 : 50 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 50 : 1" sodipodi:type="inkscape:persp3d" inkscape:persp3d-origin="50 : 33.333333 : 1">
+		</inkscape:perspective>
+	
+		<inkscape:perspective  id="perspective5533" inkscape:vp_z="64 : 32 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 32 : 1" sodipodi:type="inkscape:persp3d" inkscape:persp3d-origin="32 : 21.333333 : 1">
+		</inkscape:perspective>
+	
+		<inkscape:perspective  id="perspective2557" inkscape:vp_z="50 : 25 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 25 : 1" sodipodi:type="inkscape:persp3d" inkscape:persp3d-origin="25 : 16.666667 : 1">
+		</inkscape:perspective>
+</defs>
+<sodipodi:namedview  fit-margin-left="0" fit-margin-top="0" gridtolerance="10000" showgrid="true" inkscape:cy="-39.925494" inkscape:cx="76.456495" inkscape:zoom="2.8284271" borderopacity="1.0" bordercolor="#666666" pagecolor="#ffffff" id="base" inkscape:window-maximized="0" fit-margin-bottom="0" fit-margin-right="0" inkscape:snap-bbox="true" inkscape:window-y="27" inkscape:window-x="33" inkscape:window-height="874" inkscape:window-width="1399" inkscape:grid-points="true" inkscape:grid-bbox="true" inkscape:current-layer="g2560" inkscape:document-units="px" inkscape:pageshadow="2" inkscape:pageopacity="0.0">
+	
+		<inkscape:grid  type="xygrid" color="#0000ff" enabled="true" visible="true" empspacing="5" empopacity="0.4" opacity="0.2" empcolor="#0000ff" spacingy="1px" spacingx="1px" originy="-4.9999904" originx="-15.03125" id="GridFromPre046Settings">
+		</inkscape:grid>
+</sodipodi:namedview>
+<path d="M-162,419.9h-24v-5.2v-2l-41-11.8v1.9v7.1h-25v2h25v18h-25v2h25v7.1v1.9l41-11.7v-0.6V427v-5.2h24V419.9z M-225,438.4v-35
+	l37,10.8v13.5L-225,438.4z"/>
+</svg>


### PR DESCRIPTION
Blocks to add:
- Mux one input and two outputs (mux_1_2).
- Mux one input and four outputs (mux_1_4).
- Demux two inputs and one output (demux_2_1).
- Demux four inputs and one output (demux_4_1).
- Demux eight input and one output (demux_8_1).

Also basic images for both blocks, all blocks (except Demux_8_1) tested on iceStick board. All blocks on the logic sub-menu until a new defined location (to be discussed).