### PR TITLE
Update eu_ES.po

### DIFF
--- a/app/resources/locale/eu_ES/eu_ES.po
+++ b/app/resources/locale/eu_ES/eu_ES.po
@@ -14,7 +14,7 @@ msgstr ""
 
 #: app/scripts/services/utils.js:456 app/scripts/services/utils.js:536
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
-msgstr "<b>Plaka deskonektatu</b> eta <b>konekta ezazu</b> berriro"
+msgstr "<b>Txartela deskonektatu</b> eta <b>konekta ezazu</b> berriro"
 
 #: app/scripts/services/utils.js:527
 msgid ""
@@ -22,9 +22,9 @@ msgid ""
 "board</li><li>Replace the <b>(Interface 0)</b> driver of the board by "
 "<b>libusbK</b></li><li>Unplug and reconnect the board</li></ol>"
 msgstr ""
-"<h4>FTDI driver-a instalatzeko instrukzioak</h4><ol><li>FPGA plaka konekta "
-"ezazu</li><li>Plakaren  <b>(Interface 0)</b> driver-a aldatu eta jar ezazu "
-"honakoa: <b>libusbK</b></li><li>Plaka deskonektatu eta konekta ezazu "
+"<h4>FTDI driver-a instalatzeko instrukzioak</h4><ol><li>FPGA txartela konekta "
+"ezazu</li><li>Txartelaren  <b>(Interface 0)</b> driver-a aldatu eta jar ezazu "
+"honakoa: <b>libusbK</b></li><li>Txartela deskonektatu eta konekta ezazu "
 "berriro</li></ol>"
 
 #: app/scripts/services/utils.js:543
@@ -33,7 +33,7 @@ msgid ""
 "Device</li><li>Select the board interface and uninstall the driver</li></ol>"
 msgstr ""
 "<h4>FTDI driver-a desinstalatzeko instrukzioak</h4><ol><li>FPGAren USB "
-"gailua bila ezazu</li><li>Plakaren interfazea hauta ezazu eta driver-a "
+"gailua bila ezazu</li><li>Txartelaren interfazea hauta ezazu eta driver-a "
 "desinstalatu</li></ol>"
 
 #: app/views/menu.html:336
@@ -88,27 +88,27 @@ msgstr "Blokeak"
 
 #: app/views/menu.html:201
 msgid "Board"
-msgstr "Plaka"
+msgstr "Txartela"
 
 #: app/views/menu.html:115 app/views/menu.html:192
 msgid "Board rules"
-msgstr "Plakaren erregelak"
+msgstr "Txartelaren arauak"
 
 #: app/scripts/controllers/menu.js:334
 msgid "Board rules disabled"
-msgstr "Plakaren erregelak desgaituta"
+msgstr "Txartelaren arauak desgaituta"
 
 #: app/scripts/controllers/menu.js:329
 msgid "Board rules enabled"
-msgstr "Plakaren erregelak gaituta"
+msgstr "Txartelaren arauak gaituta"
 
 #: app/scripts/services/tools.js:234
 msgid "Board {{name}} not detected"
-msgstr "{{name}} plaka ez da aurkitu"
+msgstr "{{name}} txartela ez da aurkitu"
 
 #: app/scripts/controllers/menu.js:435
 msgid "Board {{name}} selected"
-msgstr "{{name}} plaka hautatu duzu"
+msgstr "{{name}} txartela hautatu duzu"
 
 #: app/views/menu.html:236
 msgid "Build"
@@ -577,7 +577,7 @@ msgstr "Dena hautatu"
 
 #: app/scripts/services/blocks.js:54 app/scripts/services/blocks.js:699
 msgid "Show clock"
-msgstr "Erakutsi ordularia"
+msgstr "Ordularia erakutsi"
 
 #: app/views/menu.html:328
 msgid "Source code"
@@ -601,14 +601,14 @@ msgstr "Testbench-a esportatu da"
 
 #: app/scripts/services/tools.js:616
 msgid "The collection {{name}} already exists."
-msgstr "{{name}} bilduma existitzen da"
+msgstr "{{name}} bilduma badago"
 
 #: app/scripts/controllers/menu.js:424
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
 msgstr ""
-"FPGAaren E/S konfigurazioa galduko da. {{name}} plaka aldatu nahi duzu?"
+"FPGAaren E/S konfigurazioa galduko da. {{name}} txartela aldatu nahi al duzu?"
 
 #: app/scripts/services/tools.js:350
 msgid "The toolchain will be removed. Do you want to continue?"
@@ -637,7 +637,7 @@ msgstr ""
 
 #: app/scripts/services/project.js:103
 msgid "This project is designed for the {{name}} board."
-msgstr "Proiektua {{name}} plakarentzat diseinatu da."
+msgstr "Proiektua {{name}} txartelarentzat diseinatu da."
 
 #: app/views/menu.html:243
 msgid "Toolchain"
@@ -670,7 +670,7 @@ msgstr "Desegin"
 
 #: app/scripts/services/tools.js:237
 msgid "Unknown board"
-msgstr "Plaka ezezaguna"
+msgstr "Txartel ezezaguna"
 
 #: app/scripts/app.js:43
 msgid "Untitled"
@@ -783,7 +783,7 @@ msgstr "{{board}} pinout ez zehaztua"
 
 #: app/scripts/controllers/menu.js:402
 msgid "{{board}} rules not defined"
-msgstr "{{board}} erregelak ez daude definituta"
+msgstr "{{board}} txartelaren arauak ez daude definituta"
 
 #~ msgid "1_basic"
 #~ msgstr "1. Oinarrizkoa"
@@ -798,7 +798,7 @@ msgstr "{{board}} erregelak ez daude definituta"
 #~ msgstr "3. Pultsadorea eta AND atea"
 
 #~ msgid "Boards"
-#~ msgstr "Plakak"
+#~ msgstr "Txartelak"
 
 #~ msgid "Collection file {{name}} added"
 #~ msgstr "{{name}} bildumen fitxategia gehitu da"


### PR DESCRIPTION
> Viene de #143 

- Se han modificado:
  - **plaka** ordez, **txartel**.
  - **Erakutsi ordularia** ordez, **Ordularia erakutsi**.
  - **existitu** ordez, **(ba)dago**.
  - **erregela** ordez, **arau**.
- Se han mantenido:
  - Todos los auxiliares. En un caso se ha añadido 'al' para mantener la coherencia.