### PR TITLE
Drag & replace blocks

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,7 @@
     "height": 620,
     "min_width": 800,
     "min_height": 200,
-    "toolbar": false,
+    "toolbar": true,
     "resizable": true,
     "position": "center",
     "icon": "resources/images/icestudio-logo.png"
@@ -41,6 +41,7 @@
     "glob": "^7.1.2",
     "is-online": "^5.2.0",
     "jquery": "^3.2.1",
+    "lodash.debounce": "^4.0.8",
     "marked": "^0.3.12",
     "node-emoji": "^1.8.1",
     "node-lang-info": "^0.2.1",

--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,7 @@
     "height": 620,
     "min_width": 800,
     "min_height": 200,
-    "toolbar": true,
+    "toolbar": false,
     "resizable": true,
     "position": "center",
     "icon": "resources/images/icestudio-logo.png"

--- a/app/scripts/factories/node.js
+++ b/app/scripts/factories/node.js
@@ -58,6 +58,9 @@ angular.module('icestudio')
   .factory('nodeTemp', function() {
     return require('temporary');
   })
+  .factory('nodeDebounce', function() {
+    return require('lodash.debounce');
+  })
   .factory('SVGO', function() {
     var config = {
       full: true,

--- a/app/scripts/graphics/joint.command.js
+++ b/app/scripts/graphics/joint.command.js
@@ -249,7 +249,9 @@ joint.dia.CommandManager = Backbone.Model.extend({
       switch (cmd.action) {
 
         case 'add':
-        	cell.remove();
+          if (cell) {
+            cell.remove();
+          }
         	break;
 
         case 'remove':

--- a/app/scripts/graphics/joint.command.js
+++ b/app/scripts/graphics/joint.command.js
@@ -178,7 +178,7 @@ joint.dia.CommandManager = Backbone.Model.extend({
 
   initBatchCommand: function() {
 
-    //console.log('initBatchCommand', this.batchCommand);
+    // console.log('initBatchCommand', this.batchCommand);
 
     if (!this.batchCommand) {
 
@@ -198,30 +198,30 @@ joint.dia.CommandManager = Backbone.Model.extend({
 
   storeBatchCommand: function() {
 
-    //console.log('storeBatchCommand', this.batchCommand, this.batchLevel);
+    // console.log('storeBatchCommand', this.batchCommand, this.batchLevel);
 
     // In order to store batch command it is necesary to run storeBatchCommand as many times as
     // initBatchCommand was executed
     if (this.batchCommand && this.batchLevel <= 0) {
 
-    // checking if there is any valid command in batch
-    // for example: calling `initBatchCommand` immediately followed by `storeBatchCommand`
-    if (this.lastCmdIndex >= 0) {
+      // checking if there is any valid command in batch
+      // for example: calling `initBatchCommand` immediately followed by `storeBatchCommand`
+      if (this.lastCmdIndex >= 0) {
 
-	    this.redoStack = [];
+  	    this.redoStack = [];
 
-      this.undoStack.push(this.batchCommand);
-      if (this.batchCommand && this.batchCommand[0] && this.batchCommand[0].action !== 'lang') {
-        // Do not store lang in changesStack
-        this.changesStack.push(this.batchCommand);
-        this.triggerChange();
+        this.undoStack.push(this.batchCommand);
+        if (this.batchCommand && this.batchCommand[0] && this.batchCommand[0].action !== 'lang') {
+          // Do not store lang in changesStack
+          this.changesStack.push(this.batchCommand);
+          this.triggerChange();
+        }
+        this.trigger('add', this.batchCommand);
       }
-      this.trigger('add', this.batchCommand);
-    }
 
-    delete this.batchCommand;
-    delete this.lastCmdIndex;
-    delete this.batchLevel;
+      delete this.batchCommand;
+      delete this.lastCmdIndex;
+      delete this.batchLevel;
 
     } else if (this.batchCommand && this.batchLevel > 0) {
 

--- a/app/scripts/graphics/joint.selection.js
+++ b/app/scripts/graphics/joint.selection.js
@@ -238,6 +238,8 @@ joint.ui.SelectionView = Backbone.View.extend({
       		this._snappedClientY = snappedClientY;
       	}
 
+        this.trigger('selection-box:pointermove', evt);
+
         break;
     }
   },

--- a/app/scripts/graphics/joint.selection.js
+++ b/app/scripts/graphics/joint.selection.js
@@ -103,18 +103,16 @@ joint.ui.SelectionView = Backbone.View.extend({
     }
   },
 
-  startTranslatingSelection: function(evt, noBatch) {
+  startTranslatingSelection: function(evt) {
 
-    if (evt.which === 1 || noBatch) {
+    if (this._action !== 'adding' && evt.which === 1) {
       // Mouse left button
 
       if (!evt.shiftKey) {
         this._action = 'translating';
 
-        if (!noBatch) {
-          this.options.graph.trigger('batch:stop');
-          this.options.graph.trigger('batch:start');
-        }
+        this.options.graph.trigger('batch:stop');
+        this.options.graph.trigger('batch:start');
 
         var snappedClientCoords = this.options.paper.snapToGrid(g.point(evt.clientX, evt.clientY));
         this._snappedClientX = snappedClientCoords.x;
@@ -125,9 +123,15 @@ joint.ui.SelectionView = Backbone.View.extend({
     }
   },
 
-  isTranslating: function() {
+  startAddingSelection: function(evt) {
 
-    return this._action === 'translating';
+    this._action = 'adding';
+
+    var snappedClientCoords = this.options.paper.snapToGrid(g.point(evt.clientX, evt.clientY));
+    this._snappedClientX = snappedClientCoords.x;
+    this._snappedClientY = snappedClientCoords.y;
+
+    this.trigger('selection-box:pointerdown', evt);
   },
 
   startSelecting: function(evt/*, x, y*/) {
@@ -179,6 +183,7 @@ joint.ui.SelectionView = Backbone.View.extend({
         });
         break;
 
+      case 'adding':
       case 'translating':
 
         var snappedClientCoords = this.options.paper.snapToGrid(g.point(evt.clientX, evt.clientY));
@@ -279,6 +284,9 @@ joint.ui.SelectionView = Backbone.View.extend({
 
         this.options.graph.trigger('batch:stop');
         // Everything else is done during the translation.
+        break;
+
+      case 'adding':
         break;
 
       case 'cherry-picking':

--- a/app/scripts/graphics/joint.shapes.js
+++ b/app/scripts/graphics/joint.shapes.js
@@ -296,10 +296,14 @@ joint.shapes.ice.ModelView = joint.dia.ElementView.extend({
       return;
     }
 
+    var type = self.model.get('type');
     var size = self.model.get('size');
     var state = self.model.get('state');
     var gridstep = 8 * 2;
-    var minSize = { width: 64, height: 32 };
+    var minSize = {
+      width: type === 'ice.Code' ? 96 : 64,
+      height: type === 'ice.Code' ? 64 : 32
+    };
 
     var clientCoords = snapToGrid({ x: event.clientX, y: event.clientY });
     var oldClientCoords = snapToGrid({ x: self._clientX, y: self._clientY });

--- a/app/scripts/graphics/joint.shapes.js
+++ b/app/scripts/graphics/joint.shapes.js
@@ -190,7 +190,7 @@ joint.shapes.ice.Model = joint.shapes.basic.Generic.extend({
         attrs[portLabelSelector]['y'] = -5-offset;
         attrs[portLabelSelector]['text-anchor'] = 'end';
         attrs[portWireSelector]['y'] = position;
-        attrs[portWireSelector]['d'] = 'M 0 0 L 16 0';
+        attrs[portWireSelector]['d'] = 'M 0 0 L 8 0';
         break;
       case 'right':
         attrs[portSelector]['ref-dx'] = 8;
@@ -199,7 +199,7 @@ joint.shapes.ice.Model = joint.shapes.basic.Generic.extend({
         attrs[portLabelSelector]['y'] = -5-offset;
         attrs[portLabelSelector]['text-anchor'] = 'start';
         attrs[portWireSelector]['y'] = position;
-        attrs[portWireSelector]['d'] = 'M 0 0 L -16 0';
+        attrs[portWireSelector]['d'] = 'M 0 0 L -8 0';
         break;
       case 'top':
         attrs[portSelector]['ref-y'] = -8;
@@ -208,7 +208,7 @@ joint.shapes.ice.Model = joint.shapes.basic.Generic.extend({
         attrs[portLabelSelector]['y'] = 2;
         attrs[portLabelSelector]['text-anchor'] = 'start';
         attrs[portWireSelector]['x'] = position;
-        attrs[portWireSelector]['d'] = 'M 0 0 L 0 16';
+        attrs[portWireSelector]['d'] = 'M 0 0 L 0 8';
         break;
       case 'bottom':
         attrs[portSelector]['ref-dy'] = 8;
@@ -217,7 +217,7 @@ joint.shapes.ice.Model = joint.shapes.basic.Generic.extend({
         attrs[portLabelSelector]['y'] = -2;
         attrs[portLabelSelector]['text-anchor'] = 'start';
         attrs[portWireSelector]['x'] = position;
-        attrs[portWireSelector]['d'] = 'M 0 0 L 0 -16';
+        attrs[portWireSelector]['d'] = 'M 0 0 L 0 -8';
         break;
     }
 

--- a/app/scripts/services/graph.js
+++ b/app/scripts/services/graph.js
@@ -502,7 +502,6 @@ angular.module('icestudio')
         if (lowerBlock) {
           // 1. Compute portsMap between the upperBlock and the lowerBlock
           var portsMap = computeAllPortsMap(upperBlock, lowerBlock);
-          console.log(portsMap);
           // 2. Reconnect the wires from the lowerBlock to the upperBlock
           var wires = graph.getConnectedLinks(lowerBlock);
           _.each(wires, function(wire) {

--- a/app/scripts/services/graph.js
+++ b/app/scripts/services/graph.js
@@ -684,11 +684,13 @@ angular.module('icestudio')
     this.undo = function() {
       disableSelected();
       commandManager.undo();
+      updateWiresOnObstacles();
     };
 
     this.redo = function() {
       disableSelected();
       commandManager.redo();
+      updateWiresOnObstacles();
     };
 
     this.clearAll = function() {

--- a/app/scripts/services/graph.js
+++ b/app/scripts/services/graph.js
@@ -568,6 +568,17 @@ angular.module('icestudio')
           }
         });
 
+        if (_.isEmpty(portsMap) && upperPorts.length === lowerPorts.length) {
+          // If there is no match and the number of lowerPorts and
+          // upperPorts is the same, replace the connections if the
+          // size matches ignoring the ports's name.
+          for (var i = 0; i < lowerPorts.length; i++) {
+            if (lowerPorts[i].size === upperPorts[i].size) {
+              portsMap[lowerPorts[i].id] = upperPorts[i].id;
+            }
+          }
+        }
+
         return portsMap;
       }
 

--- a/app/scripts/services/graph.js
+++ b/app/scripts/services/graph.js
@@ -568,11 +568,11 @@ angular.module('icestudio')
           }
         });
 
-        if (_.isEmpty(portsMap) && upperPorts.length === lowerPorts.length) {
-          // If there is no match and the number of lowerPorts and
-          // upperPorts is the same, replace the connections if the
-          // size matches ignoring the ports's name.
-          for (var i = 0; i < lowerPorts.length; i++) {
+        if (_.isEmpty(portsMap)) {
+          // If there is no match replace the connections if the
+          // port's size matches ignoring the port's name.
+          var n = Math.min(upperPorts.length, lowerPorts.length);
+          for (var i = 0; i < n; i++) {
             if (lowerPorts[i].size === upperPorts[i].size) {
               portsMap[lowerPorts[i].id] = upperPorts[i].id;
             }

--- a/app/scripts/services/graph.js
+++ b/app/scripts/services/graph.js
@@ -525,11 +525,15 @@ angular.module('icestudio')
       function disableReplacedBlock(lowerBlock) {
         if (prevLowerBlock) {
           // Unhighlight previous lower block
-          paper.findViewByModel(prevLowerBlock).$box.removeClass('block-disabled');
+          var prevLowerBlockView = paper.findViewByModel(prevLowerBlock);
+          prevLowerBlockView.$box.removeClass('block-disabled');
+          prevLowerBlockView.$el.removeClass('block-disabled');
         }
         if (lowerBlock) {
           // Highlight new lower block
-          paper.findViewByModel(lowerBlock).$box.addClass('block-disabled');
+          var lowerBlockView = paper.findViewByModel(lowerBlock);
+          lowerBlockView.$box.addClass('block-disabled');
+          lowerBlockView.$el.addClass('block-disabled');
         }
         prevLowerBlock = lowerBlock;
       }

--- a/app/styles/design.css
+++ b/app/styles/design.css
@@ -104,6 +104,10 @@
   pointer-events: none;
 }
 
+.block-disabled {
+  opacity: 0.4;
+}
+
 .generic-block {
   position: absolute;
   background: #C0DFEB;
@@ -113,6 +117,7 @@
   -webkit-user-select: none;
   user-select: none;
   z-index: 0;
+  transition: opacity 0.2s;
 }
 
 .generic-block .clock {
@@ -194,6 +199,7 @@
   -webkit-user-select: none;
   user-select: none;
   z-index: 0;
+  transition: opacity 0.2s;
 }
 
 .virtual-port p {
@@ -225,6 +231,7 @@
   -webkit-user-select: none;
   user-select: none;
   z-index: 0;
+  transition: opacity 0.2s;
 }
 
 .fpga-port p {
@@ -304,6 +311,7 @@
   -webkit-user-select: none;
   user-select: none;
   z-index: 0;
+  transition: opacity 0.2s;
 }
 
 .constant-block p {
@@ -353,6 +361,7 @@
   -webkit-user-select: none;
   user-select: none;
   z-index: 0;
+  transition: opacity 0.2s;
 }
 
 .code-block .code-editor {
@@ -376,6 +385,7 @@
   -webkit-user-select: none;
   user-select: none;
   z-index: 0;
+  transition: opacity 0.2s;
 }
 
 .info-block-readonly {

--- a/app/styles/design.css
+++ b/app/styles/design.css
@@ -108,6 +108,10 @@
   opacity: 0.4;
 }
 
+g {
+  transition: opacity 0.2s;
+}
+
 .generic-block {
   position: absolute;
   background: #C0DFEB;


### PR DESCRIPTION
Related to: https://github.com/FPGAwars/icestudio/issues/191
---

- [x] Drag & replace Generic, Code & Input blocks (move & create)
- [x] Add Undo/Redo for replaced blocks
- [x] Add Drag & replace effect (opacity)
- [x] Replace wires by name and size (for each side)
- [x] Replace wires by position for ports with the same name and size (for each side)

Compute the ports for each side: left, right and top. If there are ports with the same name they are ordered by position, from 0 to n.

```
                   Top ports 0 ·· n
                   _____|__|__|_____
  Left ports 0  --|                 |--  0 Right ports
             ·  --|      BLOCK      |--  ·
             ·  --|                 |--  ·
             n    |_________________|    n
```

![drag replace - 1](https://user-images.githubusercontent.com/2227572/35192089-23fe68e8-fe8b-11e7-8986-f9c17a97eb59.gif)

![drag replace - 2](https://user-images.githubusercontent.com/2227572/35192090-2f8d2500-fe8b-11e7-9b8e-ab982d271d9b.gif)

- [x] Replace wires by size (for each side)

If there is no match replace the connections if the port's size matches ignoring the port's name.

![drag replace - 3](https://user-images.githubusercontent.com/2227572/35192093-355a23de-fe8b-11e7-922a-e3abb2d4290c.gif)
