### PR TITLE
Add more FPGA resources

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -25,7 +25,7 @@
       "tinyfpgab"
     ],
     "external": "",
-    "develop": false
+    "develop": true
   },
   "collection": "0.3.0",
   "engines": {

--- a/app/resources/boards/TinyFPGA-B2/info.json
+++ b/app/resources/boards/TinyFPGA-B2/info.json
@@ -3,6 +3,8 @@
   "datasheet": "https://github.com/tinyfpga/TinyFPGA-B-Series",
   "interface": "Serial",
   "FPGAResources": {
+    "ffs": 7680,
+    "luts": 7680,
     "pios": 23,
     "plbs": 960,
     "brams": 32

--- a/app/resources/boards/blackice-ii/info.json
+++ b/app/resources/boards/blackice-ii/info.json
@@ -3,6 +3,8 @@
   "datasheet": "https://mystorm.uk/",
   "interface": "Serial",
   "FPGAResources": {
+    "ffs": 7680,
+    "luts": 7680,
     "pios": 107,
     "plbs": 960,
     "brams": 32

--- a/app/resources/boards/blackice/info.json
+++ b/app/resources/boards/blackice/info.json
@@ -3,6 +3,8 @@
   "datasheet": "https://mystorm.uk/",
   "interface": "Serial",
   "FPGAResources": {
+    "ffs": 7680,
+    "luts": 7680,
     "pios": 107,
     "plbs": 960,
     "brams": 32

--- a/app/resources/boards/go-board/info.json
+++ b/app/resources/boards/go-board/info.json
@@ -3,6 +3,8 @@
   "datasheet": "https://www.nandland.com/goboard/introduction.html",
   "interface": "FTDI",
   "FPGAResources": {
+    "ffs": 1280,
+    "luts": 1280,
     "pios": 72,
     "plbs": 160,
     "brams": 16

--- a/app/resources/boards/iCE40-HX8K/info.json
+++ b/app/resources/boards/iCE40-HX8K/info.json
@@ -3,6 +3,8 @@
   "datasheet": "http://www.latticesemi.com/view_document?document_id=50373",
   "interface": "FTDI",
   "FPGAResources": {
+    "ffs": 7680,
+    "luts": 7680,
     "pios": 206,
     "plbs": 960,
     "brams": 32

--- a/app/resources/boards/icestick/info.json
+++ b/app/resources/boards/icestick/info.json
@@ -3,6 +3,8 @@
   "datasheet": "http://www.latticesemi.com/icestick",
   "interface": "FTDI",
   "FPGAResources": {
+    "ffs": 1280,
+    "luts": 1280,
     "pios": 96,
     "plbs": 160,
     "brams": 16

--- a/app/resources/boards/icezum/info.json
+++ b/app/resources/boards/icezum/info.json
@@ -3,6 +3,8 @@
   "datasheet": "https://github.com/FPGAwars/icezum/wiki",
   "interface": "FTDI",
   "FPGAResources": {
+    "ffs": 1280,
+    "luts": 1280,
     "pios": 96,
     "plbs": 160,
     "brams": 16

--- a/app/resources/boards/icoboard/info.json
+++ b/app/resources/boards/icoboard/info.json
@@ -3,6 +3,8 @@
   "datasheet": "http://icoboard.org/about-icoboard.html",
   "interface": "GPIO",
   "FPGAResources": {
+    "ffs": 7680,
+    "luts": 7680,
     "pios": 206,
     "plbs": 960,
     "brams": 32

--- a/app/resources/boards/kefir/info.json
+++ b/app/resources/boards/kefir/info.json
@@ -3,6 +3,8 @@
   "datasheet": "http://fpgalibre.sourceforge.net/Kefir/",
   "interface": "",
   "FPGAResources": {
+    "ffs": 7680,
+    "luts": 7680,
     "pios": 107,
     "plbs": 960,
     "brams": 32

--- a/app/scripts/services/common.js
+++ b/app/scripts/services/common.js
@@ -25,6 +25,8 @@ angular.module('icestudio')
 
     // FPGA resources
     this.FPGAResources = {
+      ffs: '-',
+      luts: '-',
       pios: '-',
       plbs: '-',
       brams: '-'

--- a/app/scripts/services/project.js
+++ b/app/scripts/services/project.js
@@ -131,6 +131,7 @@ angular.module('icestudio')
           graph.resetCommandStack();
           graph.fitContent();
           alertify.success(gettextCatalog.getString('Project {{name}} loaded', { name: utils.bold(name) }));
+          common.hasChangesSinceBuild = true;
         });
 
         if (ret) {

--- a/app/scripts/services/tools.js
+++ b/app/scripts/services/tools.js
@@ -82,6 +82,9 @@ angular.module('icestudio')
           })
           .then(function() {
             var hostname = profile.get('remoteHostname');
+            if (profile.get('showFPGAResources')) {
+              commands = commands.concat('-v');
+            }
             if (hostname) {
               return executeRemote(commands, hostname);
             }

--- a/app/scripts/services/tools.js
+++ b/app/scripts/services/tools.js
@@ -43,11 +43,11 @@ angular.module('icestudio')
     };
 
     this.buildCode = function(startMessage, endMessage) {
-      return apioRun(['build', '-b', common.selectedBoard.name], startMessage, endMessage);
+      return apioRun(['build', '--board', common.selectedBoard.name], startMessage, endMessage);
     };
 
     this.uploadCode = function(startMessage, endMessage) {
-      return apioRun(['upload', '-b', common.selectedBoard.name], startMessage, endMessage);
+      return apioRun(['upload', '--board', common.selectedBoard.name], startMessage, endMessage);
     };
 
     function apioRun(commands, startMessage, endMessage) {
@@ -83,7 +83,7 @@ angular.module('icestudio')
           .then(function() {
             var hostname = profile.get('remoteHostname');
             if (profile.get('showFPGAResources')) {
-              commands = commands.concat('-v');
+              commands = commands.concat('--verbose-arachne');
             }
             if (hostname) {
               return executeRemote(commands, hostname);
@@ -273,7 +273,7 @@ angular.module('icestudio')
         }, function (error, stdout, stderr/*, cmd*/) {
           if (!error) {
             startAlert.setContent(gettextCatalog.getString('Execute remote {{label}} ...', { label: '' }));
-            nodeSSHexec((['apio'].concat(commands).concat(['-p', '.build'])).join(' '), hostname,
+            nodeSSHexec((['apio'].concat(commands).concat(['--project-dir', '.build'])).join(' '), hostname,
               function (error, stdout, stderr) {
                 resolve({ error: error, stdout: stdout, stderr: stderr });
               });

--- a/app/scripts/services/tools.js
+++ b/app/scripts/services/tools.js
@@ -496,16 +496,17 @@ angular.module('icestudio')
 
           if (stdout) {
             // Show used resources in the FPGA
-            common.FPGAResources.pios = findFPGAResources(/PIOs\s+([0-9]+)\s/g, stdout, common.FPGAResources.pios);
-            common.FPGAResources.plbs = findFPGAResources(/PLBs\s+([0-9]+)\s/g, stdout, common.FPGAResources.plbs);
-            common.FPGAResources.brams = findFPGAResources(/BRAMs\s+([0-9]+)\s/g, stdout, common.FPGAResources.brams);
+            common.FPGAResources.luts = findValue(/LCs\s+([0-9]+)\s/g, stdout, common.FPGAResources.luts);
+            common.FPGAResources.pios = findValue(/PIOs\s+([0-9]+)\s/g, stdout, common.FPGAResources.pios);
+            common.FPGAResources.plbs = findValue(/PLBs\s+([0-9]+)\s/g, stdout, common.FPGAResources.plbs);
+            common.FPGAResources.brams = findValue(/BRAMs\s+([0-9]+)\s/g, stdout, common.FPGAResources.brams);
             utils.rootScopeSafeApply();
           }
         }
       });
     }
 
-    function findFPGAResources(pattern, output, previousValue) {
+    function findValue(pattern, output, previousValue) {
       var match = pattern.exec(output);
       return (match && match[1]) ? match[1] : previousValue;
     }

--- a/app/scripts/services/tools.js
+++ b/app/scripts/services/tools.js
@@ -496,6 +496,7 @@ angular.module('icestudio')
 
           if (stdout) {
             // Show used resources in the FPGA
+            common.FPGAResources.ffs = findValue(/DFF\s+([0-9]+)\s/g, stdout, common.FPGAResources.ffs);
             common.FPGAResources.luts = findValue(/LCs\s+([0-9]+)\s/g, stdout, common.FPGAResources.luts);
             common.FPGAResources.pios = findValue(/PIOs\s+([0-9]+)\s/g, stdout, common.FPGAResources.pios);
             common.FPGAResources.plbs = findValue(/PLBs\s+([0-9]+)\s/g, stdout, common.FPGAResources.plbs);

--- a/app/scripts/services/utils.js
+++ b/app/scripts/services/utils.js
@@ -173,7 +173,8 @@ angular.module('icestudio')
     this.installOnlineApio = function(callback) {
       var versionRange = '">=' + _package.apio.min + ',<' + _package.apio.max + '"';
       var extraPackages = _package.apio.extras || [];
-      this.executeCommand([coverPath(common.ENV_PIP), 'install', '-U', 'apio[' + extraPackages.toString() + ']' + versionRange], callback);
+      var apio = _package.apio.develop ? common.APIO_PIP_VCS : 'apio';
+      this.executeCommand([coverPath(common.ENV_PIP), 'install', '-U', apio + '[' + extraPackages.toString() + ']' + versionRange], callback);
     };
 
     this.apioInstall = function(_package, callback) {

--- a/app/views/design.html
+++ b/app/views/design.html
@@ -18,6 +18,12 @@
     <div class="board-container">
       <div class="fpga-resources" ng-show="common.selectedBoard && topModule && profile.data.showFPGAResources">
         <span>
+          FFs:&nbsp;&nbsp;{{ common.hasChangesSinceBuild ? '-' : common.FPGAResources.ffs }}&nbsp;/&nbsp;{{ common.selectedBoard.info.FPGAResources.ffs }}
+        </span>
+        <span>
+          LUTs:&nbsp;&nbsp;{{ common.hasChangesSinceBuild ? '-' : common.FPGAResources.luts }}&nbsp;/&nbsp;{{ common.selectedBoard.info.FPGAResources.luts }}
+        </span>
+        <span>
           PIOs:&nbsp;&nbsp;{{ common.hasChangesSinceBuild ? '-' : common.FPGAResources.pios }}&nbsp;/&nbsp;{{ common.selectedBoard.info.FPGAResources.pios }}
         </span>
         <span>


### PR DESCRIPTION
Related to: https://github.com/FPGAwars/icestudio/issues/194
---

- [x] Add FFs & LUTs totals for all boards
- [x] Extract and show FFs
- [x] Extract and show LUTs

Bonus:

- [x] Fix apio develop mode
- [x] Reset FPGA resources when a project is opened

NOTE: Using the `--verbose-arachne` option to capture the FPGA resources.