### PR TITLE
Allow external collections

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -18,8 +18,8 @@
     "icon": "resources/images/icestudio-logo.png"
   },
   "apio": {
-    "min": "0.4.0",
-    "max": "0.5.0",
+    "min": "0.3.3",
+    "max": "0.4.0",
     "extras": [
       "blackiceprog",
       "tinyfpgab",

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -41,11 +41,9 @@ angular
         // Rearrange collections
         collections.sort();
         // Initialize selected board
-        var selectedBoard = boards.selectBoard(profile.get('board')).name;
-        profile.set('board', selectedBoard);
+        profile.set('board', boards.selectBoard(profile.get('board')).name);
         // Initialize selected collection
-        var selectedCollection = collections.selectCollection(profile.get('collection'));
-        profile.set('collection', selectedCollection);
+        profile.set('collection', collections.selectCollection(profile.get('collection')));
         // Initialize title
         project.updateTitle(gettextCatalog.getString('Untitled'));
         $('body').removeClass('waiting');

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -32,20 +32,23 @@ angular
     }, 0);
     // Load boards
     boards.loadBoards();
-    // Load collections
-    collections.loadCollections();
-    // Load language
-    utils.loadLanguage(profile, function() {
-      // Rearrange collections
-      collections.sort();
-      // Initialize selected board
-      var selectedBoard = boards.selectBoard(profile.get('board')).name;
-      profile.set('board', selectedBoard);
-      // Initialize selected collection
-      var selectedCollection = collections.selectCollection(profile.get('collection'));
-      profile.set('collection', selectedCollection);
-      // Initialize title
-      project.updateTitle(gettextCatalog.getString('Untitled'));
-      $('body').removeClass('waiting');
+    // Load profile
+    utils.loadProfile(profile, function() {
+      // Load collections
+      collections.loadCollections();
+      // Load language
+      utils.loadLanguage(profile, function() {
+        // Rearrange collections
+        collections.sort();
+        // Initialize selected board
+        var selectedBoard = boards.selectBoard(profile.get('board')).name;
+        profile.set('board', selectedBoard);
+        // Initialize selected collection
+        var selectedCollection = collections.selectCollection(profile.get('collection'));
+        profile.set('collection', selectedCollection);
+        // Initialize title
+        project.updateTitle(gettextCatalog.getString('Untitled'));
+        $('body').removeClass('waiting');
+      });
     });
   });

--- a/app/scripts/controllers/menu.js
+++ b/app/scripts/controllers/menu.js
@@ -327,27 +327,28 @@ angular.module('icestudio')
       graph.fitContent();
     };
 
-    $scope.setExternalCollection = function() {
-      var externalCollection = profile.get('externalCollection');
+    $scope.setExternalCollections = function() {
+      var externalCollections = profile.get('externalCollections');
       var formSpecs = [
         {
           type: 'text',
-          title: gettextCatalog.getString('Enter the external collection path'),
-          value: externalCollection || ''
+          title: gettextCatalog.getString('Enter the external collections path'),
+          value: externalCollections || ''
         }
       ];
       utils.renderForm(formSpecs, function(evt, values) {
-        var externalCollection = values[0];
+        var externalCollections = values[0];
         if (resultAlert) {
           resultAlert.dismiss(false);
         }
-        if (externalCollection === '' || nodeFs.existsSync(externalCollection)) {
-          profile.set('externalCollection', externalCollection);
-          alertify.success(gettextCatalog.getString('External collection updated'));
+        if (externalCollections === '' || nodeFs.existsSync(externalCollections)) {
+          profile.set('externalCollections', externalCollections);
+          $scope.reloadCollections();
+          alertify.success(gettextCatalog.getString('External collections updated'));
         }
         else {
           evt.cancel = true;
-          resultAlert = alertify.error(gettextCatalog.getString('Path {{path}} does not exist', { path: externalCollection }, 5));
+          resultAlert = alertify.error(gettextCatalog.getString('Path {{path}} does not exist', { path: externalCollections }, 5));
         }
       });
     };

--- a/app/scripts/controllers/menu.js
+++ b/app/scripts/controllers/menu.js
@@ -327,6 +327,31 @@ angular.module('icestudio')
       graph.fitContent();
     };
 
+    $scope.setExternalCollection = function() {
+      var externalCollection = profile.get('externalCollection');
+      var formSpecs = [
+        {
+          type: 'text',
+          title: gettextCatalog.getString('Enter the external collection path'),
+          value: externalCollection || ''
+        }
+      ];
+      utils.renderForm(formSpecs, function(evt, values) {
+        var externalCollection = values[0];
+        if (resultAlert) {
+          resultAlert.dismiss(false);
+        }
+        if (externalCollection === '' || nodeFs.existsSync(externalCollection)) {
+          profile.set('externalCollection', externalCollection);
+          alertify.success(gettextCatalog.getString('External collection updated'));
+        }
+        else {
+          evt.cancel = true;
+          resultAlert = alertify.error(gettextCatalog.getString('Path {{path}} does not exist', { path: externalCollection }, 5));
+        }
+      });
+    };
+
     $(document).on('infoChanged', function(evt, newValues) {
       var values = getProjectInformation();
       if (!_.isEqual(values, newValues)) {

--- a/app/scripts/controllers/menu.js
+++ b/app/scripts/controllers/menu.js
@@ -164,7 +164,7 @@ angular.module('icestudio')
       if (selected &&
           filepath.startsWith(nodePath.join(common.COLLECTIONS_DIR, selected)) ||
           filepath.startsWith(nodePath.join(profile.get('externalCollections'), selected))) {
-        collections.selectCollection(selected);
+        collections.selectCollection(common.selectedCollection.path);
       }
     }
 
@@ -354,18 +354,20 @@ angular.module('icestudio')
         }
       ];
       utils.renderForm(formSpecs, function(evt, values) {
-        var externalCollections = values[0];
+        var newExternalCollections = values[0];
         if (resultAlert) {
           resultAlert.dismiss(false);
         }
-        if (externalCollections === '' || nodeFs.existsSync(externalCollections)) {
-          profile.set('externalCollections', externalCollections);
-          $scope.reloadCollections();
-          alertify.success(gettextCatalog.getString('External collections updated'));
-        }
-        else {
-          evt.cancel = true;
-          resultAlert = alertify.error(gettextCatalog.getString('Path {{path}} does not exist', { path: externalCollections }, 5));
+        if (newExternalCollections !== externalCollections) {
+          if (newExternalCollections === '' || nodeFs.existsSync(newExternalCollections)) {
+            profile.set('externalCollections', newExternalCollections);
+            $scope.reloadCollections();
+            alertify.success(gettextCatalog.getString('External collections updated'));
+          }
+          else {
+            evt.cancel = true;
+            resultAlert = alertify.error(gettextCatalog.getString('Path {{path}} does not exist', { path: newExternalCollections }, 5));
+          }
         }
       });
     };
@@ -533,9 +535,9 @@ angular.module('icestudio')
     };
 
     $scope.selectCollection = function(collection) {
-      if (common.selectedCollection.name !== collection.name) {
-        var name = collections.selectCollection(collection.name);
-        profile.set('collection', name);
+      if (common.selectedCollection.path !== collection.path) {
+        var name = collection.name;
+        profile.set('collection', collections.selectCollection(collection.path));
         alertify.success(gettextCatalog.getString('Collection {{name}} selected',  { name: utils.bold(name ? name : 'Default') }));
       }
     };
@@ -637,7 +639,7 @@ angular.module('icestudio')
 
     $scope.reloadCollections = function() {
       collections.loadCollections();
-      collections.selectCollection(common.selectedCollection.name);
+      collections.selectCollection(common.selectedCollection.path);
     };
 
     $scope.removeCollection = function(collection) {
@@ -650,7 +652,7 @@ angular.module('icestudio')
     };
 
     $scope.removeAllCollections = function() {
-      if (common.collections.length > 1) {
+      if (common.internalCollections.length > 1) {
         alertify.confirm(gettextCatalog.getString('All stored collections will be lost. Do you want to continue?'),
         function() {
           tools.removeAllCollections();

--- a/app/scripts/controllers/menu.js
+++ b/app/scripts/controllers/menu.js
@@ -132,7 +132,9 @@ angular.module('icestudio')
     $scope.saveProject = function() {
       var filepath = project.path;
       if (filepath) {
-        project.save(filepath);
+        project.save(filepath, function () {
+          reloadCollectionsIfRequired(filepath);
+        });
         resetChangedStack();
       }
       else {
@@ -143,13 +145,28 @@ angular.module('icestudio')
     $scope.saveProjectAs = function(localCallback) {
       utils.saveDialog('#input-save-project', '.ice', function(filepath) {
         updateWorkingdir(filepath);
-        project.save(filepath);
+        project.save(filepath, function () {
+          reloadCollectionsIfRequired(filepath);
+        });
         resetChangedStack();
         if (localCallback) {
           localCallback();
         }
       });
     };
+
+    function reloadCollectionsIfRequired(filepath) {
+      var selected = common.selectedCollection.name;
+      if (filepath.startsWith(common.COLLECTIONS_DIR) ||
+          filepath.startsWith(profile.get('externalCollections'))) {
+        collections.loadCollections();
+      }
+      if (selected &&
+          filepath.startsWith(nodePath.join(common.COLLECTIONS_DIR, selected)) ||
+          filepath.startsWith(nodePath.join(profile.get('externalCollections'), selected))) {
+        collections.selectCollection(selected);
+      }
+    }
 
     $rootScope.$on('saveProjectAs', function(event, callback) {
       $scope.saveProjectAs(callback);

--- a/app/scripts/controllers/menu.js
+++ b/app/scripts/controllers/menu.js
@@ -63,11 +63,13 @@ angular.module('icestudio')
         processArg(arg);
         local = arg === 'local' || local;
       }
-      if (local) {
-        project.path = '';
+      var editable = !project.path.startsWith(common.COLLECTIONS_DIR) &&
+                     project.path.startsWith(common.selectedCollection.path);
+      if (editable || !local) {
+        updateWorkingdir(project.path);
       }
       else {
-        updateWorkingdir(project.path);
+        project.path = '';
       }
     }, 0);
 
@@ -117,7 +119,10 @@ angular.module('icestudio')
     $scope.openProject = function(filepath) {
       if (zeroProject) {
         // If this is the first action, open
-        // the projec in the same window
+        // the project in the same window
+        var editable = !filepath.startsWith(common.COLLECTIONS_DIR) &&
+                       filepath.startsWith(common.selectedCollection.path);
+        updateWorkingdir(editable ? filepath : '');
         project.open(filepath, true);
         //zeroProject = false;
       }

--- a/app/scripts/services/common.js
+++ b/app/scripts/services/common.js
@@ -20,7 +20,9 @@ angular.module('icestudio')
     this.pinoutOutputHTML = '';
 
     // Selected collection
-    this.collections = [];
+    this.defaultCollection = null;
+    this.internalCollections = [];
+    this.externalCollections = [];
     this.selectedCollection = null;
 
     // FPGA resources

--- a/app/scripts/services/profile.js
+++ b/app/scripts/services/profile.js
@@ -6,11 +6,12 @@ angular.module('icestudio')
                                nodeFs) {
 
     this.data = {
-      'language': '',
-      'remoteHostname': '',
-      'collection': '',
       'board': '',
       'boardRules': true,
+      'collection': '',
+      'externalCollection': '',
+      'language': '',
+      'remoteHostname': '',
       'showFPGAResources': false
     };
 
@@ -23,11 +24,12 @@ angular.module('icestudio')
       utils.readFile(common.PROFILE_PATH)
       .then(function(data) {
         self.data = {
-          'language': data.language || '',
-          'remoteHostname': data.remoteHostname || '',
-          'collection': data.collection || '',
           'board': data.board || '',
           'boardRules': data.boardRules !== false,
+          'collection': data.collection || '',
+          'language': data.language || '',
+          'externalCollection': data.externalCollection || '',
+          'remoteHostname': data.remoteHostname || '',
           'showFPGAResources': data.showFPGAResources || false
         };
         if (common.DARWIN) {

--- a/app/scripts/services/profile.js
+++ b/app/scripts/services/profile.js
@@ -9,7 +9,7 @@ angular.module('icestudio')
       'board': '',
       'boardRules': true,
       'collection': '',
-      'externalCollection': '',
+      'externalCollections': '',
       'language': '',
       'remoteHostname': '',
       'showFPGAResources': false
@@ -28,7 +28,7 @@ angular.module('icestudio')
           'boardRules': data.boardRules !== false,
           'collection': data.collection || '',
           'language': data.language || '',
-          'externalCollection': data.externalCollection || '',
+          'externalCollections': data.externalCollections || '',
           'remoteHostname': data.remoteHostname || '',
           'showFPGAResources': data.showFPGAResources || false
         };

--- a/app/scripts/services/project.js
+++ b/app/scripts/services/project.js
@@ -302,7 +302,7 @@ angular.module('icestudio')
       return project;
     }
 
-    this.save = function(filepath) {
+    this.save = function(filepath, callback) {
       var name = utils.basename(filepath);
       this.updateTitle(name);
       sortGraph();
@@ -350,6 +350,9 @@ angular.module('icestudio')
       function doSaveProject() {
         utils.saveFile(filepath, pruneProject(project))
         .then(function() {
+          if (callback) {
+            callback();
+          }
           alertify.success(gettextCatalog.getString('Project {{name}} saved', { name: utils.bold(name) }));
         })
         .catch(function(error) {

--- a/app/scripts/services/utils.js
+++ b/app/scripts/services/utils.js
@@ -435,13 +435,13 @@ angular.module('icestudio')
           case 'text':
             content.push('\
               <p>' + spec.title + '</p>\
-              <input class="ajs-input" type="text" value="' + spec.value + '" id="form' + i.toString() + '"/>\
+              <input class="ajs-input" type="text" id="form' + i + '"/>\
             ');
             break;
           case 'checkbox':
             content.push('\
               <div class="checkbox">\
-                <label><input type="checkbox" ' + (spec.value ? 'checked' : '') + ' id="form' + i.toString() + '"/>' + spec.label + '</label>\
+                <label><input type="checkbox" ' + (spec.value ? 'checked' : '') + ' id="form' + i + '"/>' + spec.label + '</label>\
               </div>\
             ');
             break;
@@ -453,7 +453,7 @@ angular.module('icestudio')
             content.push('\
               <div class="form-group">\
                 <label style="font-weight:normal">' + spec.label + '</label>\
-                <select class="form-control" id="form' + i.toString() + '">\
+                <select class="form-control" id="form' + i + '">\
                   ' + options + '\
                 </select>\
               </div>\
@@ -471,10 +471,10 @@ angular.module('icestudio')
             switch(spec.type) {
               case 'text':
               case 'combobox':
-                values.push($('#form' + i.toString()).val());
+                values.push($('#form' + i).val());
                 break;
               case 'checkbox':
-                values.push($('#form' + i.toString()).prop('checked'));
+                values.push($('#form' + i).prop('checked'));
                 break;
             }
           }
@@ -486,6 +486,14 @@ angular.module('icestudio')
       // Focus first element
       setTimeout(function(){
         $('#form0').select();
+        for (var i in specs) {
+          var spec = specs[i];
+          switch(spec.type) {
+            case 'text':
+              $('#form' + i).val(spec.value);
+              break;
+          }
+        }
       }, 50);
     };
 
@@ -507,7 +515,7 @@ angular.module('icestudio')
           //content.push('<br>');
         }
         content.push('  <p>' + messages[i] + '</p>');
-        content.push('  <input class="ajs-input" id="input' + i.toString() + '" type="text" value="' + values[i] + '">');
+        content.push('  <input class="ajs-input" id="input' + i + '" type="text" value="' + values[i] + '">');
       }
       content.push('  <p>' + gettextCatalog.getString('Image') + '</p>');
       content.push('  <input id="input-open-svg" type="file" accept=".svg" class="hidden">');
@@ -523,7 +531,7 @@ angular.module('icestudio')
       content.push('</div>');
       // Restore values
       for (i = 0; i < n; i++) {
-        $('#input' + i.toString()).val(values[i]);
+        $('#input' + i).val(values[i]);
       }
       if (image) {
         $('#preview-svg').attr('src', 'data:image/svg+xml,' + image);
@@ -614,7 +622,7 @@ angular.module('icestudio')
       .set('onok', function(evt) {
         var values = [];
         for (var i = 0; i < n; i++) {
-          values.push($('#input' + i.toString()).val());
+          values.push($('#input' + i).val());
         }
         values.push(image);
         if (callback) {

--- a/app/scripts/services/utils.js
+++ b/app/scripts/services/utils.js
@@ -373,8 +373,9 @@ angular.module('icestudio')
       // Application strings
       gettextCatalog.loadRemote(nodePath.join(common.LOCALE_DIR, bestLang, bestLang + '.json'));
       // Collections strings
-      for (var c in common.collections) {
-        var collection = common.collections[c];
+      var collections = common.internalCollections.concat(common.externalCollections);
+      for (var c in collections) {
+        var collection = collections[c];
         var filepath = nodePath.join(collection.path, 'locale', bestLang, bestLang + '.json');
         if (nodeFs.existsSync(filepath)) {
           gettextCatalog.loadRemote(filepath);

--- a/app/views/menu.html
+++ b/app/views/menu.html
@@ -141,7 +141,7 @@
                     </ul>
                   </li>
                   <li>
-                    <a href ng-click="setExternalCollection()">{{ 'External collection' | translate }}</a>
+                    <a href ng-click="setExternalCollections()">{{ 'External collections' | translate }}</a>
                   </li>
                   <li>
                     <a href ng-click="setRemoteHostname()">

--- a/app/views/menu.html
+++ b/app/views/menu.html
@@ -141,6 +141,9 @@
                     </ul>
                   </li>
                   <li>
+                    <a href ng-click="setExternalCollection()">{{ 'External collection' | translate }}</a>
+                  </li>
+                  <li>
                     <a href ng-click="setRemoteHostname()">
                       {{ 'Remote hostname' | translate }}
                       <span ng-show="profile.data.remoteHostname" class="glyphicon glyphicon-ok-circle"></span>

--- a/app/views/menu.html
+++ b/app/views/menu.html
@@ -203,18 +203,25 @@
               <li class="dropdown-submenu" uib-dropdown>
                 <a href uib-dropdown-toggle>{{ 'Collection' | translate }}</a>
                 <ul uib-dropdown-menu>
-                  <data ng-init="collection = common.collections[0]"/>
+                  <data ng-init="collection = common.defaultCollection"/>
                   <li>
                     <a href ng-click="selectCollection(collection)" ng-show="collection.name == ''">
                       {{ 'Default' | translate }}&ensp;
                       <span ng-show="common.selectedCollection.name == ''" class="glyphicon glyphicon-ok-circle"></span>
                     </a>
                   </li>
-                  <li class="divider" ng-show="common.collections.length > 1"></li>
-                  <li ng-repeat="collection in common.collections">
+                  <li class="divider" ng-show="common.internalCollections.length > 1"></li>
+                  <li ng-repeat="collection in common.internalCollections">
                     <a href ng-click="selectCollection(collection)" ng-hide="collection.name == ''">
                       {{ collection.name }}&ensp;
-                      <span ng-show="common.selectedCollection.name == collection.name" class="glyphicon glyphicon-ok-circle"></span>
+                      <span ng-show="common.selectedCollection.path == collection.path" class="glyphicon glyphicon-ok-circle"></span>
+                    </a>
+                  </li>
+                  <li class="divider" ng-show="common.externalCollections.length > 1"></li>
+                  <li ng-repeat="collection in common.externalCollections">
+                    <a href ng-click="selectCollection(collection)" ng-hide="collection.name == ''">
+                      {{ collection.name }}&ensp;
+                      <span ng-show="common.selectedCollection.path == collection.path" class="glyphicon glyphicon-ok-circle"></span>
                     </a>
                   </li>
                 </ul>
@@ -294,8 +301,8 @@
                   <li class="dropdown-submenu" uib-dropdown>
                     <a href uib-dropdown-toggle>{{ 'Remove' | translate }}</a>
                     <ul uib-dropdown-menu
-                        ng-show="common.collections.length > 1">
-                      <li ng-repeat="collection in common.collections">
+                        ng-show="common.internalCollections.length > 1">
+                      <li ng-repeat="collection in common.internalCollections">
                         <a href ng-click="removeCollection(collection)" ng-if="collection.name != ''">
                           {{ collection.name | translate }}
                         </a>


### PR DESCRIPTION
`External collections` is a variable stored in the profile that contains the information of an existing absolute path in the file system. This path should contain directories with Icestudio collections.

### External collections form

`Edit` > `Preferences` > `External collections`.

![ec-1](https://user-images.githubusercontent.com/2227572/42976489-195f1350-8bc2-11e8-9cfa-db2785b9f2be.png)

If the path does not exists the variable won't be set and an error alert will be shown.

![ec-20](https://user-images.githubusercontent.com/2227572/42976587-9eb282d0-8bc2-11e8-9e05-cbb4c78bfa99.png)

When a new valid path is added you can confirm the form and it will try to load the collections inside this path.

![ec-2](https://user-images.githubusercontent.com/2227572/42976569-82f66af2-8bc2-11e8-90d6-2c22247bc3bf.png)

### Select external collections

When the application starts, internal and externals collections are loaded. To avoid performance issues there is a limit of 5 levels in the search exploration of the directories.

In `Select` > `Collections` three sections appear: default collection, internal collections and external collections.

![ec-3](https://user-images.githubusercontent.com/2227572/42976682-4db8666e-8bc3-11e8-8c72-1e25bfdd1a7a.png)

For data security reasons only internal collections can be removed (to avoid accidental removal of external files).

![ec-4](https://user-images.githubusercontent.com/2227572/42976691-533a3bbc-8bc3-11e8-8ca9-15ac5aefdc3c.png)

### Edit external collections

When an external collection block or example is opened, the working dir is loaded to allow saving that file in its path. When an internal collection block or example is opened, the working dir is reset to avoid editing internal collection files by mistake.

Finally, when a file inside a collection is saved, the collection is refreshed. Note that this can be done always by pressing `Tools` > `Collections` > `Reload`.
