### PR TITLE
[Bug] Closing App with multiple windows #175

### DIFF
--- a/app/scripts/controllers/menu.js
+++ b/app/scripts/controllers/menu.js
@@ -48,7 +48,7 @@ angular.module('icestudio')
     win.on('resize', function() {
       graph.fitContent();
     });
-
+    
     // Darwin fix for shortcuts
     if (process.platform === 'darwin') {
       var mb = new gui.Menu({type: 'menubar'});
@@ -56,8 +56,30 @@ angular.module('icestudio')
       win.menu = mb;
     }
 
+    // New window, get the focus
+    win.focus();
+
     // Load app arguments
     setTimeout(function() {
+
+      // Parse GET url parmeters for window instance arguments
+      // all arguments will be embeded in icestudio_argv param
+      // that is a JSON string url encoded
+
+      let queryStr = unescape(window.location.search) + '&';
+      let regex = new RegExp('.*?[&\\?]icestudio_argv=(.*?)&.*');
+      let val = queryStr.replace(regex, "$1");
+      let params = (val == queryStr) ? false : val;
+
+      // If there are url params, compatibilize it with shell call
+      if(params !==false){
+          params=JSON.parse(decodeURI(params));
+          if(typeof gui.App.argv ==='undefined') gui.App.argv=[];
+          for(let prop in params){
+            gui.App.argv.push(params[prop]);
+          }
+      }
+      
       var local = false;
       for (var i in gui.App.argv) {
         var arg = gui.App.argv[i];
@@ -73,6 +95,7 @@ angular.module('icestudio')
       else {
         project.path = '';
       }
+
     }, 0);
 
     function processArg(arg) {

--- a/app/scripts/services/utils.js
+++ b/app/scripts/services/utils.js
@@ -871,18 +871,36 @@ angular.module('icestudio')
     };
 
     this.newWindow = function(filepath, local) {
-
+      
         var gui = require('nw.gui');
 
-        // Create a new window and get it.
-        // new-instance and new_instance are necessary to maintain
-        // compatibility between different operating systems and avoid
-        // closing the application when creating a new window
-        // (little trick for nwjs bug)
+        let params=false;
+        
+        if(typeof filepath !=='undefined'){
+            params={'filepath':filepath};
+        }
+        
+        if(typeof local !=='undefined' && local===true){
+            if(params===false) params={};
+            params.local='local';
+        }
 
-        var new_win = gui.Window.open('index.html', {
-            "new-instance": true,
-            "new_instance": true,
+        // To pass parameters to the new project window, we use de GET parameter "icestudio_argv"
+        // that contains the same arguments that shell call, in this way the two calls will be 
+        // compatible. 
+        // If in the future you will add more paremeters to the new window , you should review
+        // scripts/controllers/menu.js even if all parameters that arrive are automatically parse
+
+        let url='index.html'+((params===false)?'' :'?icestudio_argv='+encodeURI(JSON.stringify(params) ));
+
+        // Create a new window and get it.
+        // new-instance and new_instance are necesary for OS compatibility
+        // to avoid crash on new window project after close parent
+        // (little trick for nwjs bug).
+
+        var new_win = gui.Window.open(url, {
+            "new-instance" : true,
+            "new_instance" : true,
             "position": "center",
             "toolbar": false,
             "width": 900,
@@ -890,11 +908,7 @@ angular.module('icestudio')
             "show": true,
         });
 
-        // Force focus after small setup wait
-        setTimeout(function (){
-          this.focus();
-        }.bind(new_win),250);
-    };
+   };
 
     this.coverPath = coverPath;
     function coverPath(filepath) {

--- a/app/scripts/services/utils.js
+++ b/app/scripts/services/utils.js
@@ -871,11 +871,17 @@ angular.module('icestudio')
     };
 
     this.newWindow = function(filepath, local) {
-      
+
         var gui = require('nw.gui');
-    
-        // Create a new window and get it
+
+        // Create a new window and get it.
+        // new-instance and new_instance are necessary to maintain
+        // compatibility between different operating systems and avoid
+        // closing the application when creating a new window
+        // (little trick for nwjs bug)
+
         var new_win = gui.Window.open('index.html', {
+            "new-instance": true,
             "new_instance": true,
             "position": "center",
             "toolbar": false,
@@ -884,11 +890,10 @@ angular.module('icestudio')
             "show": true,
         });
 
+        // Force focus after small setup wait
         setTimeout(function (){
           this.focus();
-
         }.bind(new_win),250);
-
     };
 
     this.coverPath = coverPath;


### PR DESCRIPTION
Fix for the  #175 issue, 

It was due to a nwjs bug that depends on the operating system and different versions of dynamic libraries need one flag or another, due to backward compatibility issues. As a temporary solution we will add both flags for works correctly. 

In future versions of nwjs only need new-instance flag.