### PR TITLE
Bug fixed: not working when the view resources option was selected

### DIFF
--- a/app/scripts/services/tools.js
+++ b/app/scripts/services/tools.js
@@ -82,7 +82,7 @@ angular.module('icestudio')
               var command = commands[0];
               if (command === 'build' || command === 'upload') {
                 if (profile.get('showFPGAResources')) {
-                  commands = commands.concat('--verbose-arachne');
+                  commands = commands.concat('--verbose-pnr');
                 }
               }
               if (hostname) {


### PR DESCRIPTION
If the View resources FPGA option is activated, the circuit will be uploaded/build correctly, BUT the resources are not shown (It requires another patch)