### PR TITLE
Fix markdown elements in dark mode

### DIFF
--- a/app/styles/themes/dark/dark.css
+++ b/app/styles/themes/dark/dark.css
@@ -51,7 +51,7 @@
 }
 
 .breadcrumb {
-    background-color: #222;
+    background: #222;
 }
 
 .breadcrumb>.active {
@@ -72,7 +72,30 @@
 }
 
 .info-block .info-render {
-  color: #6d6d6d;
+    color: #6d6d6d;
+}
+
+.markdown-body {
+    color: white !important;
+}
+
+.markdown-body a {
+    color: cornflowerblue;
+}
+
+.markdown-body table th {
+    background: #444;
+    border-color: #777;
+}
+
+.markdown-body table td {
+    background: #333;
+    border-color: #777;
+}
+
+.markdown-body pre {
+    color: white;
+    background: #333;
 }
 
 .read-only {


### PR DESCRIPTION
Text, tables and pre-formatted blocks all needed special cases.

![Screenshot](https://user-images.githubusercontent.com/5117093/83342968-420f0c80-a338-11ea-973b-63e3ca941c12.png)
