### PR TITLE
Improve sorting of collections

### DIFF
--- a/app/scripts/services/collections.js
+++ b/app/scripts/services/collections.js
@@ -126,23 +126,60 @@ angular.module('icestudio')
 
     function sortContent(items) {
       if (items) {
-        items.sort(byName);
+        items.sort(byNameAlphaNum);
         for (var i in items) {
           sortContent(items[i].children);
         }
       }
     }
 
-    function byName(a, b) {
+    function byNameAlphaNum(a, b) {
       a = gettextCatalog.getString(a.name);
       b = gettextCatalog.getString(b.name);
-      if (a > b) {
-        return 1;
-      }
-      if (a < b) {
-        return -1;
-      }
-      return 0;
+      return alphaNumSort(a, b);
     }
+
+    // Thanks: Gideon, https://ux.stackexchange.com/a/134765
+    function alphaNumSort(a, b) {
+      var regex = /[^\d]+|\d+/g;
+
+      // Split each name into alphabetical and numeric parts
+      var ar = a.match(regex);
+      var br = b.match(regex);
+      var localeCompare;
+
+      // For each part in the two split names, perform the following comparison:
+      for (var ia in ar) {
+        for (var ib in br) {
+          var ari = ar[ib];
+          if (ari == undefined) {
+            ari = "";
+          }
+          var bri = br[ib];
+          if (bri == undefined) {
+            bri = "";
+          }
+
+          // If both parts are strictly numeric, compare them as numbers 
+          if (!isNaN(ari) && !isNaN(bri)) {
+            localeCompare = ari.localeCompare(bri, {}, {
+              numeric: true
+            });
+          } else {
+            localeCompare = ari.localeCompare(bri, {}, {
+              ignorePunctuation: true,
+              sensitivity: "base"
+            });
+          }
+          if (localeCompare != 0) {
+            // If you run out of parts, the name with the fewest parts comes first
+            return localeCompare;
+          }
+
+          // If they're the same, move on to the next part
+        }
+      }
+      return localeCompare;
+    };
 
   });


### PR DESCRIPTION
This accounts for numeric parts of names instead of just alphabetic.

First image shows the problem that I have with sorting order:
![CollectionMenuOrdering](https://user-images.githubusercontent.com/3942818/95282889-5ef8a680-0828-11eb-8a4c-851548a5e403.png)

Second image shows this will affect other people's work and the presentation of collections - However, I guess it's an improvement... you're going to like seeing the menu with
0_2,
0_4,
0_8,
0_16:
![KefirOrigOrder](https://user-images.githubusercontent.com/3942818/95283035-c1ea3d80-0828-11eb-8ea6-5cf21ba9da16.png)

This shows an example old order:
![KefirOrigOrder2](https://user-images.githubusercontent.com/3942818/95283193-2efdd300-0829-11eb-8545-58fe1f40720e.png)

New order:
![KefirNewOrder2](https://user-images.githubusercontent.com/3942818/95283208-358c4a80-0829-11eb-9aa6-7e752285d999.png)
