### PR TITLE
Added scrollbars to board select menu.

### DIFF
--- a/app/styles/menu.css
+++ b/app/styles/menu.css
@@ -42,6 +42,11 @@
   overflow: auto*/
 }
 
+.dropdown-overflow {
+  max-height: calc(100vh - 120px);
+  overflow: auto
+}
+
 .dropdown-submenu:hover > .dropdown-menu {
   visibility: visible;
   transition-delay: 0.3s;

--- a/app/views/menu.html
+++ b/app/views/menu.html
@@ -197,7 +197,7 @@
             <ul uib-dropdown-menu>
               <li class="dropdown-submenu" uib-dropdown>
                 <a href uib-dropdown-toggle>{{ 'Board' | translate }}</a>
-                <ul uib-dropdown-menu>
+                <ul uib-dropdown-menu class="dropdown-overflow">
                    <li><a><b>HX1K</b></a></li>
                    <li ng-repeat="board in common.boards">
                      <menuboard type="'HX1K'" board="board"></menuboard>


### PR DESCRIPTION
The boards menu is getting a bit full, so I added scrollbars to it. Originally I applied this to all sub-menus, but that caused the preferences menu to not work right. The method that I used is a bit messy, so it might be best to add this to all the menus in some way, but I do not know how to do it.