### PR TITLE
Fix "don't display" label to allow clicking anywhere on label

### DIFF
--- a/app/scripts/controllers/menu.js
+++ b/app/scripts/controllers/menu.js
@@ -163,7 +163,7 @@ angular
        *                                                                 */
       $scope.closeVersionInfoWindow = function () {
         $("#version-info-tab").addClass("hidden");
-        var nodisplay = $('input[name="version-info-tab--no-display"]').is(
+        var nodisplay = $('#version-info-tab--no-display').is(
           ":checked"
         );
         if (nodisplay) {
@@ -186,7 +186,7 @@ angular
           noShowVersion = false;
         }
 
-        $('input[name="version-info-tab--no-display"]').prop(
+        $('#version-info-tab--no-display').prop(
           "checked",
           noShowVersion
         );

--- a/app/views/version.html
+++ b/app/views/version.html
@@ -5,7 +5,7 @@
         <div class="version-info-tab--body--content">
 
 
-            <p><a ng-click="openUrl('https://github.com/FPGAwars/icestudio/wiki', $event)" 
+            <p><a ng-click="openUrl('https://github.com/FPGAwars/icestudio/wiki', $event)"
                   href="https://github.com/FPGAwars/icestudio/wiki">
                 <img class="img-responsive" src="resources/images/icestudio-github.svg"></a>
             </p>
@@ -15,29 +15,29 @@
             <h2>Welcome to Icestudio!</h2>
 
             <p>You can read the release notes on the
-                <a ng-click="openUrl('https://github.com/FPGAwars/icestudio/wiki/Release-history', $event)" 
-                href="https://github.com/FPGAwars/icestudio/wiki/Release-history">Release History WIKI</a>  
+                <a ng-click="openUrl('https://github.com/FPGAwars/icestudio/wiki/Release-history', $event)"
+                href="https://github.com/FPGAwars/icestudio/wiki/Release-history">Release History WIKI</a>
             </p>
 
             <h2>{{ 'Acknowledgment' | translate }}</h2>
             <p>This release has been possible thanks to the great work done by
                 <a ng-click="openUrl('https://github.com/cavearr', $event)" href="https://github.com/cavearr">Carlos Venegas</a>
                 (Charliva at FPGAwars community and @cavearr at GitHub or Twitter). We all in the FPGAwars community appreciate it very much. You rock! Thank you very much!</p>
-               
+
                 <p><strong>This is a WIP build and there can be some bugs. If you find one, please submit an issue at <a ng-click="openUrl('https://github.com/FPGAwars/icestudio/issues', $event)" href="https://github.com/FPGAwars/icestudio/issues">Icestudio repository</a>. Write the tag [WIP] in the issue subject</a></strong></p>
 
             <br>
             <p>Icestudio is part of <a ng-click="openUrl('http://fpgawars.github.io/')">FPGAwars</a> community</p>
 
-            <p> <a ng-click="openUrl('https://fpgawars.github.io/', $event)" 
+            <p> <a ng-click="openUrl('https://fpgawars.github.io/', $event)"
                    href="https://fpgawars.github.io/">
                 <img class="img-responsive" src="resources/images/fgpawars-banner.svg"> </a>
             </p>
-            
+
         </div>
 
     <div class="version-info-tab--options">
-        <div class="version-info-tab--options--group"><input type="checkbox" name="version-info-tab--no-display"><label for="version-info-tab--no-display">{{ 'Don\'t display' | translate }}</label></div>
+        <div class="version-info-tab--options--group"><input type="checkbox" id="version-info-tab--no-display"><label for="version-info-tab--no-display">{{ 'Don\'t display' | translate }}</label></div>
         <div class="version-info-tab--options--group"></div>
         <div class="version-info-tab--options--group util--text-align-right"><button ng-click="closeVersionInfoWindow()">{{ 'Close' | translate }}</button></div>
     </div>


### PR DESCRIPTION
Previously only clicking the small check box worked. "for" requires "id" not "name"