### PR TITLE
Fixed error in CollectionManager plugin

### DIFF
--- a/app/resources/libs/Icestudio/GUI/Widgets/IceGuiTree.js
+++ b/app/resources/libs/Icestudio/GUI/Widgets/IceGuiTree.js
@@ -278,11 +278,11 @@ class IceGuiTree {
       typeof obj.package.description !== "undefined" &&
       typeof obj.package.name != "undefined" &&
       obj.package.description !== null &&
-      obj.package.description.length > 0 &&
+      obj.package.description !== '' &&
       obj.package.name !== null &&
       obj.package.name.length > 0 &&
       obj.package.image !== null &&
-      obj.package.image.length > 0
+			obj.package.image !== ''
     ) {
       let transaction = this.assetsDB.db.transaction(
         ["blockAssets"],


### PR DESCRIPTION
- Fixed an error in collection manager plugin that causes blocks without "image" or "description" didn't work when you try to drag and drop them into your design.

This is a fix for this issue: #563