### PR TITLE
Label-Finder & ToolBox fixes

### DIFF
--- a/app/resources/uiThemes/dark/dark.css
+++ b/app/resources/uiThemes/dark/dark.css
@@ -485,6 +485,7 @@
   color: rgba(255,255,255,0.75);
   padding-left: 8px;
   line-height: 30px;
+  padding-right: 8px;
 }
 .lFinder-name--field:focus{
   border-radius: 4px;

--- a/app/resources/uiThemes/light/light.css
+++ b/app/resources/uiThemes/light/light.css
@@ -494,6 +494,7 @@
   color: rgba(0,0,0,0.75);
   padding-left: 8px;
   line-height: 30px;
+  padding-right: 8px;
 }
 .lFinder-name--field:focus{
   border-radius: 4px;

--- a/app/scripts/services/shortcuts.js
+++ b/app/scripts/services/shortcuts.js
@@ -66,8 +66,8 @@ angular.module('icestudio')
     var shortcuts = {
 
       showToolBox: {
-        linux: { label: 'Ctrl+Space', ctrl: true, key: 32 },
-        mac: { label: '⌘+A', meta: true, key: 32 }
+        linux: { label: 'Ctrl+T', ctrl: true, key: 84 },
+        mac: { label: '⌘+T', meta: true, key: 84 }
       },
       showLabelFinder: {
         linux: { label: 'Ctrl+F', ctrl: true, key: 70 },

--- a/app/views/menu.html
+++ b/app/views/menu.html
@@ -181,11 +181,6 @@ i
                 <a href ng-click="selectAll()">{{ 'Select all' | translate }}<span class="shortcut">{{ 'selectAll' | shortcut }}</span></a>
               </li>
 
-              <!-- Label-Finder -->
-              <li>
-                <a href ng-click="showLabelFinder()">{{ 'Label Finder' | translate }}<span class="shortcut">{{ 'showLabelFinder' | shortcut }}</span></a>
-              </li>
-
               <!-- Divisor line between sections of the menu -->
               <li class="divider"></li>
 
@@ -193,6 +188,17 @@ i
               <li>
                 <a href ng-click="fitContent()">{{ 'Fit content' | translate }}<span class="shortcut">{{ 'fitContent' | shortcut }}</span></a>
               </li>
+
+              <!-- Label-Finder -->
+              <li>
+                <a href ng-click="showLabelFinder()">{{ 'Label Finder' | translate }}<span class="shortcut">{{ 'showLabelFinder' | shortcut }}</span></a>
+              </li>
+
+              <!-- ToolBox -->
+              <li>
+                <a href ng-click="showToolBox()">{{ 'Toolbox' | translate }}<span class="shortcut">{{ 'showToolBox' | shortcut }}</span></a>
+              </li>
+
 
               <!-- Divisor line between sections of the menu -->
               <li class="divider"></li>


### PR DESCRIPTION
Label-Finder:
- Auto-find when option "case sensitive" or "exact word" is toggled (@jojo535275 suggestion)
- Fix Label-Finder for Buses
- Fix filter for bad names in "search" and "new name" inputs
- Added padding-right in "new name" field

Toolbox:
- Change Shortcut key for open/close Toolbox -> Ctr+T (t = 84) (in macOS "meta+space" shortcut is used for a system search function)
- Added Toolbox shortcut to "Edit" menu (@jojo535275  suggestion)