### PR TITLE
Enable driver installation on apple silicon machines

### DIFF
--- a/app/scripts/services/utils.js
+++ b/app/scripts/services/utils.js
@@ -74,6 +74,13 @@ angular.module('icestudio')
           possibleExecutables.push('/usr/bin/python3');
           possibleExecutables.push('/usr/bin/python');
 
+          possibleExecutables.push('/opt/homebrew/bin/python3.10');
+          possibleExecutables.push('/opt/homebrew/bin/python3.9');
+          possibleExecutables.push('/opt/homebrew/bin/python3.8');
+          possibleExecutables.push('/opt/homebrew/bin/python3.7');
+          possibleExecutables.push('/opt/homebrew/bin/python3');
+          possibleExecutables.push('/opt/homebrew/bin/python');
+
           possibleExecutables.push('/usr/local/bin/python3.10');
           possibleExecutables.push('/usr/local/bin/python3.9');
           possibleExecutables.push('/usr/local/bin/python3.8');


### PR DESCRIPTION
Based on the solution provided [here](https://github.com/FPGAwars/icestudio/issues/659#issuecomment-1308627735) in #659 this should enable installing the drivers on apple silicon machines and not break intel based macs.

I have tested this on `Ventura 13.0` on a `MacBook Air M2, 2022` and it enables installing the drivers which previously would fail.