### PR TITLE
Fixed the error "arch: brew not found in PATH" while installing driver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -160,7 +160,7 @@
     "node_modules/appdmg/node_modules/async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w=="
     },
     "node_modules/appdmg/node_modules/cross-spawn": {
       "version": "6.0.5",
@@ -585,7 +585,7 @@
     "node_modules/bplist-creator/node_modules/stream-buffers": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
-      "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
+      "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
       "engines": {
         "node": ">= 0.10.0"
       }
@@ -1524,7 +1524,7 @@
     "node_modules/ds-store": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ds-store/-/ds-store-0.1.6.tgz",
-      "integrity": "sha1-0QJO90btDBPw9/7IXH6FjoxLfKc=",
+      "integrity": "sha512-kY21M6Lz+76OS3bnCzjdsJSF7LBpLYGCVfavW8TgQD2XkcqIZ86W0y9qUDZu6fp7SIZzqosMDW2zi7zVFfv4hw==",
       "dependencies": {
         "bplist-creator": "~0.0.3",
         "macos-alias": "~0.2.5",
@@ -1925,7 +1925,7 @@
     "node_modules/fmix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
-      "integrity": "sha1-x7vxJN7ELJ0ZHPuUfQqXeN2YbAw=",
+      "integrity": "sha512-Y6hyofImk9JdzU8k5INtTXX1cu8LDlePWDFU5sftm9H+zKCr5SGrVjdhkvsim646cw5zD0nADj8oHyXMZmCZ9w==",
       "dependencies": {
         "imul": "^1.0.0"
       }
@@ -2350,7 +2350,7 @@
     "node_modules/grunt-appdmg/node_modules/ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2358,7 +2358,7 @@
     "node_modules/grunt-appdmg/node_modules/chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -2373,7 +2373,7 @@
     "node_modules/grunt-appdmg/node_modules/supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -3537,7 +3537,7 @@
     "node_modules/imul": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
-      "integrity": "sha1-nVhnFh6LPelsLDjV3HyxAvNeKsk=",
+      "integrity": "sha512-WFAgfwPLAjU66EKt6vRdTlKj4nAgIDQzh29JonLa4Bqtl6D8JrIMvWjCnx7xEjVNmP3U0fM5o8ZObk7d0f62bA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4368,7 +4368,7 @@
     "node_modules/macos-alias": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.11.tgz",
-      "integrity": "sha1-/u6mwTuhGYFKQ/xDxHCzHlnvcYo=",
+      "integrity": "sha512-zIUs3+qpml+w3wiRuADutd7XIO8UABqksot10Utl/tji4UxZzLG4fWDC+yJZoO8/Ehg5RqsvSRE/6TS5AEOeWw==",
       "hasInstallScript": true,
       "os": [
         "darwin"
@@ -4517,9 +4517,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "node_modules/ncp": {
       "version": "2.0.0",
@@ -5554,7 +5554,7 @@
     "node_modules/parse-color": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
-      "integrity": "sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=",
+      "integrity": "sha512-fuDHYgFHJGbpGMgw9skY/bj3HL/Jrn4l/5rSspy00DoT4RyLnDcRvPxdZ+r6OFwIsgAuhDh4I09tAId4mI12bw==",
       "dependencies": {
         "color-convert": "~0.5.0"
       }
@@ -5562,7 +5562,7 @@
     "node_modules/parse-color/node_modules/color-convert": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-      "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
+      "integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling=="
     },
     "node_modules/parse-filepath": {
       "version": "1.0.2",
@@ -6025,7 +6025,7 @@
     "node_modules/repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
       "engines": {
         "node": ">=0.10"
       }
@@ -6633,7 +6633,7 @@
     "node_modules/tn1150": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/tn1150/-/tn1150-0.1.0.tgz",
-      "integrity": "sha1-ZzUD0k1WuH3ouMd/7j/AhT1ZoY0=",
+      "integrity": "sha512-DbplOfQFkqG5IHcDyyrs/lkvSr3mPUVsFf/RbDppOshs22yTPnSJWEe6FkYd1txAwU/zcnR905ar2fi4kwF29w==",
       "dependencies": {
         "unorm": "^1.4.1"
       },
@@ -7270,7 +7270,7 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+          "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w=="
         },
         "cross-spawn": {
           "version": "6.0.5",
@@ -7665,7 +7665,7 @@
         "stream-buffers": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
-          "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ="
+          "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg=="
         }
       }
     },
@@ -8472,7 +8472,7 @@
     "ds-store": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ds-store/-/ds-store-0.1.6.tgz",
-      "integrity": "sha1-0QJO90btDBPw9/7IXH6FjoxLfKc=",
+      "integrity": "sha512-kY21M6Lz+76OS3bnCzjdsJSF7LBpLYGCVfavW8TgQD2XkcqIZ86W0y9qUDZu6fp7SIZzqosMDW2zi7zVFfv4hw==",
       "requires": {
         "bplist-creator": "~0.0.3",
         "macos-alias": "~0.2.5",
@@ -8817,7 +8817,7 @@
     "fmix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
-      "integrity": "sha1-x7vxJN7ELJ0ZHPuUfQqXeN2YbAw=",
+      "integrity": "sha512-Y6hyofImk9JdzU8k5INtTXX1cu8LDlePWDFU5sftm9H+zKCr5SGrVjdhkvsim646cw5zD0nADj8oHyXMZmCZ9w==",
       "requires": {
         "imul": "^1.0.0"
       }
@@ -9171,12 +9171,12 @@
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA=="
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -9188,7 +9188,7 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g=="
         }
       }
     },
@@ -10100,7 +10100,7 @@
     "imul": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
-      "integrity": "sha1-nVhnFh6LPelsLDjV3HyxAvNeKsk="
+      "integrity": "sha512-WFAgfwPLAjU66EKt6vRdTlKj4nAgIDQzh29JonLa4Bqtl6D8JrIMvWjCnx7xEjVNmP3U0fM5o8ZObk7d0f62bA=="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -10801,7 +10801,7 @@
     "macos-alias": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.11.tgz",
-      "integrity": "sha1-/u6mwTuhGYFKQ/xDxHCzHlnvcYo=",
+      "integrity": "sha512-zIUs3+qpml+w3wiRuADutd7XIO8UABqksot10Utl/tji4UxZzLG4fWDC+yJZoO8/Ehg5RqsvSRE/6TS5AEOeWw==",
       "requires": {
         "nan": "^2.4.0"
       }
@@ -10921,9 +10921,9 @@
       }
     },
     "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "ncp": {
       "version": "2.0.0",
@@ -11748,7 +11748,7 @@
     "parse-color": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
-      "integrity": "sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=",
+      "integrity": "sha512-fuDHYgFHJGbpGMgw9skY/bj3HL/Jrn4l/5rSspy00DoT4RyLnDcRvPxdZ+r6OFwIsgAuhDh4I09tAId4mI12bw==",
       "requires": {
         "color-convert": "~0.5.0"
       },
@@ -11756,7 +11756,7 @@
         "color-convert": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
+          "integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling=="
         }
       }
     },
@@ -12145,7 +12145,7 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
     },
     "repeating": {
       "version": "2.0.1",
@@ -12636,7 +12636,7 @@
     "tn1150": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/tn1150/-/tn1150-0.1.0.tgz",
-      "integrity": "sha1-ZzUD0k1WuH3ouMd/7j/AhT1ZoY0=",
+      "integrity": "sha512-DbplOfQFkqG5IHcDyyrs/lkvSr3mPUVsFf/RbDppOshs22yTPnSJWEe6FkYd1txAwU/zcnR905ar2fi4kwF29w==",
       "requires": {
         "unorm": "^1.4.1"
       }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.9.2w",
   "description": "Visual editor for open FPGA boards",
   "contributors": [
-   {
+    {
       "name": "Carlos Venegas Arrabe",
       "url": "https://github.com/cavearr"
     },
@@ -49,5 +49,8 @@
   },
   "darwinDependencies": {
     "grunt-appdmg": "https://github.com/agoodney/grunt-appdmg.git"
+  },
+  "dependencies": {
+    "grunt-appdmg": "github:agoodney/grunt-appdmg"
   }
 }


### PR DESCRIPTION
When running icestudio as an app on my Mac M1 (running Ventura) I always got the error `arch: brew not found in PATH` while installing the drivers. It was all running good when I started icestudio through `npm run start` - maybe because on my console the PATH is correctly set.

This fix does not depend on PATH environment variable but checks possible absolute paths to run brew from.

It also adds a little error handling while installing the drivers (for example if a command does not return a good error code).