### PR TITLE
Added Edit->Delete menu option/action

### DIFF
--- a/app/scripts/controllers/menu.js
+++ b/app/scripts/controllers/menu.js
@@ -657,6 +657,10 @@ angular
         }
       };
 
+      $scope.removeSelected = function () {
+        graph.removeSelected();
+      };
+
       $scope.selectAll = function () {
         checkGraph()
           .then(function () {
@@ -673,9 +677,11 @@ angular
         showToolBox();
       };  
 
+      /* redundant: patched via $scope - @mgesteiro
       function removeSelected() {
-        project.removeSelected();
+        project.removeSelected();  // <- this is justa a wrapper of graph.removeSelected()
       }
+      */
 
       $scope.fitContent = function () {
         graph.fitContent();
@@ -1583,6 +1589,7 @@ angular
       shortcuts.method("copySelected", $scope.copySelected);
       shortcuts.method("pasteAndCloneSelected", $scope.pasteAndCloneSelected);
       shortcuts.method("pasteSelected", $scope.pasteSelected);
+      shortcuts.method("removeSelected", $scope.removeSelected);
       shortcuts.method("selectAll", $scope.selectAll);
       shortcuts.method("fitContent", $scope.fitContent);
 
@@ -1603,10 +1610,10 @@ angular
       // -- Show Floating toolbox
       shortcuts.method("showToolBox", $scope.showToolBox);
 
-      shortcuts.method("removeSelected", removeSelected);
+      //shortcuts.method("removeSelected", removeSelected);  // moved alongside other EDIT menu options
       shortcuts.method("back", function () {
         if (graph.isEnabled()) {
-          removeSelected();
+          graph.removeSelected();
         } else {
           console.log("--------> BACK!!!!");
           //-- When inside a block in non-edit mode

--- a/app/views/menu.html
+++ b/app/views/menu.html
@@ -281,6 +281,15 @@
                   </span></a>
               </li>
 
+              <!-- Edit/Delete -->
+              <li>
+                <a href ng-click="removeSelected()">
+                  {{ 'Delete' | translate }}
+                  <span class="shortcut">
+                    {{ 'removeSelected' | shortcut }}
+                  </span></a>
+              </li>
+
               <!-- Edit/Select all -->
               <li>
                 <a href ng-click="selectAll()">


### PR DESCRIPTION
When I installed **icestudio** for the first time (v0.10-rc1), the delete key didn't work in my setup (Mac/OSX).

This led me to discover that there was **NO WAY** to delete a block, i.e., there was a hard-coded UI dependency: the only way to perform the **delete action** was a keyboard-shortcut.

This PR is just a fix to eliminate that dependency: there is now a menu option attached to the **delete action** besides the keyboard shortcut.