### PR TITLE
Some translation work: fixes and languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ ice-build/
 
 # WebStorm IDE project folder
 .idea
+# From update_translations.sh
+app/resources/locale/statistics.txt

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ ice-build/
 .idea
 # From update_translations.sh
 app/resources/locale/statistics.txt
+# From table_translations.sh
+app/resources/locale/readme_table.txt

--- a/README.md
+++ b/README.md
@@ -86,34 +86,35 @@ Icestudio is a design tool focused on new comers to the FPGA world
 
 ### Languages
 
-|  Language  | Translated strings                       |
-|:----------:|:----------------------------------------:|
-| English (en)   | ![Progress](http://progress-bar.dev/100) |
-| Spanish (en_ES)   | ![Progress](http://progress-bar.dev/100) |
-| Japanese (ja_JP)  | ![Progress](http://progress-bar.dev/79)  |
-| French (fr_FR)    | ![Progress](http://progress-bar.dev/78) |
-| Italian (it_IT)   | ![Progress](http://progress-bar.dev/77) |
-| Taiwan (zh_TW)    | ![Progress](http://progress-bar.dev/77) |
-| Chinese (zh_CN)   | ![Progress](http://progress-bar.dev/73)  |
-| Basque (eu_ES)    | ![Progress](http://progress-bar.dev/73) |
-| German (de_DE)    | ![Progress](http://progress-bar.dev/73)  |
-| Korean  (ko_KR)   | ![Progress](http://progress-bar.dev/73) |
-| Czech (cs_CZ)     | ![Progress](http://progress-bar.dev/73) |
-| Turkish  (tr_TR)  | ![Progress](http://progress-bar.dev/73) |
-| Russian (ru_RU)   | ![Progress](http://progress-bar.dev/73)  |
-| Catalan (ca_ES)   | ![Progress](http://progress-bar.dev/68)  |
-| Greek (el_GR)     | ![Progress](http://progress-bar.dev/63)  |
-| Dutch (nl_NL)     | ![Progress](http://progress-bar.dev/63)  |
-| Galician (gl_ES)  | ![Progress](http://progress-bar.dev/63)  |
-
-
+|  Language  | Translated strings |
+|:----------:|:------------------:|
+| Spanish (es_ES) | ![Progress](http://progress-bar.dev/100) |
+| English (en) | ![Progress](http://progress-bar.dev/100) |
+| German (de_DE) | ![Progress](http://progress-bar.dev/90) |
+| Russian (ru_RU) | ![Progress](http://progress-bar.dev/78) |
+| Japanese (ja_JP) | ![Progress](http://progress-bar.dev/76) |
+| French (fr_FR) | ![Progress](http://progress-bar.dev/75) |
+| Taiwanese (zh_TW) | ![Progress](http://progress-bar.dev/74) |
+| Italian (it_IT) | ![Progress](http://progress-bar.dev/74) |
+| Chinese (zh_CN) | ![Progress](http://progress-bar.dev/71) |
+| Turkish (tr_TR) | ![Progress](http://progress-bar.dev/71) |
+| Korean (ko_KR) | ![Progress](http://progress-bar.dev/71) |
+| Basque (eu_ES) | ![Progress](http://progress-bar.dev/71) |
+| Czech (cs_CZ) | ![Progress](http://progress-bar.dev/71) |
+| Catalonian (ca_ES) | ![Progress](http://progress-bar.dev/66) |
+| Dutch (nl_NL) | ![Progress](http://progress-bar.dev/61) |
+| Galician (gl_ES) | ![Progress](http://progress-bar.dev/61) |
+| Greek (el_GR) | ![Progress](http://progress-bar.dev/61) |
 
 
 **Contribute!**
 
 Add or update the [app translations](https://github.com/FPGAwars/icestudio/tree/develop/app/resources/locale) using **[Poedit](https://poedit.net/)**.
 
-*Developer note*: use `npm run gettext` to extract the labels from the code.
+*Developer note*: 
+  * use `npm run gettext` to extract the labels from the code and update the template file (`template.pot`)
+  * use `scripts/update_translations.sh` to update current existing `*.po` language files based on the template (before editing them)
+  * use `grunt nggettext_compile` to regenerate `*.json` language files (these are what the IDE really need) to test them
 
 *Developer note*: use `export NWJS_BUILD_TYPE=sdk` after npm install to enable the chrome web console.
 

--- a/app/resources/locale/ca_ES/ca_ES.po
+++ b/app/resources/locale/ca_ES/ca_ES.po
@@ -12,15 +12,27 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: app/views/design.html:20
-msgid ": '}} {{'Unlock to edit block !"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
 msgstr ""
 
-#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr "<b>Desconnecta</b> i <b>connecta</b> la placa"
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
 msgstr "Quant a Icestudio"
 
@@ -28,11 +40,11 @@ msgstr "Quant a Icestudio"
 msgid "Acknowledgment"
 msgstr ""
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr "Afegeix"
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr "Afegeix un bloc per a iniciar"
 
@@ -44,24 +56,24 @@ msgstr "Afegeix com a bloc"
 msgid "Address format"
 msgstr "Format d'adreça"
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr "Col·leccions eliminades"
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr "Totes les col·leccions emmagatzemades es perdran. Vols continuar?"
 
-#: app/scripts/services/tools.js:1389
+#: app/scripts/services/tools.js:1500
 #, fuzzy
 msgid "At least Python 3.7 is required"
 msgstr "És necessari Python 2.7"
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr "Autor"
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr "Bàsic"
 
@@ -73,6 +85,10 @@ msgstr "Basc"
 msgid "Binary"
 msgstr "Binari"
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr ""
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -82,7 +98,7 @@ msgstr "Binari"
 msgid "Block updated"
 msgstr "Bloc actualitzat"
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr "Bloc {{name}} importat"
 
@@ -90,56 +106,52 @@ msgstr "Bloc {{name}} importat"
 msgid "Blocks"
 msgstr "Blocs"
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr "Placa"
 
-#: app/views/menu.html:367 app/views/menu.html:458
+#: app/views/menu.html:385 app/views/menu.html:476
 msgid "Board rules"
 msgstr "Regles de la placa"
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr "Regles de la placa inhabilitades"
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr "Regles de la placa habilitades"
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr "Placa {{name}} desconnectada"
 
-#: app/scripts/services/tools.js:607 app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718 app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr "Placa {{name}} no disponible"
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr "Placa {{name}} no connectada"
 
-#: app/scripts/app.js:185 app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184 app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr "Placa {{name}} seleccionada"
 
-#: app/scripts/services/tools.js:596 app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707 app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr "Bootloader no actiu"
 
-#: app/scripts/controllers/menu.js:1327 app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346 app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr "Sintetitza"
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr "Sintetitzat realitzat"
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr ""
-
-#: app/scripts/app.js:59 app/scripts/services/project.js:147
+#: app/scripts/app.js:58 app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr "Cancel·la"
 
@@ -147,16 +159,16 @@ msgstr "Cancel·la"
 msgid "Catalan"
 msgstr "Català"
 
-#: app/views/design.html:264
+#: app/views/design.html:262
 #, fuzzy
 msgid "Change Color"
 msgstr "Selecciona un color"
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr "Comprovant connexió a Internet..."
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr "Comprovant Python..."
 
@@ -169,20 +181,20 @@ msgstr "Xinès"
 msgid "Choose a color:"
 msgstr "Selecciona un color"
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr "Fes clic ací per a <b>descarregar una versió més nova</b> d'Icestudio"
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr "Fes clic aquí per <b>configurar els drivers</b>"
 
-#: app/scripts/services/drivers.js:413 app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613 app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440 app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644 app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr "Fes clic aquí per instal·lar-ho"
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr "Fes clic aquí per veure"
 
@@ -194,63 +206,63 @@ msgstr "Rellotge no permès per a busos de dades"
 msgid "Clone"
 msgstr "Clona"
 
-#: app/scripts/controllers/menu.js:565 app/views/version.html:80
+#: app/scripts/controllers/menu.js:581 app/views/version.html:80
 msgid "Close"
 msgstr "Tanca"
 
-#: app/views/design.html:324 app/views/menu.html:791
+#: app/views/design.html:314 app/views/menu.html:809
 msgid "Code"
 msgstr "Codi"
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr "Col·lecció"
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr "Informació de la col·lecció"
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr "Informació de la col·lecció {{collection}} no definida"
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr "Col·lecció {{name}} afegida"
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr "Col·lecció {{name}} no reemplaçada"
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr "Col·lecció {{name}} eliminada"
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr "Col·lecció {{name}} reemplaçada"
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr "Col·lecció {{name}} seleccionada"
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr "Col·leccions"
 
-#: app/scripts/controllers/menu.js:1229 app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249 app/views/menu.html:489
 msgid "Command output"
 msgstr "Sortida d'ordres"
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr "Fòrum de la comunitat"
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr "Configuració no completada"
 
-#: app/views/design.html:312 app/views/menu.html:783
+#: app/views/design.html:304 app/views/menu.html:801
 msgid "Constant"
 msgstr "Constant"
 
@@ -259,7 +271,7 @@ msgstr "Constant"
 msgid "Constant names"
 msgstr "Constant"
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr "Converteix"
 
@@ -267,11 +279,11 @@ msgstr "Converteix"
 msgid "Copy"
 msgstr "Copia"
 
-#: app/scripts/services/forms.js:400 app/views/design.html:137
+#: app/scripts/services/forms.js:400 app/views/design.html:136
 msgid "Coral"
 msgstr ""
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr "Crea entorn virtual..."
 
@@ -296,15 +308,15 @@ msgstr ""
 msgid "Dark Orange"
 msgstr ""
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr ""
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr ""
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr "Datasheet"
 
@@ -312,39 +324,43 @@ msgstr "Datasheet"
 msgid "Decimal"
 msgstr "Decimal"
 
-#: app/scripts/services/forms.js:394 app/views/design.html:123
+#: app/scripts/services/forms.js:394 app/views/design.html:122
 msgid "Deep Pink"
 msgstr ""
 
-#: app/scripts/services/forms.js:439 app/views/design.html:236
+#: app/scripts/services/forms.js:439 app/views/design.html:234
 msgid "Deep Sky Blue"
 msgstr ""
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr "Per defecte"
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr ""
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr "Descripció"
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr "Inhabilita"
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr "Vols tancar l'aplicació?"
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr "Vols eliminar la col·lecció {{name}}?"
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr "Vols reemplaçar-la?"
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr "Documentació"
 
@@ -352,21 +368,26 @@ msgstr "Documentació"
 msgid "Don't display"
 msgstr "No mostres"
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr "Drivers"
 
 #: app/scripts/services/drivers.js:252 app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr "Drivers inhabilitats"
 
 #: app/scripts/services/drivers.js:230 app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr "Drivers habilitats"
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+#, fuzzy
+msgid "Duplicate"
+msgstr "Etiqueta d'eixida"
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr "Ports d'E/S de la FPGA duplicats"
 
@@ -383,11 +404,11 @@ msgstr "Holandès"
 msgid "Edit"
 msgstr "Edita"
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr "Edita el nom de la col·lecció"
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr "Habilita"
 
@@ -420,15 +441,15 @@ msgstr "Introdueix els ports d'entrada"
 msgid "Enter the python path"
 msgstr "Introdueix la ruta de les col·leccions externes"
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr "Introdueix el nom del host remot usuari@host"
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr "Error: {{error}}"
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr "Errors detectats en el disseny"
 
@@ -436,7 +457,7 @@ msgstr "Errors detectats en el disseny"
 msgid "Examples"
 msgstr "Exemples"
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr "Executa {{label}} remot..."
 
@@ -444,29 +465,29 @@ msgstr "Executa {{label}} remot..."
 msgid "Export"
 msgstr "Exporta"
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395 app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr "Exporta submòdul"
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr "Col·leccions externes"
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr "Col·leccions externes actualitzades"
 
-#: app/views/menu.html:383
+#: app/views/menu.html:401
 #, fuzzy
 msgid "External plugins"
 msgstr "Col·leccions externes"
 
-#: app/scripts/controllers/menu.js:780
+#: app/scripts/controllers/menu.js:800
 #, fuzzy
 msgid "External plugins updated"
 msgstr "Col·leccions externes actualitzades"
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr "Ports d'E/S de la FPGA no definits"
 
@@ -474,7 +495,7 @@ msgstr "Ports d'E/S de la FPGA no definits"
 msgid "FPGA pin"
 msgstr "FPGA pin"
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr "Recursos de la FPGA"
 
@@ -490,18 +511,18 @@ msgstr ""
 msgid "File"
 msgstr "Fitxer"
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr ""
 "El fitxer {{file}} ja existeix en el directori del projecte. Vols reemplaçar-"
 "lo?"
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr "El fitxer {{file}} no existeix"
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr "Fitxer {{file}} importat"
 
@@ -509,7 +530,7 @@ msgstr "Fitxer {{file}} importat"
 msgid "Find"
 msgstr ""
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr "Ajusta contingut"
 
@@ -517,8 +538,8 @@ msgstr "Ajusta contingut"
 msgid "French"
 msgstr "Francès"
 
-#: app/scripts/services/forms.js:385 app/views/design.html:173
-#: app/views/design.html:98
+#: app/scripts/services/forms.js:385 app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr ""
 
@@ -530,7 +551,7 @@ msgstr "Gallec"
 msgid "German"
 msgstr "Alemany"
 
-#: app/scripts/services/forms.js:409 app/views/design.html:158
+#: app/scripts/services/forms.js:409 app/views/design.html:157
 msgid "Gold"
 msgstr ""
 
@@ -542,11 +563,11 @@ msgstr "Grec"
 msgid "Green Yellow"
 msgstr ""
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr ""
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr "Ajuda"
 
@@ -559,7 +580,7 @@ msgstr "Hexadecimal"
 msgid "Icestudio is part of"
 msgstr "Icestudio Inception"
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid ""
 "If you have blank IN/OUT pins, it's because there is no equivalent in this "
 "board"
@@ -567,27 +588,27 @@ msgstr ""
 "Si apareixen pins d'ENTRADA/SORTIDA en blanc, és perquè no hi ha equivalent "
 "en aquesta placa"
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr "Imatge"
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr "Imatge {{name}} desada"
 
-#: app/scripts/services/forms.js:388 app/views/design.html:109
+#: app/scripts/services/forms.js:388 app/views/design.html:108
 msgid "Indian Red"
 msgstr ""
 
-#: app/views/design.html:330 app/views/menu.html:795
+#: app/views/design.html:319 app/views/menu.html:813
 msgid "Information"
 msgstr "Informació"
 
-#: app/views/design.html:282 app/views/menu.html:760
+#: app/views/design.html:279 app/views/menu.html:778
 msgid "Input"
 msgstr "Entrada"
 
-#: app/views/design.html:294 app/views/menu.html:769
+#: app/views/design.html:289 app/views/menu.html:787
 msgid "Input label"
 msgstr "Etiqueta d'entrada"
 
@@ -610,23 +631,23 @@ msgstr ""
 msgid "Input ports"
 msgstr "Introdueix els ports d'entrada"
 
-#: app/views/menu.html:635
+#: app/views/menu.html:653
 #, fuzzy
 msgid "Install (Stable)"
 msgstr "Instal·la"
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
 msgstr ""
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid ""
 "Install the <b>STABLE Toolchain</b>. This operation requires Internet "
 "connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
 "allow the toolchain installation</p> <p>Do you want to continue?</p>"
 msgstr ""
 
-#: app/scripts/services/tools.js:1144
+#: app/scripts/services/tools.js:1255
 #, fuzzy
 msgid ""
 "Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
@@ -635,7 +656,7 @@ msgstr ""
 "La toolchain serà actualitzada. Aquesta operació requereix connexió a "
 "Internet. Vols continuar?"
 
-#: app/scripts/services/tools.js:1166
+#: app/scripts/services/tools.js:1277
 #, fuzzy
 msgid ""
 "Install the LATEST STABLE toolchain. It will be downloaded. This operation "
@@ -644,51 +665,51 @@ msgstr ""
 "La toolchain serà actualitzada. Aquesta operació requereix connexió a "
 "Internet. Vols continuar?"
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr "Instal·lació completada"
 
-#: app/scripts/services/tools.js:1274
+#: app/scripts/services/tools.js:1385
 #, fuzzy
 msgid "Installing"
 msgstr "Instal·la"
 
-#: app/scripts/services/drivers.js:421 app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447 app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr "És necessari connexió a Internet"
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr "Connexió de <i>Pull up</i> no vàlida: bloc ja connectat"
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr ""
 "Connexió <i>Pull up</i> no vàlida: <br>només blocs <i>Entrada</i> són "
 "permitits"
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr "Connexió de blocs no vàlida:<br><i>Pull up</i> connectada"
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr "Col·lecció {{name}} no vàlida"
 
-#: app/scripts/services/graph.js:254 app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262 app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr "Connexió no vàlida"
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr "Connexió no vàlida: {{a}} → {{b}}"
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr "Connexions d'entrada múltiple no vàlides"
 
-#: app/scripts/services/project.js:499 app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510 app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr "Format de projecte no vàlid"
 
@@ -705,7 +726,7 @@ msgstr "Espanyol"
 msgid "Korean"
 msgstr ""
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
 msgstr ""
 
@@ -714,7 +735,7 @@ msgstr ""
 msgid "Label updated"
 msgstr "Bloc actualitzat"
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr "Idioma"
 
@@ -722,15 +743,15 @@ msgstr "Idioma"
 msgid "Light"
 msgstr ""
 
-#: app/scripts/services/forms.js:448 app/views/design.html:257
+#: app/scripts/services/forms.js:448 app/views/design.html:255
 msgid "Light Gray"
 msgstr ""
 
-#: app/scripts/services/forms.js:430 app/views/design.html:215
+#: app/scripts/services/forms.js:430 app/views/design.html:213
 msgid "Light Sea Green"
 msgstr ""
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr "Carrega"
 
@@ -738,20 +759,20 @@ msgstr "Carrega"
 msgid "Local parameter"
 msgstr "Paràmetre local"
 
-#: app/views/menu.html:404
+#: app/views/menu.html:422
 #, fuzzy
 msgid "Logging enabled"
 msgstr "Drivers habilitats"
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
 msgstr ""
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr "Mida màxima del bus: 96 bits"
 
@@ -759,11 +780,11 @@ msgstr "Mida màxima del bus: 96 bits"
 msgid "Medium Violet Red"
 msgstr ""
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr ""
 
-#: app/views/design.html:318 app/views/menu.html:787
+#: app/views/design.html:309 app/views/menu.html:805
 msgid "Memory"
 msgstr "Memòria"
 
@@ -772,7 +793,7 @@ msgstr "Memòria"
 msgid "Memory blocks"
 msgstr "Introdueix els blocs de memòria"
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr "Nom"
 
@@ -780,7 +801,7 @@ msgstr "Nom"
 msgid "Name of the paired labels"
 msgstr ""
 
-#: app/scripts/services/forms.js:445 app/views/design.html:250
+#: app/scripts/services/forms.js:445 app/views/design.html:248
 msgid "Navy"
 msgstr ""
 
@@ -794,15 +815,19 @@ msgstr ""
 
 #: app/views/design.html:80
 #, fuzzy
-msgid "New Name:"
+msgid "New Name"
 msgstr "Nom"
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr ""
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr "Cap col·lecció emmagatzemada"
 
-#: app/scripts/app.js:58 app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57 app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr "D'acord"
 
@@ -810,7 +835,7 @@ msgstr "D'acord"
 msgid "Olive Drab"
 msgstr ""
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr ""
 
@@ -818,7 +843,7 @@ msgstr ""
 msgid "Open"
 msgstr "Obre"
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr "Obre SVG"
 
@@ -826,19 +851,19 @@ msgstr "Obre SVG"
 msgid "Orange Red"
 msgstr ""
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr ""
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr "El fitxer original {{file}} no existeix"
 
-#: app/views/design.html:288 app/views/menu.html:764
+#: app/views/design.html:284 app/views/menu.html:782
 msgid "Output"
 msgstr "Eixida"
 
-#: app/views/design.html:300 app/views/menu.html:773
+#: app/views/design.html:294 app/views/menu.html:791
 msgid "Output label"
 msgstr "Etiqueta d'eixida"
 
@@ -857,7 +882,7 @@ msgstr "Etiqueta d'eixida"
 msgid "Output ports"
 msgstr "Etiqueta d'eixida"
 
-#: app/views/design.html:306 app/views/menu.html:778
+#: app/views/design.html:299 app/views/menu.html:796
 msgid "Paired labels"
 msgstr ""
 
@@ -865,40 +890,44 @@ msgstr ""
 msgid "Paste"
 msgstr "Enganxa"
 
-#: app/scripts/controllers/menu.js:731 app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853 app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751 app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873 app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr "La ruta {{path}} no existeix"
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr "Per favor executa: {{cmd}}"
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr "Preferències"
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr ""
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr "Informació del projecte"
 
-#: app/scripts/controllers/menu.js:935 app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955 app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr "Informació del projecte actualitzada"
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr "Projecte {{name}} carregat"
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr "Projecte {{name}} desat"
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
 msgstr ""
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
 msgstr ""
 
@@ -906,11 +935,7 @@ msgstr ""
 msgid "Quit"
 msgstr "Tanca"
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr "Només lectura"
-
-#: app/scripts/services/forms.js:391 app/views/design.html:116
+#: app/scripts/services/forms.js:391 app/views/design.html:115
 #, fuzzy
 msgid "Red"
 msgstr "Refés"
@@ -923,27 +948,27 @@ msgstr "Refés"
 msgid "Release History WIKI"
 msgstr ""
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr "Recarrega"
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr "Host remot {{name}} no connectat"
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr "Nom del host remot"
 
-#: app/views/menu.html:647 app/views/menu.html:722
+#: app/views/menu.html:665 app/views/menu.html:740
 msgid "Remove"
 msgstr "Suprimeix"
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr "Suprimeix tot"
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
 msgstr ""
 
@@ -951,11 +976,11 @@ msgstr ""
 msgid "Replace One"
 msgstr ""
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr "Reseteja SVG"
 
-#: app/scripts/services/forms.js:442 app/views/design.html:243
+#: app/scripts/services/forms.js:442 app/views/design.html:241
 msgid "Royal Blue"
 msgstr ""
 
@@ -967,7 +992,7 @@ msgstr "Rus"
 msgid "Save"
 msgstr "Desa"
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr "Desa SVG"
 
@@ -979,11 +1004,11 @@ msgstr "Anomena i desa"
 msgid "Save submodule"
 msgstr "Desa submòdul"
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr "Selecciona"
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr "Selecciona tot"
 
@@ -999,11 +1024,11 @@ msgstr "Mostra rellotge"
 msgid "Slate Blue"
 msgstr ""
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr ""
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr "Codi font"
 
@@ -1015,31 +1040,31 @@ msgstr "Espanyol"
 msgid "Spring Green"
 msgstr ""
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr "Inicia sintetitzat"
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr "Inicia càrrega"
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr "Inicia verificació"
 
-#: app/scripts/services/forms.js:436 app/views/design.html:229
+#: app/scripts/services/forms.js:436 app/views/design.html:227
 msgid "Steel Blue"
 msgstr ""
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr "Sincronitzant fitxers remots ..."
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
 msgstr ""
 
@@ -1055,11 +1080,11 @@ msgstr "Testbench"
 msgid "Thank you very much!"
 msgstr ""
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr "La col·leccio {{name}} ja existeix."
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
@@ -1067,19 +1092,19 @@ msgstr ""
 "La configuració actual d'E/S de la FPGA es perdrà. Vols canviar a la placa "
 "{{name}}?"
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr "La toolchain serà eliminada. Vols continuar?"
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr "Hi ha una nova versió nightly disponible"
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr "Hi ha una nova versió estable disponible"
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
@@ -1087,7 +1112,7 @@ msgstr ""
 "Aquesta operació d'importació requereix un directori de projecte. Has de "
 "desar el projecte actual. Vols continuar?"
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr "Aquest projecte està dissenyat per a la placa {{name}}"
 
@@ -1097,7 +1122,7 @@ msgid ""
 "              done by an emerging team from"
 msgstr ""
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 msgid ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
 "mode\", lock the keylock to do it."
@@ -1105,14 +1130,14 @@ msgstr ""
 "Per entrar al \"mode d'edició\" del bloc més profund, has de finalitzar el "
 "\"mode d'edició\" actual, bloquejant el cadenat."
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr "Per navegar pel disseny, cal tancar el \"mode d'edició\"."
 
 #: app/scripts/controllers/menu.js:349
 #, fuzzy
 msgid ""
-"To save your design you need to lock the keylock and               go to top "
+"To save your design you need to lock the padlock and               go to top "
 "level design.<br/><br/>If you want to export               this submodule to "
 "a file, execute \"Save as\" command to do it."
 msgstr ""
@@ -1120,33 +1145,33 @@ msgstr ""
 "nivell superior.<br/><br/>Si vols exportar aquest submòdul a un fitxer, "
 "executeu l'ordre «Anomena i desa» per fer-ho."
 
-#: app/views/menu.html:320
+#: app/views/menu.html:338
 #, fuzzy
 msgid "Toolbox"
 msgstr "Eines"
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr "Toolchain"
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr "Toolchain instal·lada"
 
-#: app/scripts/services/drivers.js:594 app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191 app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625 app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300 app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr "La toolchain no està instal·lada"
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr "Toolchain eliminada"
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr "La versió de la toolchain no coincideix"
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr "Eines"
 
@@ -1154,11 +1179,11 @@ msgstr "Eines"
 msgid "Turkish"
 msgstr ""
 
-#: app/scripts/services/forms.js:433 app/views/design.html:222
+#: app/scripts/services/forms.js:433 app/views/design.html:220
 msgid "Turquoise"
 msgstr ""
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 msgid "UI theme"
 msgstr ""
 
@@ -1166,57 +1191,57 @@ msgstr ""
 msgid "Undo"
 msgstr "Desfés"
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr "Placa desconeguda"
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr "Format de projecte no admès {{version}}"
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr "Sense títol"
 
-#: app/views/menu.html:639
+#: app/views/menu.html:657
 #, fuzzy
 msgid "Update (Latest stable)"
 msgstr "Actualitza el nom del bloc"
 
-#: app/scripts/controllers/menu.js:1354 app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371 app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr "Carrega"
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr "Càrrega realitzada"
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr "Verificació realitzada"
 
-#: app/views/design.html:510 app/views/menu.html:599
+#: app/views/design.html:498 app/views/menu.html:617
 msgid "Verify"
 msgstr "Verifica"
 
-#: app/scripts/services/utils.js:641 app/views/menu.html:832
+#: app/scripts/services/utils.js:636 app/views/menu.html:850
 msgid "Version"
 msgstr "Versió"
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr "Notes de la versió"
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr "Visualitza"
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr "Visualitza llicència"
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr "Advertiments detectats en el disseny"
 
@@ -1235,63 +1260,72 @@ msgstr "Format de bloc incorrecte: {{type}}"
 msgid "Wrong block name {{name}}"
 msgstr "Nom de bloc incorrecte"
 
-#: app/scripts/controllers/menu.js:1907
+#: app/scripts/controllers/menu.js:1925
 #, fuzzy
 msgid "Wrong new name!"
 msgstr "Nom del port incorrecte"
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr "Format de projecte incorrecte: {{name}}"
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr "Nom del host remot incorrecte {{name}}"
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
 msgstr ""
 
-#: app/scripts/services/forms.js:412 app/views/design.html:166
+#: app/scripts/services/forms.js:412 app/views/design.html:164
 msgid "Yellow"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:394
+#: app/scripts/controllers/menu.js:409
 #, fuzzy
 msgid ""
-"You are editing a submodule, if you save it, you save only               the "
-"submodule (in this situation \"save as\" works like               \"export "
-"module\"), Do you like to continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 msgstr ""
 "Estàs editant un submòdul, si el deses, només es desarà el submòdul (en "
 "aquesta situació \"anomena i desa\" funciona com \"exporta mòdul\"), Vols "
 "continuar?"
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+msgstr ""
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr "Pots carregar-ho com està o convertir-ho per a la placa {{name}}."
 
-#: app/scripts/controllers/menu.js:1328
+#: app/scripts/controllers/menu.js:1347
+#, fuzzy
 msgid ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 msgstr ""
 "Només pots construir en el disseny de nivell superior. Dins dels submòduls "
 "només pots <strong>Verificar</strong>"
 
-#: app/scripts/controllers/menu.js:1355
+#: app/scripts/controllers/menu.js:1372
+#, fuzzy
 msgid ""
-"You can only upload  your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
 msgstr ""
-"Només pots carregar el teu disseny en el disseny de nivell superior. Dins "
-"dels submòduls només pots <strong>Verificar</strong>"
+"Només pots construir en el disseny de nivell superior. Dins dels submòduls "
+"només pots <strong>Verificar</strong>"
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr "Els teus canvis es perdran si no els deses"
 
@@ -1299,25 +1333,35 @@ msgstr "Els teus canvis es perdran si no els deses"
 msgid "back"
 msgstr "enrere"
 
-#: app/scripts/services/drivers.js:412 app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439 app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr "És necessari {{app}}."
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr "Full de dades de {{board}} no definit"
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr "{{board}} pinout no definit"
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr "Regles de {{board}} no definides"
 
-#: app/scripts/controllers/menu.js:483 app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499 app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr "{{name}} exportat"
+
+#~ msgid "Read only"
+#~ msgstr "Només lectura"
+
+#~ msgid ""
+#~ "You can only upload  your design at top-level design. Inside submodules "
+#~ "you only can <strong>Verify</strong>"
+#~ msgstr ""
+#~ "Només pots carregar el teu disseny en el disseny de nivell superior. Dins "
+#~ "dels submòduls només pots <strong>Verificar</strong>"
 
 #~ msgid "Choose a color"
 #~ msgstr "Selecciona un color"

--- a/app/resources/locale/cs_CZ/cs_CZ.po
+++ b/app/resources/locale/cs_CZ/cs_CZ.po
@@ -12,15 +12,27 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: app/views/design.html:20
-msgid ": '}} {{'Unlock to edit block !"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
 msgstr ""
 
-#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr "<b>Odpojit</b> a <b>znovu připojit</b> desku"
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
 msgstr "O Icestudiu"
 
@@ -28,11 +40,11 @@ msgstr "O Icestudiu"
 msgid "Acknowledgment"
 msgstr ""
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr "Přidat"
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr "Přidat blok na začátek"
 
@@ -44,24 +56,24 @@ msgstr "Přidat jako blok"
 msgid "Address format"
 msgstr "Formát adresy"
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr "Všechny kolekce odstraněny"
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr "Všechny uložené kolekce budou zahozeny. Přejete si pokračovat?"
 
-#: app/scripts/services/tools.js:1389
+#: app/scripts/services/tools.js:1500
 #, fuzzy
 msgid "At least Python 3.7 is required"
 msgstr "Je potřeba Python verze 2.7"
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr "Autor"
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr "Základní prvky"
 
@@ -73,6 +85,10 @@ msgstr "Baskičtina"
 msgid "Binary"
 msgstr "Binární"
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr ""
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -82,7 +98,7 @@ msgstr "Binární"
 msgid "Block updated"
 msgstr "Blok aktualizován"
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr "Blok {{name}} importován"
 
@@ -90,56 +106,52 @@ msgstr "Blok {{name}} importován"
 msgid "Blocks"
 msgstr "Bloky"
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr "Deska"
 
-#: app/views/menu.html:367 app/views/menu.html:458
+#: app/views/menu.html:385 app/views/menu.html:476
 msgid "Board rules"
 msgstr "Pravidla desky"
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr "Pravidla desky zakázána"
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr "Pravidla desky povolena"
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr "Deska {{name}} odpojena"
 
-#: app/scripts/services/tools.js:607 app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718 app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr "Deska {{name}} není dostupná"
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr "Deska {{name}} není připojena"
 
-#: app/scripts/app.js:185 app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184 app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr "Deska {{name}} vybrána"
 
-#: app/scripts/services/tools.js:596 app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707 app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr "Zavaděč není aktivní"
 
-#: app/scripts/controllers/menu.js:1327 app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346 app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr "Sestavení"
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr "Sestavení hotovo"
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr ""
-
-#: app/scripts/app.js:59 app/scripts/services/project.js:147
+#: app/scripts/app.js:58 app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr "Zrušit"
 
@@ -147,16 +159,16 @@ msgstr "Zrušit"
 msgid "Catalan"
 msgstr "Katalánština"
 
-#: app/views/design.html:264
+#: app/views/design.html:262
 #, fuzzy
 msgid "Change Color"
 msgstr "Zvolte barvu"
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr "Kontrola připojení na internet..."
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr "Kontrola Pythonu..."
 
@@ -169,20 +181,20 @@ msgstr "Čínština"
 msgid "Choose a color:"
 msgstr "Zvolte barvu"
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr "Klikněte zde <b>ke stažení novější verze</b> Icestudia"
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr "Klikněte zde <b>pro instalování ovladačů</b>"
 
-#: app/scripts/services/drivers.js:413 app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613 app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440 app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644 app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr "Pro instalaci klikněte zde"
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr "Pro zobrazení klikněte zde"
 
@@ -194,63 +206,63 @@ msgstr "Hodiny nejsou povoleny pro datové sběrnice"
 msgid "Clone"
 msgstr "Klonovat"
 
-#: app/scripts/controllers/menu.js:565 app/views/version.html:80
+#: app/scripts/controllers/menu.js:581 app/views/version.html:80
 msgid "Close"
 msgstr "Zavřít"
 
-#: app/views/design.html:324 app/views/menu.html:791
+#: app/views/design.html:314 app/views/menu.html:809
 msgid "Code"
 msgstr "Kód"
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr "Kolekce"
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr "Informace o kolekci"
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr "Informace o kolekci {{collection}} nejsou definovány"
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr "Kolekce {{name}} přidána"
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr "Kolekce {{name}} nenahrazena"
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr "Kolekce {{name}} odstraněna"
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr "Kolekce {{name}} nahrazena"
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr "Kolekce {{name}} vybrána"
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr "Kolekce"
 
-#: app/scripts/controllers/menu.js:1229 app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249 app/views/menu.html:489
 msgid "Command output"
 msgstr "Výstup"
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr "Komunitní fórum"
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr "Konfigurace není kompletní"
 
-#: app/views/design.html:312 app/views/menu.html:783
+#: app/views/design.html:304 app/views/menu.html:801
 msgid "Constant"
 msgstr "Konstanta"
 
@@ -259,7 +271,7 @@ msgstr "Konstanta"
 msgid "Constant names"
 msgstr "Konstanta"
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr "Převést"
 
@@ -267,11 +279,11 @@ msgstr "Převést"
 msgid "Copy"
 msgstr "Kopírovat"
 
-#: app/scripts/services/forms.js:400 app/views/design.html:137
+#: app/scripts/services/forms.js:400 app/views/design.html:136
 msgid "Coral"
 msgstr "Korálový"
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr "Vytvoření virtuálního prostředí..."
 
@@ -298,15 +310,15 @@ msgstr "Tmavě zelená"
 msgid "Dark Orange"
 msgstr "Tmavě oranžová"
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr "Tmavě zelená"
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr "Tmavě oranžová"
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr "Datový list"
 
@@ -314,41 +326,45 @@ msgstr "Datový list"
 msgid "Decimal"
 msgstr "Desítkové"
 
-#: app/scripts/services/forms.js:394 app/views/design.html:123
+#: app/scripts/services/forms.js:394 app/views/design.html:122
 #, fuzzy
 msgid "Deep Pink"
 msgstr "Tmavě růžová"
 
-#: app/scripts/services/forms.js:439 app/views/design.html:236
+#: app/scripts/services/forms.js:439 app/views/design.html:234
 #, fuzzy
 msgid "Deep Sky Blue"
 msgstr "Tmavě modrá"
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr "Výchozí"
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr ""
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr "Popis"
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr "Zakázat"
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr "Chcete zavřít aplikaci?"
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr "Chcete odstranit kolekci {{name}}?"
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr "Přejete si to nahradit?"
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr "Dokumentace"
 
@@ -356,21 +372,26 @@ msgstr "Dokumentace"
 msgid "Don't display"
 msgstr "Nezobrazovat"
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr "Ovladače"
 
 #: app/scripts/services/drivers.js:252 app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr "Ovladače zakázány"
 
 #: app/scripts/services/drivers.js:230 app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr "Ovladače povoleny"
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+#, fuzzy
+msgid "Duplicate"
+msgstr "Popisek výstupu"
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr "Duplikované FPGA vstupně výstupní porty"
 
@@ -387,11 +408,11 @@ msgstr "Holandština"
 msgid "Edit"
 msgstr "Upravit"
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr "Upravit název kolekce"
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr "Povolit"
 
@@ -424,15 +445,15 @@ msgstr "Zadejte vstupní porty"
 msgid "Enter the python path"
 msgstr "Zadejte cestu k externím kolekcím"
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr "Zadejte vzdáleného hostitele uživatel@hostitel"
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr "Chyba: {{error}}"
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr "V návrhu byly zjištěny chyby"
 
@@ -440,7 +461,7 @@ msgstr "V návrhu byly zjištěny chyby"
 msgid "Examples"
 msgstr "Příklady"
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr "Spouštění vzdáleně {{label}} ..."
 
@@ -448,29 +469,29 @@ msgstr "Spouštění vzdáleně {{label}} ..."
 msgid "Export"
 msgstr "Exportovat"
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395 app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr "Exportovat submodul"
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr "Externí kolekce"
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr "Externí kolekce aktualizována"
 
-#: app/views/menu.html:383
+#: app/views/menu.html:401
 #, fuzzy
 msgid "External plugins"
 msgstr "Externí kolekce"
 
-#: app/scripts/controllers/menu.js:780
+#: app/scripts/controllers/menu.js:800
 #, fuzzy
 msgid "External plugins updated"
 msgstr "Externí kolekce aktualizována"
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr "FPGA vstupně/výstupní porty nejsou definovány"
 
@@ -478,7 +499,7 @@ msgstr "FPGA vstupně/výstupní porty nejsou definovány"
 msgid "FPGA pin"
 msgstr "FPGA vývod"
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr "FPGA prostředky"
 
@@ -494,16 +515,16 @@ msgstr ""
 msgid "File"
 msgstr "Soubor"
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr "Soubor {{file}} již existuje v projektu. Přejete si ho nahradit?"
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr "Soubor {{file}} neexistuje"
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr "Soubor {{file}} importován"
 
@@ -511,7 +532,7 @@ msgstr "Soubor {{file}} importován"
 msgid "Find"
 msgstr ""
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr "Přizpůsbit obsah"
 
@@ -519,8 +540,8 @@ msgstr "Přizpůsbit obsah"
 msgid "French"
 msgstr "Francouzština"
 
-#: app/scripts/services/forms.js:385 app/views/design.html:173
-#: app/views/design.html:98
+#: app/scripts/services/forms.js:385 app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr "Fuchsie"
 
@@ -532,7 +553,7 @@ msgstr "Galicijština"
 msgid "German"
 msgstr "Němčina"
 
-#: app/scripts/services/forms.js:409 app/views/design.html:158
+#: app/scripts/services/forms.js:409 app/views/design.html:157
 msgid "Gold"
 msgstr "Zlatá"
 
@@ -545,11 +566,11 @@ msgstr "Řečtina"
 msgid "Green Yellow"
 msgstr "Žluto zelená"
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr "Žluto zelená"
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr "Nápověda"
 
@@ -562,7 +583,7 @@ msgstr "Šestnáctkové"
 msgid "Icestudio is part of"
 msgstr "Vznik Icestudia"
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid ""
 "If you have blank IN/OUT pins, it's because there is no equivalent in this "
 "board"
@@ -570,28 +591,28 @@ msgstr ""
 "Pokud máte nepřiřazené vstupně/výstupní piny, je to proto, že na desce není "
 "žádný vhodný ekvivalent"
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr "Obraz"
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr "Obraz {{name}} uložen"
 
-#: app/scripts/services/forms.js:388 app/views/design.html:109
+#: app/scripts/services/forms.js:388 app/views/design.html:108
 #, fuzzy
 msgid "Indian Red"
 msgstr "Indická červená"
 
-#: app/views/design.html:330 app/views/menu.html:795
+#: app/views/design.html:319 app/views/menu.html:813
 msgid "Information"
 msgstr "Informace"
 
-#: app/views/design.html:282 app/views/menu.html:760
+#: app/views/design.html:279 app/views/menu.html:778
 msgid "Input"
 msgstr "Vstup"
 
-#: app/views/design.html:294 app/views/menu.html:769
+#: app/views/design.html:289 app/views/menu.html:787
 msgid "Input label"
 msgstr "Popisek vstupu"
 
@@ -614,23 +635,23 @@ msgstr ""
 msgid "Input ports"
 msgstr "Zadejte vstupní porty"
 
-#: app/views/menu.html:635
+#: app/views/menu.html:653
 #, fuzzy
 msgid "Install (Stable)"
 msgstr "Instalovat"
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
 msgstr ""
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid ""
 "Install the <b>STABLE Toolchain</b>. This operation requires Internet "
 "connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
 "allow the toolchain installation</p> <p>Do you want to continue?</p>"
 msgstr ""
 
-#: app/scripts/services/tools.js:1144
+#: app/scripts/services/tools.js:1255
 #, fuzzy
 msgid ""
 "Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
@@ -639,7 +660,7 @@ msgstr ""
 "Nástroj bude aktualizován. Tato operace vyžaduje připojení na internet. "
 "Přejete si pokračovat?"
 
-#: app/scripts/services/tools.js:1166
+#: app/scripts/services/tools.js:1277
 #, fuzzy
 msgid ""
 "Install the LATEST STABLE toolchain. It will be downloaded. This operation "
@@ -648,51 +669,51 @@ msgstr ""
 "Nástroj bude aktualizován. Tato operace vyžaduje připojení na internet. "
 "Přejete si pokračovat?"
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr "Instalace dokončena"
 
-#: app/scripts/services/tools.js:1274
+#: app/scripts/services/tools.js:1385
 #, fuzzy
 msgid "Installing"
 msgstr "Instalovat"
 
-#: app/scripts/services/drivers.js:421 app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447 app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr "Potřeba připojení na internet"
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr "Neplatné připojení <i>Pull-upu</i>:<br>blok je již připojen"
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr ""
 "Neplatné připojení <i>Pull-upu</i>:<br>to je povoleno pouze pro <i>Vstupní</"
 "i> bloky"
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr "Neplatné zapojení bloku:<br><i>Pull-up</i>je již připojen"
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr "Neplatná kolekce {{name}}"
 
-#: app/scripts/services/graph.js:254 app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262 app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr "Neplatné spojení"
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr "Neplatné spojení: {{a}} → {{b}}"
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr "Neplatné vícenásobná vstupní připojení"
 
-#: app/scripts/services/project.js:499 app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510 app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr "Neplatný formát projektu"
 
@@ -709,7 +730,7 @@ msgstr "Španělština"
 msgid "Korean"
 msgstr ""
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
 msgstr ""
 
@@ -718,7 +739,7 @@ msgstr ""
 msgid "Label updated"
 msgstr "Blok aktualizován"
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr "Jazyk"
 
@@ -726,17 +747,17 @@ msgstr "Jazyk"
 msgid "Light"
 msgstr ""
 
-#: app/scripts/services/forms.js:448 app/views/design.html:257
+#: app/scripts/services/forms.js:448 app/views/design.html:255
 #, fuzzy
 msgid "Light Gray"
 msgstr "Světle mořská zelená"
 
-#: app/scripts/services/forms.js:430 app/views/design.html:215
+#: app/scripts/services/forms.js:430 app/views/design.html:213
 #, fuzzy
 msgid "Light Sea Green"
 msgstr "Světle mořská zelená"
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr "Nahrát"
 
@@ -744,20 +765,20 @@ msgstr "Nahrát"
 msgid "Local parameter"
 msgstr "Lokální parametr"
 
-#: app/views/menu.html:404
+#: app/views/menu.html:422
 #, fuzzy
 msgid "Logging enabled"
 msgstr "Ovladače povoleny"
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
 msgstr ""
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr "Maximální šířka sběrnice: 96 bitů"
 
@@ -766,11 +787,11 @@ msgstr "Maximální šířka sběrnice: 96 bitů"
 msgid "Medium Violet Red"
 msgstr "Středně fialově červená"
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr "Středně fialově červená"
 
-#: app/views/design.html:318 app/views/menu.html:787
+#: app/views/design.html:309 app/views/menu.html:805
 msgid "Memory"
 msgstr "Paměť"
 
@@ -779,7 +800,7 @@ msgstr "Paměť"
 msgid "Memory blocks"
 msgstr "Zadejte paměťové bloky"
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr "Jméno"
 
@@ -787,7 +808,7 @@ msgstr "Jméno"
 msgid "Name of the paired labels"
 msgstr ""
 
-#: app/scripts/services/forms.js:445 app/views/design.html:250
+#: app/scripts/services/forms.js:445 app/views/design.html:248
 msgid "Navy"
 msgstr "Námořnická"
 
@@ -801,15 +822,19 @@ msgstr ""
 
 #: app/views/design.html:80
 #, fuzzy
-msgid "New Name:"
+msgid "New Name"
 msgstr "Jméno"
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr ""
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr "Žádné kolekce neuloženy"
 
-#: app/scripts/app.js:58 app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57 app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr "Budiž"
 
@@ -818,7 +843,7 @@ msgstr "Budiž"
 msgid "Olive Drab"
 msgstr "Olivová"
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr "Olivová"
 
@@ -826,7 +851,7 @@ msgstr "Olivová"
 msgid "Open"
 msgstr "Otevřít"
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr "Otevřít SVG"
 
@@ -835,19 +860,19 @@ msgstr "Otevřít SVG"
 msgid "Orange Red"
 msgstr "Oranžovo červená"
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr "Oranžovo červená"
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr "Původní soubor {{file}} neexistuje"
 
-#: app/views/design.html:288 app/views/menu.html:764
+#: app/views/design.html:284 app/views/menu.html:782
 msgid "Output"
 msgstr "Výstup"
 
-#: app/views/design.html:300 app/views/menu.html:773
+#: app/views/design.html:294 app/views/menu.html:791
 msgid "Output label"
 msgstr "Popisek výstupu"
 
@@ -866,7 +891,7 @@ msgstr "Popisek výstupu"
 msgid "Output ports"
 msgstr "Popisek výstupu"
 
-#: app/views/design.html:306 app/views/menu.html:778
+#: app/views/design.html:299 app/views/menu.html:796
 msgid "Paired labels"
 msgstr ""
 
@@ -874,40 +899,44 @@ msgstr ""
 msgid "Paste"
 msgstr "Vložit"
 
-#: app/scripts/controllers/menu.js:731 app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853 app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751 app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873 app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr "Cesta {{path}} neexistuje"
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr "Prosím spusťte: {{cmd}}"
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr "Předvolby"
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr ""
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr "Informace o projektu"
 
-#: app/scripts/controllers/menu.js:935 app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955 app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr "Informace o projektu aktualizovány"
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr "Projekt {{name}} nahrán"
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr "Projekt {{name}} uložen"
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
 msgstr ""
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
 msgstr ""
 
@@ -915,11 +944,7 @@ msgstr ""
 msgid "Quit"
 msgstr "Ukončit"
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr "Pouze pro čtení"
-
-#: app/scripts/services/forms.js:391 app/views/design.html:116
+#: app/scripts/services/forms.js:391 app/views/design.html:115
 msgid "Red"
 msgstr "Červená"
 
@@ -931,27 +956,27 @@ msgstr "Znovu"
 msgid "Release History WIKI"
 msgstr ""
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr "Znovu nahrát"
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr "Vzdálený hostitel {{name}} není připojen"
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr "Jméno vzdáleného hostitele"
 
-#: app/views/menu.html:647 app/views/menu.html:722
+#: app/views/menu.html:665 app/views/menu.html:740
 msgid "Remove"
 msgstr "Odebrat"
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr "Odebrat vše"
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
 msgstr ""
 
@@ -959,11 +984,11 @@ msgstr ""
 msgid "Replace One"
 msgstr ""
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr "Obnovit SVG"
 
-#: app/scripts/services/forms.js:442 app/views/design.html:243
+#: app/scripts/services/forms.js:442 app/views/design.html:241
 #, fuzzy
 msgid "Royal Blue"
 msgstr "Pruská modř"
@@ -976,7 +1001,7 @@ msgstr "Ruština"
 msgid "Save"
 msgstr "Uložit"
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr "Uložit SVG"
 
@@ -988,11 +1013,11 @@ msgstr "Uložit jako"
 msgid "Save submodule"
 msgstr "Uložit submodul"
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr "Vybrat"
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr "Vybrat vše"
 
@@ -1009,11 +1034,11 @@ msgstr "Zobrazit hodiny"
 msgid "Slate Blue"
 msgstr "Břidlicově modrá"
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr "Břidlicově modrá"
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr "Zdrojový kód"
 
@@ -1026,32 +1051,32 @@ msgstr "Španělština"
 msgid "Spring Green"
 msgstr "Jarní zelená"
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr "Jarní zelená"
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr "Začínám překlad"
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr "Začínám nahrávat"
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr "Začínám kontrolovat"
 
-#: app/scripts/services/forms.js:436 app/views/design.html:229
+#: app/scripts/services/forms.js:436 app/views/design.html:227
 #, fuzzy
 msgid "Steel Blue"
 msgstr "Ocelová modř"
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr "Synchronizace vzdálených souborů..."
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
 msgstr ""
 
@@ -1067,11 +1092,11 @@ msgstr "Testbench"
 msgid "Thank you very much!"
 msgstr ""
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr "Kolekce {{name}} již existuje."
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
@@ -1079,19 +1104,19 @@ msgstr ""
 "Současná konfigurace FPGA vstupu/výstupu bude ztracena. Přejete si změnit na "
 "desku {{name}}?"
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr "Nástroj bude odstraněn. Přejete si pokračovat?"
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr "Nové noční sestavení je k dispozici"
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr "Nová stabilní verze k dispozici"
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
@@ -1099,7 +1124,7 @@ msgstr ""
 "Operace importu vyžaduje projektovou cestu. Potřebujete uložit současný "
 "projekt. Přejete si pokračovat?"
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr "Tento projekt je navržen pro desku {{name}}."
 
@@ -1109,7 +1134,7 @@ msgid ""
 "              done by an emerging team from"
 msgstr ""
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 msgid ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
 "mode\", lock the keylock to do it."
@@ -1117,14 +1142,14 @@ msgstr ""
 "Ke vstupu do úpravy vnitřního bloku potřebujete dokončit současnou úpravu, "
 "uzamkněte zámek."
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr "Pro procházení návrhu musíte uzavřít režim úprav."
 
 #: app/scripts/controllers/menu.js:349
 #, fuzzy
 msgid ""
-"To save your design you need to lock the keylock and               go to top "
+"To save your design you need to lock the padlock and               go to top "
 "level design.<br/><br/>If you want to export               this submodule to "
 "a file, execute \"Save as\" command to do it."
 msgstr ""
@@ -1132,33 +1157,33 @@ msgstr ""
 "návrhu.<br/></br>Pokud chcete exportovat tento submodul do souboru, použijte "
 "\"Uložit jako\"."
 
-#: app/views/menu.html:320
+#: app/views/menu.html:338
 #, fuzzy
 msgid "Toolbox"
 msgstr "Nástroje"
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr "Nástroj"
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr "Nástroj nainstalován"
 
-#: app/scripts/services/drivers.js:594 app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191 app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625 app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300 app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr "Nástroj nenainstalován"
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr "Nástroj odstraněn"
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr "Verze nástroje nesouhlasí"
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr "Nástroje"
 
@@ -1166,11 +1191,11 @@ msgstr "Nástroje"
 msgid "Turkish"
 msgstr ""
 
-#: app/scripts/services/forms.js:433 app/views/design.html:222
+#: app/scripts/services/forms.js:433 app/views/design.html:220
 msgid "Turquoise"
 msgstr "Tyrkysová"
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 msgid "UI theme"
 msgstr ""
 
@@ -1178,57 +1203,57 @@ msgstr ""
 msgid "Undo"
 msgstr "Zpět"
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr "Neznámá deska"
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr "Nepodporovaný formát projektu {{version}}"
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr "Nepojmenovaný"
 
-#: app/views/menu.html:639
+#: app/views/menu.html:657
 #, fuzzy
 msgid "Update (Latest stable)"
 msgstr "Aktualizovat jméno bloku"
 
-#: app/scripts/controllers/menu.js:1354 app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371 app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr "Nahrát"
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr "Nahrávání hotovo"
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr "Kontrola hotová"
 
-#: app/views/design.html:510 app/views/menu.html:599
+#: app/views/design.html:498 app/views/menu.html:617
 msgid "Verify"
 msgstr "Zkontrolovat"
 
-#: app/scripts/services/utils.js:641 app/views/menu.html:832
+#: app/scripts/services/utils.js:636 app/views/menu.html:850
 msgid "Version"
 msgstr "Verze"
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr "Poznámky k verzi"
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr "Zobrazit"
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr "Zobrazit licenci"
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr "V návrhu byla zjištěna varování"
 
@@ -1247,63 +1272,72 @@ msgstr "Špatný formát bloku: {{type}}"
 msgid "Wrong block name {{name}}"
 msgstr "Špatný název bloku {{name}}"
 
-#: app/scripts/controllers/menu.js:1907
+#: app/scripts/controllers/menu.js:1925
 #, fuzzy
 msgid "Wrong new name!"
 msgstr "Špatné jméno portu {{name}}"
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr "Špatný formát projektu: {{name}}"
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr "Špatný název vzdáleného hostitele {{name}}"
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
 msgstr ""
 
-#: app/scripts/services/forms.js:412 app/views/design.html:166
+#: app/scripts/services/forms.js:412 app/views/design.html:164
 msgid "Yellow"
 msgstr "Žlutá"
 
-#: app/scripts/controllers/menu.js:394
+#: app/scripts/controllers/menu.js:409
 #, fuzzy
 msgid ""
-"You are editing a submodule, if you save it, you save only               the "
-"submodule (in this situation \"save as\" works like               \"export "
-"module\"), Do you like to continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 msgstr ""
 "Upravujete submodul, pokud bude ukládat, uložíte pouze submodul (v této "
 "situaci \"uložit jako\" funguje jako \"exportovat modul\"), chcete "
 "pokračovat?"
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+msgstr ""
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr "Můžete nahrát tak jak je, nebo převést pro desku {{name}}."
 
-#: app/scripts/controllers/menu.js:1328
+#: app/scripts/controllers/menu.js:1347
+#, fuzzy
 msgid ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 msgstr ""
 "Sestavovat můžete pouze na nejvyšší úrovni návrhu. Uvnitř submodulů můžete "
 "pouze <strong>Verifikovat</strong>"
 
-#: app/scripts/controllers/menu.js:1355
+#: app/scripts/controllers/menu.js:1372
+#, fuzzy
 msgid ""
-"You can only upload  your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
 msgstr ""
-"Nahrávat můžete pouze na nejvyšší úrovni návrhu. Uvnitř submodulů můžete "
+"Sestavovat můžete pouze na nejvyšší úrovni návrhu. Uvnitř submodulů můžete "
 "pouze <strong>Verifikovat</strong>"
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr "Vaše změny budou ztraceny pokud je neuložíte"
 
@@ -1311,25 +1345,35 @@ msgstr "Vaše změny budou ztraceny pokud je neuložíte"
 msgid "back"
 msgstr "zpět"
 
-#: app/scripts/services/drivers.js:412 app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439 app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr "{{app}} je vyžadováno."
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr "{{board}} katalogový list není definován"
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr "{{board}} vývody nejsou definované"
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr "{{board}} pravidla nejsou definována"
 
-#: app/scripts/controllers/menu.js:483 app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499 app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr "{{name}} exportováno"
+
+#~ msgid "Read only"
+#~ msgstr "Pouze pro čtení"
+
+#~ msgid ""
+#~ "You can only upload  your design at top-level design. Inside submodules "
+#~ "you only can <strong>Verify</strong>"
+#~ msgstr ""
+#~ "Nahrávat můžete pouze na nejvyšší úrovni návrhu. Uvnitř submodulů můžete "
+#~ "pouze <strong>Verifikovat</strong>"
 
 #~ msgid "Choose a color"
 #~ msgstr "Zvolte barvu"

--- a/app/resources/locale/de_DE/de_DE.po
+++ b/app/resources/locale/de_DE/de_DE.po
@@ -12,15 +12,27 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: app/views/design.html:20
-msgid ": '}} {{'Unlock to edit block !"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
 msgstr ""
 
-#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr "<b>Trenne</b> die Platine und <b>stelle wieder eine Verbindung her</b>"
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
 msgstr "Über Icestudio"
 
@@ -28,11 +40,11 @@ msgstr "Über Icestudio"
 msgid "Acknowledgment"
 msgstr "Danksagung"
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr "Zuerst Block hinzufügen"
 
@@ -44,23 +56,23 @@ msgstr "Als Block hinzufügen"
 msgid "Address format"
 msgstr "Adressformat"
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr "Alle Sammlungen wurden entfernt"
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr "Alle gespeicherten Sammlungen werden gelöscht. Fortfahren?"
 
-#: app/scripts/services/tools.js:1389
+#: app/scripts/services/tools.js:1500
 msgid "At least Python 3.7 is required"
 msgstr "Python 2.7 wird benötigt"
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr "Autor"
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr "Basis"
 
@@ -72,6 +84,10 @@ msgstr "Baskisch"
 msgid "Binary"
 msgstr "Binär"
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr ""
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -81,7 +97,7 @@ msgstr "Binär"
 msgid "Block updated"
 msgstr "Block aktualisiert"
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr "Block {{name}} importier"
 
@@ -89,56 +105,52 @@ msgstr "Block {{name}} importier"
 msgid "Blocks"
 msgstr "Blöcke"
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr "Board"
 
-#: app/views/menu.html:367 app/views/menu.html:458
+#: app/views/menu.html:385 app/views/menu.html:476
 msgid "Board rules"
 msgstr "Board-Regeln"
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr "Board-Regeln deaktiviert"
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr "Board-Regeln aktiviert"
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr "Board {{name}} getrennt"
 
-#: app/scripts/services/tools.js:607 app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718 app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr "Board {{name}} nicht verfügbar"
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr "Board {{name}} nicht verbunden"
 
-#: app/scripts/app.js:185 app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184 app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr "Board {{name}} ausgewählt"
 
-#: app/scripts/services/tools.js:596 app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707 app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr "Bootloader inaktiv"
 
-#: app/scripts/controllers/menu.js:1327 app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346 app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr "Erstellen"
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr "Erstellen abgeschlossen"
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr "Achtung !: Änderungen werden in allen Kopien angewendet"
-
-#: app/scripts/app.js:59 app/scripts/services/project.js:147
+#: app/scripts/app.js:58 app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr "Beenden"
 
@@ -146,15 +158,15 @@ msgstr "Beenden"
 msgid "Catalan"
 msgstr "Katalanisch"
 
-#: app/views/design.html:264
+#: app/views/design.html:262
 msgid "Change Color"
 msgstr "Wähle eine Farbe"
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr "Prüfe Internetverbindung..."
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr "Prüfe Python..."
 
@@ -166,21 +178,21 @@ msgstr "Chinesisch"
 msgid "Choose a color:"
 msgstr "Wähle eine Farbe:"
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr ""
 "Klicke hier, um eine <b>neuere Version von Icestudio herunterzuladen</b>"
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr "Klicke hier, um <b>die Treiber einzurichten</b>"
 
-#: app/scripts/services/drivers.js:413 app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613 app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440 app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644 app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr "Zur Installation hier klicken"
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr "Zum Ansehen hier klicken"
 
@@ -192,63 +204,63 @@ msgstr "Clock ist für Daten-Busse nicht erlaubt"
 msgid "Clone"
 msgstr "Duplizieren"
 
-#: app/scripts/controllers/menu.js:565 app/views/version.html:80
+#: app/scripts/controllers/menu.js:581 app/views/version.html:80
 msgid "Close"
 msgstr "Schließen"
 
-#: app/views/design.html:324 app/views/menu.html:791
+#: app/views/design.html:314 app/views/menu.html:809
 msgid "Code"
 msgstr "Code"
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr "Sammlung"
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr "Sammlungs-Info"
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr "Sammlungsinfo {{collection}} nicht definiert"
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr "Sammlung {{name}} hinzugefügt"
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr "Sammlung {{name}} nicht ersetzt"
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr "Sammlung {{name}} entfernt"
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr "Sammlung {{name}} ersetzt"
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr "Sammlung {{name}} ausgewählt"
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr "Sammlungen"
 
-#: app/scripts/controllers/menu.js:1229 app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249 app/views/menu.html:489
 msgid "Command output"
 msgstr "Befehlsausgabe"
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr "Community-Forum"
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr "Konfiguration nicht abgeschlossen"
 
-#: app/views/design.html:312 app/views/menu.html:783
+#: app/views/design.html:304 app/views/menu.html:801
 msgid "Constant"
 msgstr "Konstante"
 
@@ -257,7 +269,7 @@ msgstr "Konstante"
 msgid "Constant names"
 msgstr "Konstante"
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr "Konvertieren"
 
@@ -265,11 +277,11 @@ msgstr "Konvertieren"
 msgid "Copy"
 msgstr "Kopieren"
 
-#: app/scripts/services/forms.js:400 app/views/design.html:137
+#: app/scripts/services/forms.js:400 app/views/design.html:136
 msgid "Coral"
 msgstr "Koralle"
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr "Virtualenv erstellen..."
 
@@ -295,15 +307,15 @@ msgstr "Dunkel-Grün"
 msgid "Dark Orange"
 msgstr "Dunkel-Orange"
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr "Dunkel-Grün"
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr "Dunkel-Orange"
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr "Datenblatt"
 
@@ -311,41 +323,45 @@ msgstr "Datenblatt"
 msgid "Decimal"
 msgstr "Dezimal"
 
-#: app/scripts/services/forms.js:394 app/views/design.html:123
+#: app/scripts/services/forms.js:394 app/views/design.html:122
 #, fuzzy
 msgid "Deep Pink"
 msgstr "Dunkelrosa"
 
-#: app/scripts/services/forms.js:439 app/views/design.html:236
+#: app/scripts/services/forms.js:439 app/views/design.html:234
 #, fuzzy
 msgid "Deep Sky Blue"
 msgstr "Dunkles Himmelblau"
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr "Standard"
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr ""
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr "Beschreibung"
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr "Deaktivieren"
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr "Möchtest du die Anwendung schließen?"
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr "Möchtest du die Sammlung {{name}} entfernen?"
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr "Möchtest du sie ersetzen?"
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr "Dokumentation"
 
@@ -353,21 +369,26 @@ msgstr "Dokumentation"
 msgid "Don't display"
 msgstr "Ausblenden"
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr "Treiber"
 
 #: app/scripts/services/drivers.js:252 app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr "Treiber deaktiviert"
 
 #: app/scripts/services/drivers.js:230 app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr "Treiber aktiviert"
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+#, fuzzy
+msgid "Duplicate"
+msgstr "Duplikat bei der Beschriftung:"
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr "Doppelte FPGA I/O Schnittstellen"
 
@@ -383,11 +404,11 @@ msgstr "Niederländisch"
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr "Namen der Sammlung ändern"
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr "Aktivieren"
 
@@ -415,15 +436,15 @@ msgstr "Python-Pop Pfad angeben"
 msgid "Enter the python path"
 msgstr "Python-Pfad eingeben"
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr "Gebe den Remote-Hostnamen user@host ein"
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr "Fehler: {{error}}"
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr "Fehler im Design erkannt"
 
@@ -431,7 +452,7 @@ msgstr "Fehler im Design erkannt"
 msgid "Examples"
 msgstr "Beispiele"
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr "Remote ausführen von {{label}} ..."
 
@@ -439,27 +460,27 @@ msgstr "Remote ausführen von {{label}} ..."
 msgid "Export"
 msgstr "Exportieren"
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395 app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr "Untermodul exportieren"
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr "Externe Sammlungen"
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr "Externe Sammlungen aktualisiert"
 
-#: app/views/menu.html:383
+#: app/views/menu.html:401
 msgid "External plugins"
 msgstr "Externe Erweiterungen"
 
-#: app/scripts/controllers/menu.js:780
+#: app/scripts/controllers/menu.js:800
 msgid "External plugins updated"
 msgstr "Externe Erweiterungen aktualisiert"
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr "FPGA I/O Anschlüsse nicht definiert"
 
@@ -467,7 +488,7 @@ msgstr "FPGA I/O Anschlüsse nicht definiert"
 msgid "FPGA pin"
 msgstr "FPGA Pin"
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr "FPGA Ressourcen"
 
@@ -483,16 +504,16 @@ msgstr "FPGAwars Community."
 msgid "File"
 msgstr "Datei"
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr "Die Datei {{file}} existiert bereits im Projektpfad. Ersetzen?"
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr "Datei {{file}} existiert nicht"
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr "Datei {{file}} importiert"
 
@@ -500,7 +521,7 @@ msgstr "Datei {{file}} importiert"
 msgid "Find"
 msgstr "Suche"
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr "Inhalt anpassen"
 
@@ -508,8 +529,8 @@ msgstr "Inhalt anpassen"
 msgid "French"
 msgstr "Französisch"
 
-#: app/scripts/services/forms.js:385 app/views/design.html:173
-#: app/views/design.html:98
+#: app/scripts/services/forms.js:385 app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr "Fuchsie"
 
@@ -521,7 +542,7 @@ msgstr "Galizisch"
 msgid "German"
 msgstr "Deutsch"
 
-#: app/scripts/services/forms.js:409 app/views/design.html:158
+#: app/scripts/services/forms.js:409 app/views/design.html:157
 msgid "Gold"
 msgstr "Gold"
 
@@ -533,11 +554,11 @@ msgstr "Griechisch"
 msgid "Green Yellow"
 msgstr "Grün-Gelb"
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr "Grün-Gelb"
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr "Hilfe"
 
@@ -549,7 +570,7 @@ msgstr "Hexadezimal"
 msgid "Icestudio is part of"
 msgstr "Icestudio ist ein Teil von"
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid ""
 "If you have blank IN/OUT pins, it's because there is no equivalent in this "
 "board"
@@ -557,27 +578,27 @@ msgstr ""
 "Wenn Sie unbelegte IN/OUT-Pins haben, liegt das daran, dass es keine "
 "entsprechenden Pins auf dem Board gibt"
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr "Bild"
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr "Bild {{name}} gespeichert"
 
-#: app/scripts/services/forms.js:388 app/views/design.html:109
+#: app/scripts/services/forms.js:388 app/views/design.html:108
 msgid "Indian Red"
 msgstr "Indisches-Rot"
 
-#: app/views/design.html:330 app/views/menu.html:795
+#: app/views/design.html:319 app/views/menu.html:813
 msgid "Information"
 msgstr "Information"
 
-#: app/views/design.html:282 app/views/menu.html:760
+#: app/views/design.html:279 app/views/menu.html:778
 msgid "Input"
 msgstr "Eingang"
 
-#: app/views/design.html:294 app/views/menu.html:769
+#: app/views/design.html:289 app/views/menu.html:787
 msgid "Input label"
 msgstr "Eingangs-Beschriftung"
 
@@ -597,15 +618,15 @@ msgstr "Port-Name eingeben:"
 msgid "Input ports"
 msgstr "Eingangs-Anschlüsse"
 
-#: app/views/menu.html:635
+#: app/views/menu.html:653
 msgid "Install (Stable)"
 msgstr "Installiere (stabile Version)"
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
 msgstr "Installiere Entwicklungsversion"
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid ""
 "Install the <b>STABLE Toolchain</b>. This operation requires Internet "
 "connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
@@ -615,7 +636,7 @@ msgstr ""
 "Internetverbindung <br><p><b>HINWEIS:</b> Bitte gegebenenfalls all VPN "
 "Verbindungen vor der Installation trennen</p> <p>Fortfahren?</p>"
 
-#: app/scripts/services/tools.js:1144
+#: app/scripts/services/tools.js:1255
 #, fuzzy
 msgid ""
 "Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
@@ -624,7 +645,7 @@ msgstr ""
 "Toolchain wird aktualisiert. Dieser Vorgang erfordert eine "
 "Internetverbindung. Fortfahren?"
 
-#: app/scripts/services/tools.js:1166
+#: app/scripts/services/tools.js:1277
 #, fuzzy
 msgid ""
 "Install the LATEST STABLE toolchain. It will be downloaded. This operation "
@@ -633,49 +654,49 @@ msgstr ""
 "Toolchain wird aktualisiert. Dieser Vorgang erfordert eine "
 "Internetverbindung. Fortfahren?"
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr "Installation abgeschlossen"
 
-#: app/scripts/services/tools.js:1274
+#: app/scripts/services/tools.js:1385
 msgid "Installing"
 msgstr "Installation wird ausgeführt"
 
-#: app/scripts/services/drivers.js:421 app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447 app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr "Internetverbindung erforderlich"
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr "Ungültige <i>Pull up</i> Verbindung: Block bereits verbunden"
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr ""
 "Ungültige <i>Pull up</i> Verbindung: Nur <i>Eingangs</i>-Blöcke erlaubt"
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr "Ungültige Verbindung:<br><i>Pull up</i> bereits verbunden"
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr "Ungültige Sammlung {{name}}"
 
-#: app/scripts/services/graph.js:254 app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262 app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr "Ungültige Verbindung"
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr "Ungültige Verbindung: {{a}} → {{b}}"
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr "Ungültige Mehrfach-Eingangs-Verbindungen"
 
-#: app/scripts/services/project.js:499 app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510 app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr "Ungültiges Projektformat"
 
@@ -691,7 +712,7 @@ msgstr "Japanisch"
 msgid "Korean"
 msgstr "Koreanisch"
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
 msgstr "Suche Label"
 
@@ -699,7 +720,7 @@ msgstr "Suche Label"
 msgid "Label updated"
 msgstr "Label aktualisiert"
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr "Sprache"
 
@@ -707,15 +728,15 @@ msgstr "Sprache"
 msgid "Light"
 msgstr "Hell"
 
-#: app/scripts/services/forms.js:448 app/views/design.html:257
+#: app/scripts/services/forms.js:448 app/views/design.html:255
 msgid "Light Gray"
 msgstr "Helles Grau"
 
-#: app/scripts/services/forms.js:430 app/views/design.html:215
+#: app/scripts/services/forms.js:430 app/views/design.html:213
 msgid "Light Sea Green"
 msgstr "Helles Meergrün"
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr "Laden"
 
@@ -723,19 +744,19 @@ msgstr "Laden"
 msgid "Local parameter"
 msgstr "Lokaler Parameter"
 
-#: app/views/menu.html:404
+#: app/views/menu.html:422
 msgid "Logging enabled"
 msgstr "Log-Protokollierung aktiviert"
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
 msgstr "Log-Datei"
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
 msgstr "Log-Datei aktualisiert"
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr "Maximale Bus-Größe: 96 bits"
 
@@ -744,11 +765,11 @@ msgstr "Maximale Bus-Größe: 96 bits"
 msgid "Medium Violet Red"
 msgstr "Mittelviolettes Rot"
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr "Mittelviolettes Rot"
 
-#: app/views/design.html:318 app/views/menu.html:787
+#: app/views/design.html:309 app/views/menu.html:805
 msgid "Memory"
 msgstr "Speicher"
 
@@ -756,7 +777,7 @@ msgstr "Speicher"
 msgid "Memory blocks"
 msgstr "Speicher Blöcke"
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr "Name"
 
@@ -764,7 +785,7 @@ msgstr "Name"
 msgid "Name of the paired labels"
 msgstr "Name der verknüpften Labels"
 
-#: app/scripts/services/forms.js:445 app/views/design.html:250
+#: app/scripts/services/forms.js:445 app/views/design.html:248
 msgid "Navy"
 msgstr "Havy"
 
@@ -777,15 +798,20 @@ msgid "New Color:"
 msgstr "Neue Farbe:"
 
 #: app/views/design.html:80
-msgid "New Name:"
+#, fuzzy
+msgid "New Name"
 msgstr "Neuer Name:"
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr ""
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr "Keine Sammlungen gespeichert"
 
-#: app/scripts/app.js:58 app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57 app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr "OK"
 
@@ -794,7 +820,7 @@ msgstr "OK"
 msgid "Olive Drab"
 msgstr "Olivgrün"
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr "Olivgrün"
 
@@ -802,7 +828,7 @@ msgstr "Olivgrün"
 msgid "Open"
 msgstr "Öffnen"
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr "Öffne SVG"
 
@@ -811,19 +837,19 @@ msgstr "Öffne SVG"
 msgid "Orange Red"
 msgstr "Orange Rot"
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr "Orange Rot"
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr "Originaldatei {{file}} existiert nicht"
 
-#: app/views/design.html:288 app/views/menu.html:764
+#: app/views/design.html:284 app/views/menu.html:782
 msgid "Output"
 msgstr "Ausgang"
 
-#: app/views/design.html:300 app/views/menu.html:773
+#: app/views/design.html:294 app/views/menu.html:791
 msgid "Output label"
 msgstr "Ausgangs-Beschriftung"
 
@@ -839,7 +865,7 @@ msgstr "Ausgangs-Port Name"
 msgid "Output ports"
 msgstr "Ausgangs-Port"
 
-#: app/views/design.html:306 app/views/menu.html:778
+#: app/views/design.html:299 app/views/menu.html:796
 msgid "Paired labels"
 msgstr "Verknüpfte Labels"
 
@@ -847,40 +873,44 @@ msgstr "Verknüpfte Labels"
 msgid "Paste"
 msgstr "Einfügen"
 
-#: app/scripts/controllers/menu.js:731 app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853 app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751 app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873 app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr "Pfad {{path}} existiert nicht"
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr "Bitte ausführen: {{cmd}}"
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr ""
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr "Projektinformationen"
 
-#: app/scripts/controllers/menu.js:935 app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955 app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr "Projektinformationen aktualisiert"
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr "Projekt {{name}} geladen"
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr "Projekt {{name}} gespeichert"
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
 msgstr "Python-Umgebung aktualisiert"
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
 msgstr "Python-Umgebung"
 
@@ -888,11 +918,7 @@ msgstr "Python-Umgebung"
 msgid "Quit"
 msgstr "Beenden"
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr "Schreibgeschützt"
-
-#: app/scripts/services/forms.js:391 app/views/design.html:116
+#: app/scripts/services/forms.js:391 app/views/design.html:115
 msgid "Red"
 msgstr "Rot"
 
@@ -904,27 +930,27 @@ msgstr "Wiederholen"
 msgid "Release History WIKI"
 msgstr "Versions-Historie"
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr "Neu laden"
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr "Remote-Host {{name}} nicht verbunden"
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr "Remote-Hostname"
 
-#: app/views/menu.html:647 app/views/menu.html:722
+#: app/views/menu.html:665 app/views/menu.html:740
 msgid "Remove"
 msgstr "Löschen"
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr "Alle löschen"
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
 msgstr "Alle ersetzten"
 
@@ -932,11 +958,11 @@ msgstr "Alle ersetzten"
 msgid "Replace One"
 msgstr "Ersetzten"
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr "SVG zurücksetzen"
 
-#: app/scripts/services/forms.js:442 app/views/design.html:243
+#: app/scripts/services/forms.js:442 app/views/design.html:241
 #, fuzzy
 msgid "Royal Blue"
 msgstr "Royal-Blau"
@@ -949,7 +975,7 @@ msgstr "Russisch"
 msgid "Save"
 msgstr "Speichern"
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr "SVG speichern"
 
@@ -961,11 +987,11 @@ msgstr "Speichern unter"
 msgid "Save submodule"
 msgstr "Untermodul speichern"
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr "Auswählen"
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr "Alles auswählen"
 
@@ -982,11 +1008,11 @@ msgstr "Clock anzeigen"
 msgid "Slate Blue"
 msgstr "Schieferblau"
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr "Schieferblau"
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr "Quellcode"
 
@@ -999,32 +1025,32 @@ msgstr "Spanisch"
 msgid "Spring Green"
 msgstr "Frühlingsgrün"
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr "Frühlingsgrün"
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr "Erstellen starten"
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr "Übertragung starten"
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr "Überprüfung starten"
 
-#: app/scripts/services/forms.js:436 app/views/design.html:229
+#: app/scripts/services/forms.js:436 app/views/design.html:227
 #, fuzzy
 msgid "Steel Blue"
 msgstr "Stahlblau"
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr "Synchronisiere Remote-Dateien..."
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
 msgstr "Systeminformationen"
 
@@ -1040,11 +1066,11 @@ msgstr "Testbench"
 msgid "Thank you very much!"
 msgstr "Vielen Dank!"
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr "Die Sammlung {{name}} existiert bereits."
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
@@ -1052,19 +1078,19 @@ msgstr ""
 "Die aktuelle FPGA I/O Konfiguration geht verloren. Zum {{name}} Board "
 "wechseln?"
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr "Toolchain wird entfernt. Möchtest du fortfahren?"
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr "Es ist eine neue Entwicklungs-Version verfügabr"
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr "Es ist eine neue Version verfügbar"
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
@@ -1072,7 +1098,7 @@ msgstr ""
 "Dieser Importvorgang erfordert einen Projektpfad. Aktuelles Projekt muss "
 "gespeichert werden. Fortfahren?"
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr "Dieses Projekt wurde für das {{name}} Board entwickelt."
 
@@ -1084,7 +1110,7 @@ msgstr ""
 "Diese Veröffentlichung war möglich dank der großartigen Arbeit \n"
 "              von einem aufstrebenden Team von"
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 msgid ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
 "mode\", lock the keylock to do it."
@@ -1093,14 +1119,14 @@ msgstr ""
 "müssen Sie den aktuellen \"Bearbeitungsmodus\" beenden bzw. mit dem Schloss "
 "sperren."
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr "Um zu navigieren, beende bitte den \"Bearbeitungsmodus\"."
 
 #: app/scripts/controllers/menu.js:349
 #, fuzzy
 msgid ""
-"To save your design you need to lock the keylock and               go to top "
+"To save your design you need to lock the padlock and               go to top "
 "level design.<br/><br/>If you want to export               this submodule to "
 "a file, execute \"Save as\" command to do it."
 msgstr ""
@@ -1109,33 +1135,33 @@ msgstr ""
 "Untermodul in eine Datei exportieren möchtest, führe bitte den Befehl "
 "\"Speichern unter\" aus."
 
-#: app/views/menu.html:320
+#: app/views/menu.html:338
 #, fuzzy
 msgid "Toolbox"
 msgstr "Werkzeuge"
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr "Toolchain"
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr "Toolchain installiert"
 
-#: app/scripts/services/drivers.js:594 app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191 app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625 app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300 app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr "Toolchain nicht installiert"
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr "Toolchain entfernt"
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr "Toolchain Version stimmt nicht überein"
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr "Werkzeuge"
 
@@ -1143,11 +1169,11 @@ msgstr "Werkzeuge"
 msgid "Turkish"
 msgstr "Türkisch"
 
-#: app/scripts/services/forms.js:433 app/views/design.html:222
+#: app/scripts/services/forms.js:433 app/views/design.html:220
 msgid "Turquoise"
 msgstr "Türkis"
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 #, fuzzy
 msgid "UI theme"
 msgstr "Benutzeroberfläche"
@@ -1156,56 +1182,56 @@ msgstr "Benutzeroberfläche"
 msgid "Undo"
 msgstr "Rückgängig"
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr "Unbekanntes Board"
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr "Nicht unterstütztes Projektformat {{version}}"
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr "Unbenannt"
 
-#: app/views/menu.html:639
+#: app/views/menu.html:657
 msgid "Update (Latest stable)"
 msgstr "Aktualisiere"
 
-#: app/scripts/controllers/menu.js:1354 app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371 app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr "Übertragen"
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr "Übertragen abgeschlossen"
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr "Überprüfen abgeschlossen"
 
-#: app/views/design.html:510 app/views/menu.html:599
+#: app/views/design.html:498 app/views/menu.html:617
 msgid "Verify"
 msgstr "Überprüfen"
 
-#: app/scripts/services/utils.js:641 app/views/menu.html:832
+#: app/scripts/services/utils.js:636 app/views/menu.html:850
 msgid "Version"
 msgstr "Version"
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr "Versionshinweise"
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr "Ansicht"
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr "Lizenz anzeigen"
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr "Warnungen im Entwurf erkannt"
 
@@ -1223,62 +1249,71 @@ msgstr "Falsches Block-Format: {{type}}"
 msgid "Wrong block name {{name}}"
 msgstr "Falscher Block-Name {{name}}"
 
-#: app/scripts/controllers/menu.js:1907
+#: app/scripts/controllers/menu.js:1925
 #, fuzzy
 msgid "Wrong new name!"
 msgstr "Falscher Port-Name {{name}}"
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr "Falsches Projekt-Format: {{name}}"
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr "Falscher Remote-Hostname {{name}}"
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
 msgstr "Falscher Suchname!"
 
-#: app/scripts/services/forms.js:412 app/views/design.html:166
+#: app/scripts/services/forms.js:412 app/views/design.html:164
 msgid "Yellow"
 msgstr "Gelb"
 
-#: app/scripts/controllers/menu.js:394
+#: app/scripts/controllers/menu.js:409
 #, fuzzy
 msgid ""
-"You are editing a submodule, if you save it, you save only               the "
-"submodule (in this situation \"save as\" works like               \"export "
-"module\"), Do you like to continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 msgstr ""
 "Du bearbeitest ein Untermodul. wenn du es speichert, wird nur das Untermodul "
 "gespeichert. Möchtest du fortfahren ?"
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+msgstr ""
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr "Lade es so wie es ist oder konvertiere es für das {{name}} Board."
 
-#: app/scripts/controllers/menu.js:1328
+#: app/scripts/controllers/menu.js:1347
+#, fuzzy
 msgid ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 msgstr ""
 "Du kannst nur auf höchster Ebene einen Entwurf erstellen. Untermodule können "
 "nur <strong>Überprüft</strong> werden"
 
-#: app/scripts/controllers/menu.js:1355
+#: app/scripts/controllers/menu.js:1372
+#, fuzzy
 msgid ""
-"You can only upload  your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
 msgstr ""
-"Du kannst nur auf höchster Ebene einen Entwurf hochladen. Untermodule können "
+"Du kannst nur auf höchster Ebene einen Entwurf erstellen. Untermodule können "
 "nur <strong>Überprüft</strong> werden"
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
 msgstr "Versionshinweise auf der"
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr "Nicht gespeicherte Änderungen gehen verloren"
 
@@ -1286,25 +1321,38 @@ msgstr "Nicht gespeicherte Änderungen gehen verloren"
 msgid "back"
 msgstr "Zurück"
 
-#: app/scripts/services/drivers.js:412 app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439 app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr "{{app}} wird benötigt."
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr "{{board}} Datenblatt nicht definiert"
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr "{{board}} Pinout nicht definiert"
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr "{{board}} Regeln nicht definiert"
 
-#: app/scripts/controllers/menu.js:483 app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499 app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr "{{name}} exportiert"
+
+#~ msgid "CAUTION ! : Changes will also be applied in all the copied"
+#~ msgstr "Achtung !: Änderungen werden in allen Kopien angewendet"
+
+#~ msgid "Read only"
+#~ msgstr "Schreibgeschützt"
+
+#~ msgid ""
+#~ "You can only upload  your design at top-level design. Inside submodules "
+#~ "you only can <strong>Verify</strong>"
+#~ msgstr ""
+#~ "Du kannst nur auf höchster Ebene einen Entwurf hochladen. Untermodule "
+#~ "können nur <strong>Überprüft</strong> werden"
 
 #~ msgid "Choose a color"
 #~ msgstr "Wähle eine Farbe"

--- a/app/resources/locale/el_GR/el_GR.po
+++ b/app/resources/locale/el_GR/el_GR.po
@@ -12,15 +12,27 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: app/views/design.html:20
-msgid ": '}} {{'Unlock to edit block !"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
 msgstr ""
 
-#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr "<b>Αποσυνδέστε</b> και <b>επανασυνδέστε</b> την πλακέτα"
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
 msgstr "Σχετικά με το Icestudio"
 
@@ -28,11 +40,11 @@ msgstr "Σχετικά με το Icestudio"
 msgid "Acknowledgment"
 msgstr ""
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr "Προσθήκη"
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr "Προσθέστε ένα block στην αρχή"
 
@@ -44,24 +56,24 @@ msgstr "Προσθήκη ως block"
 msgid "Address format"
 msgstr "Μορφοποίηση Διεύθυνσης"
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr "Όλες οι συλλογές διαγράφηκαν"
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr "Όλες οι αποθηκευμένες συλλογές θα διαγραφούν. θέλετε να συνεχίσετε?"
 
-#: app/scripts/services/tools.js:1389
+#: app/scripts/services/tools.js:1500
 #, fuzzy
 msgid "At least Python 3.7 is required"
 msgstr "Η Python 2.7 είναι απαραίτητη"
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr "Συντάκτης"
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr "Basic"
 
@@ -73,6 +85,10 @@ msgstr "Βασκικά"
 msgid "Binary"
 msgstr "Δυαδικό"
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr ""
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -82,7 +98,7 @@ msgstr "Δυαδικό"
 msgid "Block updated"
 msgstr "Το block ενημερώθηκε"
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr "Το {{name}} block εισάχθηκε"
 
@@ -90,56 +106,52 @@ msgstr "Το {{name}} block εισάχθηκε"
 msgid "Blocks"
 msgstr "Blocks"
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr "Πλακέτα"
 
-#: app/views/menu.html:367 app/views/menu.html:458
+#: app/views/menu.html:385 app/views/menu.html:476
 msgid "Board rules"
 msgstr "Κανόνες πλακέτας"
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr "Οι κανόνες της πλακέτας απενεργοποιήθηκαν"
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr "Οι κανόνες της πλακέτας ενεργοποιήθηκαν"
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr "Η πλακέτα {{name}} αποσυνδέθηκε"
 
-#: app/scripts/services/tools.js:607 app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718 app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr "Η πλακέτα {{name}} δεν είναι διαθέσιμη"
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr "Η πλακέτα {{name}} δεν είναι συνδεδεμένη"
 
-#: app/scripts/app.js:185 app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184 app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr "Η πλακέτα {{name}} επιλέχθηκε"
 
-#: app/scripts/services/tools.js:596 app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707 app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr "Ο Bootloader δεν είναι ενεργός"
 
-#: app/scripts/controllers/menu.js:1327 app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346 app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr "Χτίσιμο"
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr "Το χτίσιμο ολοκληρώθηκε"
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr ""
-
-#: app/scripts/app.js:59 app/scripts/services/project.js:147
+#: app/scripts/app.js:58 app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr "Ακύρωση"
 
@@ -147,15 +159,15 @@ msgstr "Ακύρωση"
 msgid "Catalan"
 msgstr "Καταλανικά"
 
-#: app/views/design.html:264
+#: app/views/design.html:262
 msgid "Change Color"
 msgstr ""
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr "Έλεγχος συνδεσιμότητας..."
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr "Έλεγχος Python..."
 
@@ -167,20 +179,20 @@ msgstr "Κινέζικα"
 msgid "Choose a color:"
 msgstr ""
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr "Πατήστε εδώ <b>για να κατεβάσετε την νέα έκδοση</b> του icestudio"
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr "Πατήστε εδώ <b>για να εγκαταστήσετε τους νέους οδηγούς"
 
-#: app/scripts/services/drivers.js:413 app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613 app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440 app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644 app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr "Πατήστε εδώ για να το εγκαταστήσετε"
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr "Πατήστε εδώ για εμφάνιση"
 
@@ -192,63 +204,63 @@ msgstr "Το ρολόι δεν επιτρέπετε για διαύλους δε
 msgid "Clone"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:565 app/views/version.html:80
+#: app/scripts/controllers/menu.js:581 app/views/version.html:80
 msgid "Close"
 msgstr "Κλείσιμο"
 
-#: app/views/design.html:324 app/views/menu.html:791
+#: app/views/design.html:314 app/views/menu.html:809
 msgid "Code"
 msgstr "Κώδικας"
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr "Βιβλιοθήκη"
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr "Λεπτομέρειες βιβλιοθήκης"
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr "Δεν υπάρχουν πληροφορίες για την βιβλιοθήκη {{collection}}"
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr "Η βιβλιοθήκη {{name}} προστέθηκε"
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr "Η βιβλιοθήκη {{name}} δεν αντικαταστάθηκε"
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr "Η βιβλιοθήκη {{name}} αφαιρέθηκε"
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr "Η βιβλιοθήκη {{name}} αντικαταστάθηκε"
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr "Η βιβλιοθήκη {{name}} επιλέχθηκε"
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr "Βιβλιοθήκες"
 
-#: app/scripts/controllers/menu.js:1229 app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249 app/views/menu.html:489
 msgid "Command output"
 msgstr "Τερματικό εξόδου εντολών"
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr "Φόρουμ κοινότητας"
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr "Η παραμετροποίηση δεν ολοκληρώθηκε"
 
-#: app/views/design.html:312 app/views/menu.html:783
+#: app/views/design.html:304 app/views/menu.html:801
 msgid "Constant"
 msgstr "Σταθερά"
 
@@ -257,7 +269,7 @@ msgstr "Σταθερά"
 msgid "Constant names"
 msgstr "Σταθερά"
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr "Μετατροπή"
 
@@ -265,11 +277,11 @@ msgstr "Μετατροπή"
 msgid "Copy"
 msgstr "Αντιγραφή"
 
-#: app/scripts/services/forms.js:400 app/views/design.html:137
+#: app/scripts/services/forms.js:400 app/views/design.html:136
 msgid "Coral"
 msgstr ""
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr "Δημιουργία εικονικού περιβάλλοντος..."
 
@@ -294,15 +306,15 @@ msgstr ""
 msgid "Dark Orange"
 msgstr ""
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr ""
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr ""
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr "Δελτίο δεδομένων"
 
@@ -310,39 +322,43 @@ msgstr "Δελτίο δεδομένων"
 msgid "Decimal"
 msgstr "Δεκαδικό"
 
-#: app/scripts/services/forms.js:394 app/views/design.html:123
+#: app/scripts/services/forms.js:394 app/views/design.html:122
 msgid "Deep Pink"
 msgstr ""
 
-#: app/scripts/services/forms.js:439 app/views/design.html:236
+#: app/scripts/services/forms.js:439 app/views/design.html:234
 msgid "Deep Sky Blue"
 msgstr ""
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr "Προεπηλεγμένο"
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr ""
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr "Περιγραφή"
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr "Απενεργοποίηση"
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr "Θέλετε να κλείσετε την εφαρμογή?"
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr "Θέλετε να διαγράψετε τη βιβλιοθήκη {{name}}?"
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr "Θέλετε να γίνει αντικαταστήσετε?"
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr "Τεκμηρίωση"
 
@@ -350,21 +366,26 @@ msgstr "Τεκμηρίωση"
 msgid "Don't display"
 msgstr ""
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr "Οδήγοι"
 
 #: app/scripts/services/drivers.js:252 app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr "Οι οδηγοί απενεργοποιήθηκαν"
 
 #: app/scripts/services/drivers.js:230 app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr "Οι οδηγοί ενεργοποιήθηκαν"
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+#, fuzzy
+msgid "Duplicate"
+msgstr "Οι FPGA θύρες εισόδου/εξόδου υπάρχουν ήδη"
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr "Οι FPGA θύρες εισόδου/εξόδου υπάρχουν ήδη"
 
@@ -381,11 +402,11 @@ msgstr "Ολλανδικά"
 msgid "Edit"
 msgstr "Επεξεργασία"
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr "Επεξεργασία ονόματος βιβλιοθήκης"
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr "Ενεργοποίηση"
 
@@ -418,15 +439,15 @@ msgstr "Εισαγάγετε τις θύρες εισόδου"
 msgid "Enter the python path"
 msgstr "Εισαγάγετε τη διαδρομή της εξωτερικής βιβλιοθήκης"
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr "Εισαγάγετε το όνομα του απομακρυσμένου υπολογιστή/συσκευής (user@host)"
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr "Σφάλμα: {{error}}"
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr "Λάθη εντοπίστηκαν στο σχεδιασμό"
 
@@ -434,7 +455,7 @@ msgstr "Λάθη εντοπίστηκαν στο σχεδιασμό"
 msgid "Examples"
 msgstr "Παράδειγματα"
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr "Εκτέλεση απομακρυσμένου {{label}} ..."
 
@@ -442,29 +463,29 @@ msgstr "Εκτέλεση απομακρυσμένου {{label}} ..."
 msgid "Export"
 msgstr "Εξαγωγή"
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395 app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr ""
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr "Εξωτερικές βιβλιοθήκες"
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr "Οι εξωτερικές βιβλιοθήκες ανανεώθηκαν"
 
-#: app/views/menu.html:383
+#: app/views/menu.html:401
 #, fuzzy
 msgid "External plugins"
 msgstr "Εξωτερικές βιβλιοθήκες"
 
-#: app/scripts/controllers/menu.js:780
+#: app/scripts/controllers/menu.js:800
 #, fuzzy
 msgid "External plugins updated"
 msgstr "Οι εξωτερικές βιβλιοθήκες ανανεώθηκαν"
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr "Δεν έχουν δηλωθεί οι πύλες εισόδου/εξόδου της FPGA"
 
@@ -472,7 +493,7 @@ msgstr "Δεν έχουν δηλωθεί οι πύλες εισόδου/εξόδ
 msgid "FPGA pin"
 msgstr "Ακροδέκτης FPGA"
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr "FPGA πόροι"
 
@@ -488,18 +509,18 @@ msgstr ""
 msgid "File"
 msgstr "Αρχείο"
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr ""
 "Το αρχείο {{file}} υπάρχει ήδη στην διαδρομή του έργου. θέλετε να το "
 "αντικαταστήσετε?"
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr "Το αρχείο {{file}} δεν υπάρχει"
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr "Το αρχείο {{file}} εισάχθηκε"
 
@@ -507,7 +528,7 @@ msgstr "Το αρχείο {{file}} εισάχθηκε"
 msgid "Find"
 msgstr ""
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr "Πλήρης εμφάνιση"
 
@@ -515,8 +536,8 @@ msgstr "Πλήρης εμφάνιση"
 msgid "French"
 msgstr "Γαλικά"
 
-#: app/scripts/services/forms.js:385 app/views/design.html:173
-#: app/views/design.html:98
+#: app/scripts/services/forms.js:385 app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr ""
 
@@ -528,7 +549,7 @@ msgstr "Γαλικιανά"
 msgid "German"
 msgstr "Γερμανικά"
 
-#: app/scripts/services/forms.js:409 app/views/design.html:158
+#: app/scripts/services/forms.js:409 app/views/design.html:157
 msgid "Gold"
 msgstr ""
 
@@ -540,11 +561,11 @@ msgstr "Ελληνικά"
 msgid "Green Yellow"
 msgstr ""
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr ""
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr "Βοήθεια"
 
@@ -556,33 +577,33 @@ msgstr "Δεκαεξαδικό"
 msgid "Icestudio is part of"
 msgstr ""
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid ""
 "If you have blank IN/OUT pins, it's because there is no equivalent in this "
 "board"
 msgstr ""
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr "Εικόνα"
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr "H eικόνα {{name}} αποθηκεύτηκε"
 
-#: app/scripts/services/forms.js:388 app/views/design.html:109
+#: app/scripts/services/forms.js:388 app/views/design.html:108
 msgid "Indian Red"
 msgstr ""
 
-#: app/views/design.html:330 app/views/menu.html:795
+#: app/views/design.html:319 app/views/menu.html:813
 msgid "Information"
 msgstr "Πληροφορίες"
 
-#: app/views/design.html:282 app/views/menu.html:760
+#: app/views/design.html:279 app/views/menu.html:778
 msgid "Input"
 msgstr "Είσοδος"
 
-#: app/views/design.html:294 app/views/menu.html:769
+#: app/views/design.html:289 app/views/menu.html:787
 msgid "Input label"
 msgstr ""
 
@@ -605,23 +626,23 @@ msgstr ""
 msgid "Input ports"
 msgstr "Εισαγάγετε τις θύρες εισόδου"
 
-#: app/views/menu.html:635
+#: app/views/menu.html:653
 #, fuzzy
 msgid "Install (Stable)"
 msgstr "Εγκατάσταση"
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
 msgstr ""
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid ""
 "Install the <b>STABLE Toolchain</b>. This operation requires Internet "
 "connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
 "allow the toolchain installation</p> <p>Do you want to continue?</p>"
 msgstr ""
 
-#: app/scripts/services/tools.js:1144
+#: app/scripts/services/tools.js:1255
 #, fuzzy
 msgid ""
 "Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
@@ -630,7 +651,7 @@ msgstr ""
 "Το toolchain θα αναβαθμιστεί και θα χρειαστεί σύνδεση στο διαδίκτυο για "
 "αυτό, θέλετε να συνεχίσετε?"
 
-#: app/scripts/services/tools.js:1166
+#: app/scripts/services/tools.js:1277
 #, fuzzy
 msgid ""
 "Install the LATEST STABLE toolchain. It will be downloaded. This operation "
@@ -639,50 +660,50 @@ msgstr ""
 "Το toolchain θα αναβαθμιστεί και θα χρειαστεί σύνδεση στο διαδίκτυο για "
 "αυτό, θέλετε να συνεχίσετε?"
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr "Η εγκατάσταση ολοκληρώθηκε"
 
-#: app/scripts/services/tools.js:1274
+#: app/scripts/services/tools.js:1385
 #, fuzzy
 msgid "Installing"
 msgstr "Εγκατάσταση"
 
-#: app/scripts/services/drivers.js:421 app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447 app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr "Είναι απαραίτητη η συνδεσιμότητα στο διαδίκτυο"
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr "Μη έγκυρη <i>Pull up</i> σύνδεση:<br>το block είναι ήδη συνδεδεμένο"
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr ""
 "Μη έγκυρη <i>Pull up</i> σύνδεση:<br>μόνο block <i>εισόδου</i>επιτρέπονται"
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr "Μη έγκυρη σύνδεση block:<br>Το <i>Pull up</i> είναι ήδη συνδεδεμένο"
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr "Μη έγκυρη βιβλιοθήκη {{name}}"
 
-#: app/scripts/services/graph.js:254 app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262 app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr "Μη έγκυρη σύνδεση"
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr "Μη έγκυρη σύνδεση: {{a}} → {{b}}"
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr "Πολλαπλές μη έγκυρες συνδέσεις"
 
-#: app/scripts/services/project.js:499 app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510 app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr "Μη έγκυρη μορφοποίηση έργου"
 
@@ -699,7 +720,7 @@ msgstr "Ισπανικά"
 msgid "Korean"
 msgstr ""
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
 msgstr ""
 
@@ -708,7 +729,7 @@ msgstr ""
 msgid "Label updated"
 msgstr "Το block ενημερώθηκε"
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr "Γλώσσα"
 
@@ -716,15 +737,15 @@ msgstr "Γλώσσα"
 msgid "Light"
 msgstr ""
 
-#: app/scripts/services/forms.js:448 app/views/design.html:257
+#: app/scripts/services/forms.js:448 app/views/design.html:255
 msgid "Light Gray"
 msgstr ""
 
-#: app/scripts/services/forms.js:430 app/views/design.html:215
+#: app/scripts/services/forms.js:430 app/views/design.html:213
 msgid "Light Sea Green"
 msgstr ""
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr "Φόρτωση"
 
@@ -732,20 +753,20 @@ msgstr "Φόρτωση"
 msgid "Local parameter"
 msgstr "Τοπική παράμετρος"
 
-#: app/views/menu.html:404
+#: app/views/menu.html:422
 #, fuzzy
 msgid "Logging enabled"
 msgstr "Οι οδηγοί ενεργοποιήθηκαν"
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
 msgstr ""
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr "Μέγιστο μέγεθος διαύλου: 96 bits"
 
@@ -753,11 +774,11 @@ msgstr "Μέγιστο μέγεθος διαύλου: 96 bits"
 msgid "Medium Violet Red"
 msgstr ""
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr ""
 
-#: app/views/design.html:318 app/views/menu.html:787
+#: app/views/design.html:309 app/views/menu.html:805
 msgid "Memory"
 msgstr "Μνήμη"
 
@@ -766,7 +787,7 @@ msgstr "Μνήμη"
 msgid "Memory blocks"
 msgstr "Εισαγάγετε τα blocks μνήμης"
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr "Όνομα"
 
@@ -774,7 +795,7 @@ msgstr "Όνομα"
 msgid "Name of the paired labels"
 msgstr ""
 
-#: app/scripts/services/forms.js:445 app/views/design.html:250
+#: app/scripts/services/forms.js:445 app/views/design.html:248
 msgid "Navy"
 msgstr ""
 
@@ -788,15 +809,19 @@ msgstr ""
 
 #: app/views/design.html:80
 #, fuzzy
-msgid "New Name:"
+msgid "New Name"
 msgstr "Όνομα"
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr ""
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr "Δεν έχουν αποθηκευτεί βιβλιοθήκες"
 
-#: app/scripts/app.js:58 app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57 app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr "ΟΚ"
 
@@ -804,7 +829,7 @@ msgstr "ΟΚ"
 msgid "Olive Drab"
 msgstr ""
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr ""
 
@@ -812,7 +837,7 @@ msgstr ""
 msgid "Open"
 msgstr "Άνοιγμα"
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr "Άνοιγμα SVG"
 
@@ -820,19 +845,19 @@ msgstr "Άνοιγμα SVG"
 msgid "Orange Red"
 msgstr ""
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr ""
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr "Το αρχικό αρχείο {{file}}  δεν υπάρχει"
 
-#: app/views/design.html:288 app/views/menu.html:764
+#: app/views/design.html:284 app/views/menu.html:782
 msgid "Output"
 msgstr "Έξοδος"
 
-#: app/views/design.html:300 app/views/menu.html:773
+#: app/views/design.html:294 app/views/menu.html:791
 msgid "Output label"
 msgstr ""
 
@@ -850,7 +875,7 @@ msgstr ""
 msgid "Output ports"
 msgstr "Έξοδος"
 
-#: app/views/design.html:306 app/views/menu.html:778
+#: app/views/design.html:299 app/views/menu.html:796
 msgid "Paired labels"
 msgstr ""
 
@@ -858,40 +883,44 @@ msgstr ""
 msgid "Paste"
 msgstr "Επικόλληση"
 
-#: app/scripts/controllers/menu.js:731 app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853 app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751 app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873 app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr "Η διαδρομή {{path}} δεν υπάρχει"
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr "Παρακαλώ εκτελέστε: {{cmd}}"
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr "Επιλογές"
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr ""
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr "Πληροφορίες έργου"
 
-#: app/scripts/controllers/menu.js:935 app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955 app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr "Οι πληροφορίες του έργου ανανεωθήκαν"
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr "Το έργο {{name}} φορτώθηκε"
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr "Το έργο {{name}} αποθηκεύτηκε"
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
 msgstr ""
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
 msgstr ""
 
@@ -899,11 +928,7 @@ msgstr ""
 msgid "Quit"
 msgstr "Έξοδος"
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr "Μόνο για ανάγνωση"
-
-#: app/scripts/services/forms.js:391 app/views/design.html:116
+#: app/scripts/services/forms.js:391 app/views/design.html:115
 #, fuzzy
 msgid "Red"
 msgstr "Επανάληψη"
@@ -916,27 +941,27 @@ msgstr "Επανάληψη"
 msgid "Release History WIKI"
 msgstr ""
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr "Επαναφόρτωση"
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr "Ο απομακρυσμένος υπολογιστής/συσκευή {{name}} δεν είναι συνδεδεμένος"
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr "Απομακρυσμένο όνομα υπολογιστή/συσκευής"
 
-#: app/views/menu.html:647 app/views/menu.html:722
+#: app/views/menu.html:665 app/views/menu.html:740
 msgid "Remove"
 msgstr "Διαγραφή"
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr "Διαγραφή όλων"
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
 msgstr ""
 
@@ -944,11 +969,11 @@ msgstr ""
 msgid "Replace One"
 msgstr ""
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr "Επαναφορά SVG"
 
-#: app/scripts/services/forms.js:442 app/views/design.html:243
+#: app/scripts/services/forms.js:442 app/views/design.html:241
 msgid "Royal Blue"
 msgstr ""
 
@@ -960,7 +985,7 @@ msgstr ""
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr "Αποθήκευση SVG"
 
@@ -972,11 +997,11 @@ msgstr "Αποθήκευση ως"
 msgid "Save submodule"
 msgstr ""
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr "Επιλογή"
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr "Επιλογή όλων"
 
@@ -992,11 +1017,11 @@ msgstr "Εμφάνιση Ρολογιού"
 msgid "Slate Blue"
 msgstr ""
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr ""
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr "Πηγαίος κώδικας"
 
@@ -1008,31 +1033,31 @@ msgstr "Ισπανικά"
 msgid "Spring Green"
 msgstr ""
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr "Έναρξη χτισίματος"
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr "Έναρξη μεταφόρτωσης"
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr "Έναρξη επαλήθευσης"
 
-#: app/scripts/services/forms.js:436 app/views/design.html:229
+#: app/scripts/services/forms.js:436 app/views/design.html:227
 msgid "Steel Blue"
 msgstr ""
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr "Συγχρονισμός απομακρυσμένων αρχείων ..."
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
 msgstr ""
 
@@ -1048,11 +1073,11 @@ msgstr "Testbench"
 msgid "Thank you very much!"
 msgstr ""
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr "Η βιβλιοθήκη {{name}} υπάρχει ήδη."
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
@@ -1060,19 +1085,19 @@ msgstr ""
 "Η τωρινές ρυθμίσεις εισόδου/εξόδου της FPGA  θα χαθούν. Θέλετε να αλλάξετε "
 "την πλακέτα σε {{name}}?"
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr "Το toolchan θα διαγραφεί. Θέλετε να συνεχίσετε?"
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr ""
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr ""
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
@@ -1080,7 +1105,7 @@ msgstr ""
 "Αυτή η διαδικασία εισαγωγής χρειάζεται μια διαδρομή έργου.Θα πρέπει να "
 "σώσετε το τρέχων έργο. Θέλετε να συνεχίσετε?"
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr "Αυτό το έργο έχει σχεδιαστεί για την πλακέτα {{name}}."
 
@@ -1090,50 +1115,50 @@ msgid ""
 "              done by an emerging team from"
 msgstr ""
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 msgid ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
 "mode\", lock the keylock to do it."
 msgstr ""
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr ""
 
 #: app/scripts/controllers/menu.js:349
 msgid ""
-"To save your design you need to lock the keylock and               go to top "
+"To save your design you need to lock the padlock and               go to top "
 "level design.<br/><br/>If you want to export               this submodule to "
 "a file, execute \"Save as\" command to do it."
 msgstr ""
 
-#: app/views/menu.html:320
+#: app/views/menu.html:338
 #, fuzzy
 msgid "Toolbox"
 msgstr "Εργαλεία"
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr "Toolchain"
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr "Το Toolchain εγκαταστάθηκε"
 
-#: app/scripts/services/drivers.js:594 app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191 app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625 app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300 app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr "Το Toolchain δεν εγκαταστάθηκε"
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr "Το Toolchain διαγράφηκε"
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr "Η έκδοση του Toolchain δεν ταιριάζει"
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr "Εργαλεία"
 
@@ -1141,11 +1166,11 @@ msgstr "Εργαλεία"
 msgid "Turkish"
 msgstr ""
 
-#: app/scripts/services/forms.js:433 app/views/design.html:222
+#: app/scripts/services/forms.js:433 app/views/design.html:220
 msgid "Turquoise"
 msgstr ""
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 msgid "UI theme"
 msgstr ""
 
@@ -1153,57 +1178,57 @@ msgstr ""
 msgid "Undo"
 msgstr "Αναίρεση"
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr "Άγνωστη πλακέτα"
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr "Μη υποστηριζόμενη μορφοποίηση έργου {{version}}"
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr "Άτιτλο"
 
-#: app/views/menu.html:639
+#: app/views/menu.html:657
 #, fuzzy
 msgid "Update (Latest stable)"
 msgstr "Ενημερώστε το όνομα του block"
 
-#: app/scripts/controllers/menu.js:1354 app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371 app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr "Μεταφόρτωση"
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr "Η μεταφόρτωση ολοκληρωθηκε"
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr "Η επαλήθευση ολοκληρωθηκε"
 
-#: app/views/design.html:510 app/views/menu.html:599
+#: app/views/design.html:498 app/views/menu.html:617
 msgid "Verify"
 msgstr "Επαλήθευση"
 
-#: app/scripts/services/utils.js:641 app/views/menu.html:832
+#: app/scripts/services/utils.js:636 app/views/menu.html:850
 msgid "Version"
 msgstr "Έκδοση"
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr ""
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr "Προβολή"
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr "Προβολή άδειας"
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr "Προειδοποιήσεις εντοπίστηκαν στο έργο"
 
@@ -1222,57 +1247,64 @@ msgstr "Λάθος μορφοποίηση block: {{type}}"
 msgid "Wrong block name {{name}}"
 msgstr "Λάθος όνομα block: {{name}}"
 
-#: app/scripts/controllers/menu.js:1907
+#: app/scripts/controllers/menu.js:1925
 #, fuzzy
 msgid "Wrong new name!"
 msgstr "Λάθος όνομα θύρας: {{name}}"
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr "Λάθος μορφοποίηση έργου: {{name}}"
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr "Εσφαλμένη διεύθυνση απομακρυσμένου υπολογιστή/συσκευής"
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
 msgstr ""
 
-#: app/scripts/services/forms.js:412 app/views/design.html:166
+#: app/scripts/services/forms.js:412 app/views/design.html:164
 msgid "Yellow"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:394
+#: app/scripts/controllers/menu.js:409
 msgid ""
-"You are editing a submodule, if you save it, you save only               the "
-"submodule (in this situation \"save as\" works like               \"export "
-"module\"), Do you like to continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 msgstr ""
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+msgstr ""
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr ""
 "Μπορείτε να το φορτώσετε όπως είναι ή να το μετατρέψετε για την πλακέτα "
 "{{name}}"
 
-#: app/scripts/controllers/menu.js:1328
+#: app/scripts/controllers/menu.js:1347
 msgid ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1355
+#: app/scripts/controllers/menu.js:1372
 msgid ""
-"You can only upload  your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
 msgstr ""
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr "Οι αλλαγές σας θα χαθούν αν δεν τις αποθηκεύσετε"
 
@@ -1280,25 +1312,28 @@ msgstr "Οι αλλαγές σας θα χαθούν αν δεν τις αποθ
 msgid "back"
 msgstr "επιστροφή"
 
-#: app/scripts/services/drivers.js:412 app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439 app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr "{{app}} είναι απαρέτητ."
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr "το δελτίο δεδομένων για την πλακέτα {{board}} δεν έχει δηλωθεί"
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr "το pinout για την πλακέτα {{board}} δεν έχει δηλωθεί"
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr "οι κανόνες για την πλακέτα {{board}} δεν έχουν δηλωθεί"
 
-#: app/scripts/controllers/menu.js:483 app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499 app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr "Το {{name}} εξήχθη"
+
+#~ msgid "Read only"
+#~ msgstr "Μόνο για ανάγνωση"
 
 #~ msgid "Duplicated block attributes"
 #~ msgstr "Τα χαρακτηριστικά του block υπάρχουν ήδη"

--- a/app/resources/locale/en/en.po
+++ b/app/resources/locale/en/en.po
@@ -9,30 +9,50 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.2.2\n"
 
-#: app/views/design.html:20
-msgid ": '}} {{'Unlock to edit block !"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
 msgstr ""
+"<b>Read only</b><br>\n"
+"Unlock to edit the block!"
 
-#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr "<b>Unplug</b> and <b>reconnect</b> the board"
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
 msgstr "About Icestudio"
 
 #: app/views/version.html:33
 msgid "Acknowledgment"
-msgstr ""
+msgstr "Acknowledgment"
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr "Add"
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr "Add a block to start"
 
@@ -44,24 +64,23 @@ msgstr "Add as block"
 msgid "Address format"
 msgstr "Address format"
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr "All collections removed"
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr "All stored collections will be lost. Do you want to continue?"
 
-#: app/scripts/services/tools.js:1389
-#, fuzzy
+#: app/scripts/services/tools.js:1500
 msgid "At least Python 3.7 is required"
-msgstr "Python 2.7 is required"
+msgstr "At least Python 3.7 is required"
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr "Author"
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr "Basic"
 
@@ -73,6 +92,10 @@ msgstr "Basque"
 msgid "Binary"
 msgstr "Binary"
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr "Bitstream not found, build first your project"
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -82,7 +105,7 @@ msgstr "Binary"
 msgid "Block updated"
 msgstr "Block updated"
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr "Block {{name}} imported"
 
@@ -90,56 +113,52 @@ msgstr "Block {{name}} imported"
 msgid "Blocks"
 msgstr "Blocks"
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr "Board"
 
-#: app/views/menu.html:367 app/views/menu.html:458
+#: app/views/menu.html:385 app/views/menu.html:476
 msgid "Board rules"
 msgstr "Board rules"
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr "Board rules disabled"
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr "Board rules enabled"
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr "Board {{name}} disconnected"
 
-#: app/scripts/services/tools.js:607 app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718 app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr "Board {{name}} not available"
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr "Board {{name}} not connected"
 
-#: app/scripts/app.js:185 app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184 app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr "Board {{name}} selected"
 
-#: app/scripts/services/tools.js:596 app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707 app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr "Bootloader not active"
 
-#: app/scripts/controllers/menu.js:1327 app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346 app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr "Build"
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr "Build done"
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr ""
-
-#: app/scripts/app.js:59 app/scripts/services/project.js:147
+#: app/scripts/app.js:58 app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -147,16 +166,15 @@ msgstr "Cancel"
 msgid "Catalan"
 msgstr "Catalan"
 
-#: app/views/design.html:264
-#, fuzzy
+#: app/views/design.html:262
 msgid "Change Color"
-msgstr "Choose a color"
+msgstr "Change Color"
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr "Check Internet connection..."
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr "Check Python..."
 
@@ -165,24 +183,23 @@ msgid "Chinese"
 msgstr "Chinese"
 
 #: app/scripts/services/forms.js:1199
-#, fuzzy
 msgid "Choose a color:"
-msgstr "Choose a color"
+msgstr "Choose a color:"
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr "Click here to <b>download a newer version</b> of Icestudio"
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr "Click here to <b>setup the drivers</b>"
 
-#: app/scripts/services/drivers.js:413 app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613 app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440 app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644 app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr "Click here to install it"
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr "Click here to view"
 
@@ -194,72 +211,71 @@ msgstr "Clock not allowed for data buses"
 msgid "Clone"
 msgstr "Clone"
 
-#: app/scripts/controllers/menu.js:565 app/views/version.html:80
+#: app/scripts/controllers/menu.js:581 app/views/version.html:80
 msgid "Close"
 msgstr "Close"
 
-#: app/views/design.html:324 app/views/menu.html:791
+#: app/views/design.html:314 app/views/menu.html:809
 msgid "Code"
 msgstr "Code"
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr "Collection"
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr "Collection info"
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr "Collection {{collection}} info not defined"
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr "Collection {{name}} added"
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr "Collection {{name}} not replaced"
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr "Collection {{name}} removed"
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr "Collection {{name}} replaced"
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr "Collection {{name}} selected"
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr "Collections"
 
-#: app/scripts/controllers/menu.js:1229 app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249 app/views/menu.html:489
 msgid "Command output"
 msgstr "Command output"
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr "Community forum"
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr "Configuration not completed"
 
-#: app/views/design.html:312 app/views/menu.html:783
+#: app/views/design.html:304 app/views/menu.html:801
 msgid "Constant"
 msgstr "Constant"
 
 #: app/scripts/services/forms.js:1985
-#, fuzzy
 msgid "Constant names"
-msgstr "Constant"
+msgstr "Constant names"
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr "Convert"
 
@@ -267,11 +283,11 @@ msgstr "Convert"
 msgid "Copy"
 msgstr "Copy"
 
-#: app/scripts/services/forms.js:400 app/views/design.html:137
+#: app/scripts/services/forms.js:400 app/views/design.html:136
 msgid "Coral"
 msgstr "Coral"
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr "Create virtualenv..."
 
@@ -284,29 +300,26 @@ msgid "Czech"
 msgstr "Czech"
 
 #: app/views/uithemes.html:16
-#, fuzzy
 msgid "Dark (default)"
-msgstr "Default"
+msgstr "Dark (default)"
 
 #: app/scripts/services/forms.js:424
-#, fuzzy
 msgid "Dark Green"
-msgstr "DarkGreen"
+msgstr "Dark Green"
 
 #: app/scripts/services/forms.js:406
-#, fuzzy
 msgid "Dark Orange"
-msgstr "DarkOrange"
+msgstr "Dark Orange"
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr "DarkGreen"
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr "DarkOrange"
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr "Datasheet"
 
@@ -314,41 +327,43 @@ msgstr "Datasheet"
 msgid "Decimal"
 msgstr "Decimal"
 
-#: app/scripts/services/forms.js:394 app/views/design.html:123
-#, fuzzy
+#: app/scripts/services/forms.js:394 app/views/design.html:122
 msgid "Deep Pink"
-msgstr "DeepPink"
+msgstr "Deep Pink"
 
-#: app/scripts/services/forms.js:439 app/views/design.html:236
-#, fuzzy
+#: app/scripts/services/forms.js:439 app/views/design.html:234
 msgid "Deep Sky Blue"
-msgstr "DeepSkyBlue"
+msgstr "Deep Sky Blue"
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr "Default"
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr "Delete"
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr "Description"
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr "Disable"
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr "Do you want to close the application?"
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr "Do you want to remove the {{name}} collection?"
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr "Do you want to replace it?"
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr "Documentation"
 
@@ -356,28 +371,31 @@ msgstr "Documentation"
 msgid "Don't display"
 msgstr "Don't display"
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr "Drivers"
 
 #: app/scripts/services/drivers.js:252 app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr "Drivers disabled"
 
 #: app/scripts/services/drivers.js:230 app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr "Drivers enabled"
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+msgid "Duplicate"
+msgstr "Duplicate"
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr "Duplicated FPGA I/O ports"
 
 #: app/scripts/services/forms.js:1712
-#, fuzzy
 msgid "Duplicated port name:"
-msgstr "Duplicated FPGA I/O ports"
+msgstr "Duplicated port name:"
 
 #: app/views/languages.html:44
 msgid "Dutch"
@@ -387,11 +405,11 @@ msgstr "Dutch"
 msgid "Edit"
 msgstr "Edit"
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr "Edit the collection name"
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr "Enable"
 
@@ -400,39 +418,34 @@ msgid "English"
 msgstr "English"
 
 #: app/scripts/services/forms.js:2368
-#, fuzzy
 msgid "Enter the external collection path"
 msgstr "Enter the external collections path"
 
 #: app/scripts/services/forms.js:2265
-#, fuzzy
 msgid "Enter the external plugins path"
-msgstr "Enter the external collections path"
+msgstr "Enter the external plugins path"
 
 #: app/scripts/services/forms.js:2219
-#, fuzzy
 msgid "Enter the log filename"
-msgstr "Enter the project name"
+msgstr "Enter the log filename"
 
 #: app/scripts/services/forms.js:2320
-#, fuzzy
 msgid "Enter the pip path"
-msgstr "Enter the input ports"
+msgstr "Enter the pip path"
 
 #: app/scripts/services/forms.js:2312
-#, fuzzy
 msgid "Enter the python path"
-msgstr "Enter the ports"
+msgstr "Enter the python path"
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr "Enter the remote hostname user@host"
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr "Error: {{error}}"
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr "Errors detected in the design"
 
@@ -440,7 +453,7 @@ msgstr "Errors detected in the design"
 msgid "Examples"
 msgstr "Examples"
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr "Execute remote {{label}} ..."
 
@@ -448,29 +461,27 @@ msgstr "Execute remote {{label}} ..."
 msgid "Export"
 msgstr "Export"
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395 app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr "Export submodule"
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr "External collections"
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr "External collections updated"
 
-#: app/views/menu.html:383
-#, fuzzy
+#: app/views/menu.html:401
 msgid "External plugins"
-msgstr "External collections"
+msgstr "External plugins"
 
-#: app/scripts/controllers/menu.js:780
-#, fuzzy
+#: app/scripts/controllers/menu.js:800
 msgid "External plugins updated"
-msgstr "External collections updated"
+msgstr "External plugins updated"
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr "FPGA I/O ports not defined"
 
@@ -478,41 +489,41 @@ msgstr "FPGA I/O ports not defined"
 msgid "FPGA pin"
 msgstr "FPGA pin"
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr "FPGA resources"
 
 #: app/views/version.html:51
 msgid "FPGAwars community"
-msgstr ""
+msgstr "FPGAwars community"
 
 #: app/views/version.html:43
 msgid "FPGAwars community."
-msgstr ""
+msgstr "FPGAwars community."
 
 #: app/views/menu.html:76
 msgid "File"
 msgstr "File"
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr "File {{file}} does not exist"
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr "File {{file}} imported"
 
 #: app/views/design.html:65
 msgid "Find"
-msgstr ""
+msgstr "Find"
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr "Fit content"
 
@@ -520,8 +531,8 @@ msgstr "Fit content"
 msgid "French"
 msgstr "French"
 
-#: app/scripts/services/forms.js:385 app/views/design.html:173
-#: app/views/design.html:98
+#: app/scripts/services/forms.js:385 app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr "Fuchsia"
 
@@ -533,7 +544,7 @@ msgstr "Galician"
 msgid "German"
 msgstr "German"
 
-#: app/scripts/services/forms.js:409 app/views/design.html:158
+#: app/scripts/services/forms.js:409 app/views/design.html:157
 msgid "Gold"
 msgstr "Gold"
 
@@ -542,15 +553,14 @@ msgid "Greek"
 msgstr "Greek"
 
 #: app/scripts/services/forms.js:418
-#, fuzzy
 msgid "Green Yellow"
-msgstr "GreenYellow"
+msgstr "Green Yellow"
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr "GreenYellow"
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr "Help"
 
@@ -559,11 +569,10 @@ msgid "Hexadecimal"
 msgstr "Hexadecimal"
 
 #: app/views/version.html:49
-#, fuzzy
 msgid "Icestudio is part of"
-msgstr "Icestudio Inception"
+msgstr "Icestudio is part of"
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid ""
 "If you have blank IN/OUT pins, it's because there is no equivalent in this "
 "board"
@@ -571,127 +580,122 @@ msgstr ""
 "If you see blank IN/OUT pins, it is because there is no equivalent in this "
 "board"
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr "Image"
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr "Image {{name}} saved"
 
-#: app/scripts/services/forms.js:388 app/views/design.html:109
-#, fuzzy
+#: app/scripts/services/forms.js:388 app/views/design.html:108
 msgid "Indian Red"
-msgstr "IndianRed"
+msgstr "Indian Red"
 
-#: app/views/design.html:330 app/views/menu.html:795
+#: app/views/design.html:319 app/views/menu.html:813
 msgid "Information"
 msgstr "Information"
 
-#: app/views/design.html:282 app/views/menu.html:760
+#: app/views/design.html:279 app/views/menu.html:778
 msgid "Input"
 msgstr "Input"
 
-#: app/views/design.html:294 app/views/menu.html:769
+#: app/views/design.html:289 app/views/menu.html:787
 msgid "Input label"
 msgstr "Input label"
 
 #: app/scripts/services/forms.js:1431
-#, fuzzy
 msgid "Input labels"
-msgstr "Input label"
+msgstr "Input labels"
 
 #: app/scripts/services/forms.js:1579
-#, fuzzy
 msgid "Input parameters"
-msgstr "Enter the parameters"
+msgstr "Input parameters"
 
 #: app/scripts/services/forms.js:987
 msgid "Input port name:"
-msgstr ""
+msgstr "Input port name:"
 
 #: app/scripts/services/forms.js:1565
-#, fuzzy
 msgid "Input ports"
-msgstr "Enter the input ports"
+msgstr "Input ports"
 
-#: app/views/menu.html:635
-#, fuzzy
+#: app/views/menu.html:653
 msgid "Install (Stable)"
-msgstr "Install"
+msgstr "Install (Stable)"
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
-msgstr ""
+msgstr "Install Development version"
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid ""
 "Install the <b>STABLE Toolchain</b>. This operation requires Internet "
 "connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
 "allow the toolchain installation</p> <p>Do you want to continue?</p>"
 msgstr ""
+"Install the <b>STABLE Toolchain</b>. This operation requires Internet "
+"connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
+"allow the toolchain installation</p> <p>Do you want to continue?</p>"
 
-#: app/scripts/services/tools.js:1144
-#, fuzzy
+#: app/scripts/services/tools.js:1255
 msgid ""
 "Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
 "requires Internet connection. Do you want to continue?"
 msgstr ""
-"The toolchain will be updated. This operation requires Internet connection. "
-"Do you want to continue?"
+"Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
+"requires Internet connection. Do you want to continue?"
 
-#: app/scripts/services/tools.js:1166
-#, fuzzy
+#: app/scripts/services/tools.js:1277
 msgid ""
 "Install the LATEST STABLE toolchain. It will be downloaded. This operation "
 "requires Internet connection. Do you want to continue?"
 msgstr ""
-"The toolchain will be updated. This operation requires Internet connection. "
-"Do you want to continue?"
+"Install the LATEST STABLE toolchain. It will be downloaded. This operation "
+"requires Internet connection. Do you want to continue?"
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr "Installation completed"
 
-#: app/scripts/services/tools.js:1274
-#, fuzzy
+#: app/scripts/services/tools.js:1385
 msgid "Installing"
-msgstr "Install"
+msgstr "Installing"
 
-#: app/scripts/services/drivers.js:421 app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447 app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr "Internet connection required"
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr "Invalid <i>Pull up</i> connection:<br>block already connected"
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr "Invalid block connection:<br><i>Pull up</i> already connected"
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr "Invalid collection {{name}}"
 
-#: app/scripts/services/graph.js:254 app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262 app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr "Invalid connection"
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr "Invalid connection: {{a}} → {{b}}"
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr "Invalid multiple input connections"
 
-#: app/scripts/services/project.js:499 app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510 app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr "Invalid project format"
 
@@ -700,42 +704,38 @@ msgid "Italian"
 msgstr "Italian"
 
 #: app/views/languages.html:110
-#, fuzzy
 msgid "Japanish"
-msgstr "Spanish"
+msgstr "Japanish"
 
 #: app/views/languages.html:98
 msgid "Korean"
-msgstr ""
+msgstr "Korean"
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
-msgstr ""
+msgstr "Label Finder"
 
 #: app/scripts/services/blockforms.js:991
-#, fuzzy
 msgid "Label updated"
-msgstr "Block updated"
+msgstr "Label updated"
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr "Language"
 
 #: app/views/uithemes.html:26
 msgid "Light"
-msgstr ""
+msgstr "Light"
 
-#: app/scripts/services/forms.js:448 app/views/design.html:257
-#, fuzzy
+#: app/scripts/services/forms.js:448 app/views/design.html:255
 msgid "Light Gray"
-msgstr "LightSeaGreen"
+msgstr "Light Gray"
 
-#: app/scripts/services/forms.js:430 app/views/design.html:215
-#, fuzzy
+#: app/scripts/services/forms.js:430 app/views/design.html:213
 msgid "Light Sea Green"
-msgstr "LightSeaGreen"
+msgstr "Light Sea Green"
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr "Load"
 
@@ -743,50 +743,47 @@ msgstr "Load"
 msgid "Local parameter"
 msgstr "Local parameter"
 
-#: app/views/menu.html:404
-#, fuzzy
+#: app/views/menu.html:422
 msgid "Logging enabled"
-msgstr "Drivers enabled"
+msgstr "Logging enabled"
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
-msgstr ""
+msgstr "Logging file"
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
-msgstr ""
+msgstr "Logging file updated"
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr "Maximum bus size: 96 bits"
 
 #: app/scripts/services/forms.js:397
-#, fuzzy
 msgid "Medium Violet Red"
-msgstr "MediumVioletRed"
+msgstr "Medium Violet Red"
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr "MediumVioletRed"
 
-#: app/views/design.html:318 app/views/menu.html:787
+#: app/views/design.html:309 app/views/menu.html:805
 msgid "Memory"
 msgstr "Memory"
 
 #: app/scripts/services/forms.js:1770
-#, fuzzy
 msgid "Memory blocks"
-msgstr "Import block"
+msgstr "Memory blocks"
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr "Name"
 
 #: app/scripts/services/forms.js:1493
 msgid "Name of the paired labels"
-msgstr ""
+msgstr "Name of the paired labels"
 
-#: app/scripts/services/forms.js:445 app/views/design.html:250
+#: app/scripts/services/forms.js:445 app/views/design.html:248
 msgid "Navy"
 msgstr "Navy"
 
@@ -796,28 +793,30 @@ msgstr "New"
 
 #: app/views/design.html:87
 msgid "New Color:"
-msgstr ""
+msgstr "New Color:"
 
 #: app/views/design.html:80
-#, fuzzy
-msgid "New Name:"
-msgstr "Name"
+msgid "New Name"
+msgstr "New Name"
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr "Next"
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr "No collections stored"
 
-#: app/scripts/app.js:58 app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57 app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr "OK"
 
 #: app/scripts/services/forms.js:427
-#, fuzzy
 msgid "Olive Drab"
-msgstr "OliveDrab"
+msgstr "Olive Drab"
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr "OliveDrab"
 
@@ -825,100 +824,96 @@ msgstr "OliveDrab"
 msgid "Open"
 msgstr "Open"
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr "Open SVG"
 
 #: app/scripts/services/forms.js:403
-#, fuzzy
 msgid "Orange Red"
-msgstr "OrangeRed"
+msgstr "Orange Red"
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr "OrangeRed"
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr "Original file {{file}} does not exist"
 
-#: app/views/design.html:288 app/views/menu.html:764
+#: app/views/design.html:284 app/views/menu.html:782
 msgid "Output"
 msgstr "Output"
 
-#: app/views/design.html:300 app/views/menu.html:773
+#: app/views/design.html:294 app/views/menu.html:791
 msgid "Output label"
 msgstr "Output label"
 
 #: app/scripts/services/forms.js:1350
-#, fuzzy
 msgid "Output labels"
-msgstr "Output label"
+msgstr "Output labels"
 
 #: app/scripts/services/forms.js:1109
-#, fuzzy
 msgid "Output port name"
-msgstr "Output label"
+msgstr "Output port name"
 
 #: app/scripts/services/forms.js:1572
-#, fuzzy
 msgid "Output ports"
-msgstr "Output"
+msgstr "Output ports"
 
-#: app/views/design.html:306 app/views/menu.html:778
+#: app/views/design.html:299 app/views/menu.html:796
 msgid "Paired labels"
-msgstr ""
+msgstr "Paired labels"
 
 #: app/views/menu.html:268
 msgid "Paste"
 msgstr "Paste"
 
-#: app/scripts/controllers/menu.js:731 app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853 app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751 app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873 app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr "Path {{path}} does not exist"
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr "Please run: {{cmd}}"
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr "Preferences"
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr "Prev."
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr "Project information"
 
-#: app/scripts/controllers/menu.js:935 app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955 app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr "Project information updated"
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr "Project {{name}} loaded"
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr "Project {{name}} saved"
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
-msgstr ""
+msgstr "Python Environment updated"
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
-msgstr ""
+msgstr "Python environment"
 
 #: app/views/menu.html:202
 msgid "Quit"
 msgstr "Quit"
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr "Read only"
-
-#: app/scripts/services/forms.js:391 app/views/design.html:116
+#: app/scripts/services/forms.js:391 app/views/design.html:115
 msgid "Red"
 msgstr "Red"
 
@@ -928,44 +923,43 @@ msgstr "Redo"
 
 #: app/views/version.html:29
 msgid "Release History WIKI"
-msgstr ""
+msgstr "Release History WIKI"
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr "Reload"
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr "Remote host {{name}} not connected"
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr "Remote hostname"
 
-#: app/views/menu.html:647 app/views/menu.html:722
+#: app/views/menu.html:665 app/views/menu.html:740
 msgid "Remove"
 msgstr "Remove"
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr "Remove all"
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
-msgstr ""
+msgstr "Replace All"
 
 #: app/views/design.html:84
 msgid "Replace One"
-msgstr ""
+msgstr "Replace One"
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr "Reset SVG"
 
-#: app/scripts/services/forms.js:442 app/views/design.html:243
-#, fuzzy
+#: app/scripts/services/forms.js:442 app/views/design.html:241
 msgid "Royal Blue"
-msgstr "RoyalBlue"
+msgstr "Royal Blue"
 
 #: app/views/languages.html:74
 msgid "Russian"
@@ -975,7 +969,7 @@ msgstr "Russian"
 msgid "Save"
 msgstr "Save"
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr "Save SVG"
 
@@ -987,11 +981,11 @@ msgstr "Save as"
 msgid "Save submodule"
 msgstr "Save submodule"
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr "Select"
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr "Select all"
 
@@ -1004,15 +998,14 @@ msgid "Show clock"
 msgstr "Show clock"
 
 #: app/scripts/services/forms.js:415
-#, fuzzy
 msgid "Slate Blue"
-msgstr "SlateBlue"
+msgstr "Slate Blue"
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr "SlateBlue"
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr "Source code"
 
@@ -1021,42 +1014,40 @@ msgid "Spanish"
 msgstr "Spanish"
 
 #: app/scripts/services/forms.js:421
-#, fuzzy
 msgid "Spring Green"
-msgstr "SpringGreen"
+msgstr "Spring Green"
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr "SpringGreen"
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr "Start build"
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr "Start upload"
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr "Start verification"
 
-#: app/scripts/services/forms.js:436 app/views/design.html:229
-#, fuzzy
+#: app/scripts/services/forms.js:436 app/views/design.html:227
 msgid "Steel Blue"
-msgstr "SteelBlue"
+msgstr "Steel Blue"
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr "Synchronize remote files ..."
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
-msgstr ""
+msgstr "System Info"
 
 #: app/views/languages.html:62
 msgid "Taiwan"
-msgstr ""
+msgstr "Taiwan"
 
 #: app/views/menu.html:174
 msgid "Testbench"
@@ -1064,13 +1055,13 @@ msgstr "Testbench"
 
 #: app/views/version.html:45
 msgid "Thank you very much!"
-msgstr ""
+msgstr "Thank you very much!"
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr "The collection {{name}} already exists."
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
@@ -1078,19 +1069,19 @@ msgstr ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr "The toolchain will be removed. Do you want to continue?"
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr "There is a new nightly version available"
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr "There is a new stable version available"
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
@@ -1098,7 +1089,7 @@ msgstr ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr "This project is designed for the {{name}} board."
 
@@ -1107,8 +1098,10 @@ msgid ""
 "This release has been possible thanks to the great work \n"
 "              done by an emerging team from"
 msgstr ""
+"This release has been possible thanks to the great work \n"
+"              done by an emerging team from"
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 msgid ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
 "mode\", lock the keylock to do it."
@@ -1116,125 +1109,121 @@ msgstr ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
 "mode\", lock the keylock to do so."
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr "To navigate through a design, you need to close \"edit mode\"."
 
 #: app/scripts/controllers/menu.js:349
-#, fuzzy
 msgid ""
-"To save your design you need to lock the keylock and               go to top "
+"To save your design you need to lock the padlock and               go to top "
 "level design.<br/><br/>If you want to export               this submodule to "
 "a file, execute \"Save as\" command to do it."
 msgstr ""
-"To save your design you need to lock the keylock and go to top level design."
-"<br/><br/>If you want to export this submodule to a file, execute \"Save as"
-"\" command."
+"To save your design you need to lock the padlock and               go to top "
+"level design.<br/><br/>If you want to export               this submodule to "
+"a file, execute \"Save as\" command to do it."
 
-#: app/views/menu.html:320
-#, fuzzy
+#: app/views/menu.html:338
 msgid "Toolbox"
-msgstr "Tools"
+msgstr "Toolbox"
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr "Toolchain"
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr "Toolchain installed"
 
-#: app/scripts/services/drivers.js:594 app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191 app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625 app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300 app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr "Toolchain not installed"
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr "Toolchain removed"
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr "Toolchain version does not match"
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr "Tools"
 
 #: app/views/languages.html:104
 msgid "Turkish"
-msgstr ""
+msgstr "Turkish"
 
-#: app/scripts/services/forms.js:433 app/views/design.html:222
+#: app/scripts/services/forms.js:433 app/views/design.html:220
 msgid "Turquoise"
 msgstr "Turquoise"
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 msgid "UI theme"
-msgstr ""
+msgstr "UI theme"
 
 #: app/views/menu.html:228
 msgid "Undo"
 msgstr "Undo"
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr "Unknown board"
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr "Unsupported project format {{version}}"
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr "Untitled"
 
-#: app/views/menu.html:639
-#, fuzzy
+#: app/views/menu.html:657
 msgid "Update (Latest stable)"
-msgstr "Update the block name"
+msgstr "Update (Latest stable)"
 
-#: app/scripts/controllers/menu.js:1354 app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371 app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr "Upload"
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr "Upload done"
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr "Verification done"
 
-#: app/views/design.html:510 app/views/menu.html:599
+#: app/views/design.html:498 app/views/menu.html:617
 msgid "Verify"
 msgstr "Verify"
 
-#: app/scripts/services/utils.js:641 app/views/menu.html:832
+#: app/scripts/services/utils.js:636 app/views/menu.html:850
 msgid "Version"
 msgstr "Version"
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr "Version notes"
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr "View"
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr "View license"
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr "Warnings detected in the design"
 
 #: app/views/version.html:21
-#, fuzzy
 msgid "Welcome to Icestudio!"
-msgstr "About Icestudio"
+msgstr "Welcome to Icestudio!"
 
 #: app/scripts/services/blockforms.js:517
 msgid "Wrong block format: {{type}}"
@@ -1246,63 +1235,71 @@ msgstr "Wrong block format: {{type}}"
 msgid "Wrong block name {{name}}"
 msgstr "Wrong block name {{name}}"
 
-#: app/scripts/controllers/menu.js:1907
-#, fuzzy
+#: app/scripts/controllers/menu.js:1925
 msgid "Wrong new name!"
-msgstr "Wrong port name {{name}}"
+msgstr "Wrong new name!"
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr "Wrong project format: {{name}}"
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr "Wrong remote hostname {{name}}"
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
-msgstr ""
+msgstr "Wrong search name!"
 
-#: app/scripts/services/forms.js:412 app/views/design.html:166
+#: app/scripts/services/forms.js:412 app/views/design.html:164
 msgid "Yellow"
 msgstr "Yellow"
 
-#: app/scripts/controllers/menu.js:394
-#, fuzzy
+#: app/scripts/controllers/menu.js:409
 msgid ""
-"You are editing a submodule, if you save it, you save only               the "
-"submodule (in this situation \"save as\" works like               \"export "
-"module\"), Do you like to continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 msgstr ""
-"You are editing a submodule, if you save it, you save only the submodule (in "
-"this situation \"save as\" works like \"export module\"), Do you like to "
-"continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+msgstr ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr "You can load it as it is or convert it for the {{name}} board."
 
-#: app/scripts/controllers/menu.js:1328
+#: app/scripts/controllers/menu.js:1347
 msgid ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 msgstr ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 
-#: app/scripts/controllers/menu.js:1355
+#: app/scripts/controllers/menu.js:1372
 msgid ""
-"You can only upload  your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
 msgstr ""
-"You can only upload your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
-msgstr ""
+msgstr "You can read the release notes on the"
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr "Your changes will be lost if you do not save them"
 
@@ -1310,25 +1307,35 @@ msgstr "Your changes will be lost if you do not save them"
 msgid "back"
 msgstr "back"
 
-#: app/scripts/services/drivers.js:412 app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439 app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr "{{app}} is required."
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr "{{board}} datasheet not defined"
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr "{{board}} pinout not defined"
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr "{{board}} rules not defined"
 
-#: app/scripts/controllers/menu.js:483 app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499 app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr "{{name}} exported"
+
+#~ msgid "Read only"
+#~ msgstr "Read only"
+
+#~ msgid ""
+#~ "You can only upload  your design at top-level design. Inside submodules "
+#~ "you only can <strong>Verify</strong>"
+#~ msgstr ""
+#~ "You can only upload your design at top-level design. Inside submodules "
+#~ "you only can <strong>Verify</strong>"
 
 #~ msgid ""
 #~ "<h4>FTDI driver installation instructions</h4><ol><li>Connect the FPGA "

--- a/app/resources/locale/es_ES/es_ES.po
+++ b/app/resources/locale/es_ES/es_ES.po
@@ -10,29 +10,49 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.3\n"
+"X-Generator: Poedit 3.2.2\n"
 
-#: app/views/design.html:20
-msgid ": '}} {{'Unlock to edit block !"
-msgstr ": '}} {{'¡Desbloquea para editar el bloque!"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
+msgstr ""
+"<b>Solo lectura</b><br>\n"
+"¡Desbloquea el candado para editar el bloque!"
 
-#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr "<b>Desconecta</b> y <b>conecta</b> la placa"
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+"<b>¡AVISO!</b><br>\n"
+"Los cambios que hagas aquí, también serán aplicados a todos los\n"
+"bloques [<b>{{ information.name }}</b>] en el diseño\n"
+"actual. Si NO QUIERES que se propaguen, crea entonces\n"
+"un bloque clonado usando<br>\n"
+"<b>Editar → Clonar</b>."
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
-msgstr "Sobre Icestudio"
+msgstr "Acerca de Icestudio"
 
 #: app/views/version.html:33
 msgid "Acknowledgment"
 msgstr "Agradecimientos"
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr "Añadir"
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr "Añade un bloque para comenzar"
 
@@ -44,23 +64,23 @@ msgstr "Añadir como bloque"
 msgid "Address format"
 msgstr "Formato de dirección"
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr "Colecciones eliminadas"
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr "Todas las colecciones almacenadas se perderán. ¿Deseas continuar?"
 
-#: app/scripts/services/tools.js:1389
+#: app/scripts/services/tools.js:1500
 msgid "At least Python 3.7 is required"
 msgstr "Es necesario Python 3.7 o superior"
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr "Autor"
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr "Básico"
 
@@ -72,6 +92,10 @@ msgstr "Euskera"
 msgid "Binary"
 msgstr "Binario"
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr "Bitstream no encontrado, sintetiza primero tu proyecto"
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -81,7 +105,7 @@ msgstr "Binario"
 msgid "Block updated"
 msgstr "Bloque actualizado"
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr "Bloque {{name}} importado"
 
@@ -89,58 +113,52 @@ msgstr "Bloque {{name}} importado"
 msgid "Blocks"
 msgstr "Bloques"
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr "Placa"
 
-#: app/views/menu.html:367 app/views/menu.html:458
+#: app/views/menu.html:385 app/views/menu.html:476
 msgid "Board rules"
 msgstr "Reglas de la placa"
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr "Reglas de la placa deshabilitadas"
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr "Reglas de la placa habilitadas"
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr "Placa {{name}} desconectada"
 
-#: app/scripts/services/tools.js:607 app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718 app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr "Placa {{name}} no disponible"
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr "Placa {{name}} no conectada"
 
-#: app/scripts/app.js:185 app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184 app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr "Placa {{name}} seleccionada"
 
-#: app/scripts/services/tools.js:596 app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707 app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr "Bootloader no activo"
 
-#: app/scripts/controllers/menu.js:1327 app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346 app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr "Sintetizar"
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr "Sintetizado realizado"
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr ""
-"ATENCIÓN ! : Las modificaciones también se aplicarán en todas las copias del "
-"bloque"
-
-#: app/scripts/app.js:59 app/scripts/services/project.js:147
+#: app/scripts/app.js:58 app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -148,15 +166,15 @@ msgstr "Cancelar"
 msgid "Catalan"
 msgstr "Catalán"
 
-#: app/views/design.html:264
+#: app/views/design.html:262
 msgid "Change Color"
 msgstr "Cambiar Color"
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr "Comprobando conexión a Internet..."
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr "Comprobando Python..."
 
@@ -168,21 +186,21 @@ msgstr "Chino"
 msgid "Choose a color:"
 msgstr "Selecciona un color:"
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr ""
 "Haz clic aquí para <b>descargar una versión más nueva</ b> de Icestudio"
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr "Haz clic aquí para <b>configurar los drivers</b>"
 
-#: app/scripts/services/drivers.js:413 app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613 app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440 app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644 app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr "Haz clic aquí para instalarlo"
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr "Haz clic aquí para ver"
 
@@ -194,63 +212,63 @@ msgstr "Reloj no permitido para buses de datos"
 msgid "Clone"
 msgstr "Clonar"
 
-#: app/scripts/controllers/menu.js:565 app/views/version.html:80
+#: app/scripts/controllers/menu.js:581 app/views/version.html:80
 msgid "Close"
 msgstr "Cerrar"
 
-#: app/views/design.html:324 app/views/menu.html:791
+#: app/views/design.html:314 app/views/menu.html:809
 msgid "Code"
 msgstr "Código"
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr "Colección"
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr "Información de la colección"
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr "Información de la colección {{collection}} no definida"
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr "Colección {{name}} añadida"
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr "Colección {{name}} no reemplazada"
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr "Colección {{name}} eliminada"
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr "Colección {{name}} reemplazada"
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr "Colección {{name}} seleccionada"
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr "Colecciones"
 
-#: app/scripts/controllers/menu.js:1229 app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249 app/views/menu.html:489
 msgid "Command output"
 msgstr "Salida de comando"
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr "Foro de la comunidad"
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr "Configuración no completada"
 
-#: app/views/design.html:312 app/views/menu.html:783
+#: app/views/design.html:304 app/views/menu.html:801
 msgid "Constant"
 msgstr "Constante"
 
@@ -258,7 +276,7 @@ msgstr "Constante"
 msgid "Constant names"
 msgstr "Nombre de las constantes"
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr "Convertir"
 
@@ -266,11 +284,11 @@ msgstr "Convertir"
 msgid "Copy"
 msgstr "Copiar"
 
-#: app/scripts/services/forms.js:400 app/views/design.html:137
+#: app/scripts/services/forms.js:400 app/views/design.html:136
 msgid "Coral"
 msgstr "Coral"
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr "Crear virtualenv..."
 
@@ -294,15 +312,15 @@ msgstr "Verde oscuro"
 msgid "Dark Orange"
 msgstr "Naranja oscuro"
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr "Verde oscuro"
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr "Naranja oscuro"
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr "Datasheet"
 
@@ -310,39 +328,43 @@ msgstr "Datasheet"
 msgid "Decimal"
 msgstr "Decimal"
 
-#: app/scripts/services/forms.js:394 app/views/design.html:123
+#: app/scripts/services/forms.js:394 app/views/design.html:122
 msgid "Deep Pink"
 msgstr "Rosa oscuro"
 
-#: app/scripts/services/forms.js:439 app/views/design.html:236
+#: app/scripts/services/forms.js:439 app/views/design.html:234
 msgid "Deep Sky Blue"
 msgstr "Celeste intenso"
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr "Por defecto"
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr "Suprimir"
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr "Descripción"
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr "Deshabilitar"
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr "¿Deseas cerrar la aplicación?"
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr "¿Deseas eliminar la colección {{name}}?"
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr "¿Deseas reemplazarla?"
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr "Documentación"
 
@@ -350,21 +372,25 @@ msgstr "Documentación"
 msgid "Don't display"
 msgstr "No mostrar"
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr "Drivers"
 
 #: app/scripts/services/drivers.js:252 app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr "Drivers deshabilitados"
 
 #: app/scripts/services/drivers.js:230 app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr "Drivers habilitados"
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+msgid "Duplicate"
+msgstr "Duplicado"
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr "Puertos E/S de la FPGA duplicados"
 
@@ -380,11 +406,11 @@ msgstr "Holandés"
 msgid "Edit"
 msgstr "Editar"
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr "Edita el nombre de la colección"
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr "Habilitar"
 
@@ -412,15 +438,15 @@ msgstr "Introduce la ruta de pip"
 msgid "Enter the python path"
 msgstr "Introduce la ruta de python"
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr "Introduce el nombre del host remoto usuario@host"
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr "Error: {{error}}"
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr "Errores detectados en el diseño"
 
@@ -428,7 +454,7 @@ msgstr "Errores detectados en el diseño"
 msgid "Examples"
 msgstr "Ejemplos"
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr "Ejecutar {{label}} remoto ..."
 
@@ -436,27 +462,27 @@ msgstr "Ejecutar {{label}} remoto ..."
 msgid "Export"
 msgstr "Exportar"
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395 app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr "Exportar submódulo"
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr "Colecciones externas"
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr "Colecciones externas actualizadas"
 
-#: app/views/menu.html:383
+#: app/views/menu.html:401
 msgid "External plugins"
 msgstr "Plugins externos"
 
-#: app/scripts/controllers/menu.js:780
+#: app/scripts/controllers/menu.js:800
 msgid "External plugins updated"
 msgstr "Plugins externos actualizados"
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr "Puertos E/S de la FPGA no definidos"
 
@@ -464,7 +490,7 @@ msgstr "Puertos E/S de la FPGA no definidos"
 msgid "FPGA pin"
 msgstr "FPGA pin"
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr "Recursos de la FPGA"
 
@@ -480,18 +506,18 @@ msgstr "comunidad FPGAwars."
 msgid "File"
 msgstr "Archivo"
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr ""
 "El archivo {{file}} ya existe en el directorio del proyecto. ¿Deseas "
 "reemplazarlo?"
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr "El archivo {{file}} no existe"
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr "Archivo {{file}} importado"
 
@@ -499,7 +525,7 @@ msgstr "Archivo {{file}} importado"
 msgid "Find"
 msgstr "Buscar"
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr "Ajustar contenido"
 
@@ -507,8 +533,8 @@ msgstr "Ajustar contenido"
 msgid "French"
 msgstr "Francés"
 
-#: app/scripts/services/forms.js:385 app/views/design.html:173
-#: app/views/design.html:98
+#: app/scripts/services/forms.js:385 app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr "Fuxia"
 
@@ -520,7 +546,7 @@ msgstr "Gallego"
 msgid "German"
 msgstr "Alemán"
 
-#: app/scripts/services/forms.js:409 app/views/design.html:158
+#: app/scripts/services/forms.js:409 app/views/design.html:157
 msgid "Gold"
 msgstr "Oro"
 
@@ -532,11 +558,11 @@ msgstr "Griego"
 msgid "Green Yellow"
 msgstr "Amarillo verdoso"
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr "Amarillo verdoso"
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr "Ayuda"
 
@@ -548,7 +574,7 @@ msgstr "Hexadecimal"
 msgid "Icestudio is part of"
 msgstr "Icestudio es parte de"
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid ""
 "If you have blank IN/OUT pins, it's because there is no equivalent in this "
 "board"
@@ -556,27 +582,27 @@ msgstr ""
 "Si aparecen pins de ENTRADA/SALIDA vacíos, es porque no existe una "
 "equivalencia para tu tarjeta"
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr "Imagen"
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr "Imagen {{name}} guardada"
 
-#: app/scripts/services/forms.js:388 app/views/design.html:109
+#: app/scripts/services/forms.js:388 app/views/design.html:108
 msgid "Indian Red"
 msgstr "Rojo indio"
 
-#: app/views/design.html:330 app/views/menu.html:795
+#: app/views/design.html:319 app/views/menu.html:813
 msgid "Information"
 msgstr "Información"
 
-#: app/views/design.html:282 app/views/menu.html:760
+#: app/views/design.html:279 app/views/menu.html:778
 msgid "Input"
 msgstr "Entrada"
 
-#: app/views/design.html:294 app/views/menu.html:769
+#: app/views/design.html:289 app/views/menu.html:787
 msgid "Input label"
 msgstr "Etiqueta de entrada"
 
@@ -596,15 +622,15 @@ msgstr "Nombre de puerto de entrada:"
 msgid "Input ports"
 msgstr "Puertos de entrada"
 
-#: app/views/menu.html:635
+#: app/views/menu.html:653
 msgid "Install (Stable)"
 msgstr "Instalar (Estable)"
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
 msgstr "Instalar la versión de desarrollo"
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid ""
 "Install the <b>STABLE Toolchain</b>. This operation requires Internet "
 "connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
@@ -614,7 +640,7 @@ msgstr ""
 "internet<br><p><b>NOTA:</b> Debes desconectar la VPN (si la usas) para "
 "permitir la instalación de la Toolchain</p> <p>¿Quieres continuar?</p>"
 
-#: app/scripts/services/tools.js:1144
+#: app/scripts/services/tools.js:1255
 msgid ""
 "Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
 "requires Internet connection. Do you want to continue?"
@@ -622,7 +648,7 @@ msgstr ""
 "Instale la cadena de herramientas de DESARROLLO. Se descargará. Esta "
 "operaciónRequiere conexión a Internet. ¿Quieres continuar?"
 
-#: app/scripts/services/tools.js:1166
+#: app/scripts/services/tools.js:1277
 msgid ""
 "Install the LATEST STABLE toolchain. It will be downloaded. This operation "
 "requires Internet connection. Do you want to continue?"
@@ -630,50 +656,50 @@ msgstr ""
 "Instale la ÚLTIMA cadena de herramientas ESTABLE. Se descargará. Esta "
 "operaciónRequiere conexión a Internet. ¿Quieres continuar?"
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr "Instalación completada"
 
-#: app/scripts/services/tools.js:1274
+#: app/scripts/services/tools.js:1385
 msgid "Installing"
 msgstr "Instalando"
 
-#: app/scripts/services/drivers.js:421 app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447 app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr "Es necesario conexión a Internet"
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr "Conexión de <i>Pull up</i> no válida:<br>hay un bloque conectado"
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr ""
 "Conexión de <i>Pull up</i> no válida:<br>sólo se permiten bloques "
 "<i>Entrada</i>"
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr "Conexión de bloque no válida:<br>hay un <i>Pull up</i>  conectado"
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr "Colección {{name}} no válida"
 
-#: app/scripts/services/graph.js:254 app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262 app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr "Conexión no válida"
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr "Conexión no válida: {{a}} → {{b}}"
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr "Conexiones de entrada múltiple no válidas"
 
-#: app/scripts/services/project.js:499 app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510 app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr "Formato de proyecto no válido"
 
@@ -689,7 +715,7 @@ msgstr "Japonés"
 msgid "Korean"
 msgstr "Koreano"
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
 msgstr "Buscar etiqueta"
 
@@ -697,7 +723,7 @@ msgstr "Buscar etiqueta"
 msgid "Label updated"
 msgstr "Etiqueta actualizada"
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr "Idioma"
 
@@ -705,15 +731,15 @@ msgstr "Idioma"
 msgid "Light"
 msgstr "Luminoso"
 
-#: app/scripts/services/forms.js:448 app/views/design.html:257
+#: app/scripts/services/forms.js:448 app/views/design.html:255
 msgid "Light Gray"
 msgstr "Gris claro"
 
-#: app/scripts/services/forms.js:430 app/views/design.html:215
+#: app/scripts/services/forms.js:430 app/views/design.html:213
 msgid "Light Sea Green"
 msgstr "Verde marino claro"
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr "Cargar"
 
@@ -721,19 +747,19 @@ msgstr "Cargar"
 msgid "Local parameter"
 msgstr "Parámetro local"
 
-#: app/views/menu.html:404
+#: app/views/menu.html:422
 msgid "Logging enabled"
 msgstr "Logging avtivado"
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
 msgstr "Archivo de registro (log)"
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
 msgstr "Archivo de registro actualizado"
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr "Tamaño máximo del bus: 96 bits"
 
@@ -741,11 +767,11 @@ msgstr "Tamaño máximo del bus: 96 bits"
 msgid "Medium Violet Red"
 msgstr "Rojo violeta medio"
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr "Rojo violeta medio"
 
-#: app/views/design.html:318 app/views/menu.html:787
+#: app/views/design.html:309 app/views/menu.html:805
 msgid "Memory"
 msgstr "Memoria"
 
@@ -753,7 +779,7 @@ msgstr "Memoria"
 msgid "Memory blocks"
 msgstr "Bloques de memoria"
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr "Nombre"
 
@@ -761,7 +787,7 @@ msgstr "Nombre"
 msgid "Name of the paired labels"
 msgstr "Nombre de las etiquetas emparejadas"
 
-#: app/scripts/services/forms.js:445 app/views/design.html:250
+#: app/scripts/services/forms.js:445 app/views/design.html:248
 msgid "Navy"
 msgstr "Azul marino"
 
@@ -774,15 +800,19 @@ msgid "New Color:"
 msgstr "Nuevo Color:"
 
 #: app/views/design.html:80
-msgid "New Name:"
-msgstr "Nuevo nombre:"
+msgid "New Name"
+msgstr "Nuevo nombre"
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr "Sig."
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr "Ninguna colección almacenada"
 
-#: app/scripts/app.js:58 app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57 app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr "OK"
 
@@ -790,7 +820,7 @@ msgstr "OK"
 msgid "Olive Drab"
 msgstr "Verde oliva"
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr "Verde oliva"
 
@@ -798,7 +828,7 @@ msgstr "Verde oliva"
 msgid "Open"
 msgstr "Abrir"
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr "Abrir SVG"
 
@@ -806,19 +836,19 @@ msgstr "Abrir SVG"
 msgid "Orange Red"
 msgstr "Rojo naranja"
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr "Rojo naranja"
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr "El archivo original {{file}} no existe"
 
-#: app/views/design.html:288 app/views/menu.html:764
+#: app/views/design.html:284 app/views/menu.html:782
 msgid "Output"
 msgstr "Salida"
 
-#: app/views/design.html:300 app/views/menu.html:773
+#: app/views/design.html:294 app/views/menu.html:791
 msgid "Output label"
 msgstr "Etiqueta de salida"
 
@@ -834,7 +864,7 @@ msgstr "Nombre del puerto de salida"
 msgid "Output ports"
 msgstr "Puertos de salida"
 
-#: app/views/design.html:306 app/views/menu.html:778
+#: app/views/design.html:299 app/views/menu.html:796
 msgid "Paired labels"
 msgstr "Etiquetas emparejadas"
 
@@ -842,40 +872,44 @@ msgstr "Etiquetas emparejadas"
 msgid "Paste"
 msgstr "Pegar"
 
-#: app/scripts/controllers/menu.js:731 app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853 app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751 app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873 app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr "La ruta {{path}} no existe"
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr "Por favor ejecuta: {{cmd}}"
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr "Ant."
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr "Información del proyecto"
 
-#: app/scripts/controllers/menu.js:935 app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955 app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr "Información del proyecto actualizada"
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr "Proyecto {{name}} cargado"
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr "Proyecto {{name}} guardado"
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
 msgstr "Entorno de python actualizado"
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
 msgstr "Entorno de Python"
 
@@ -883,11 +917,7 @@ msgstr "Entorno de Python"
 msgid "Quit"
 msgstr "Salir"
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr "Solo lectura"
-
-#: app/scripts/services/forms.js:391 app/views/design.html:116
+#: app/scripts/services/forms.js:391 app/views/design.html:115
 msgid "Red"
 msgstr "Rojo"
 
@@ -899,27 +929,27 @@ msgstr "Rehacer"
 msgid "Release History WIKI"
 msgstr "WIKI del historial de lanzamientos"
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr "Recargar"
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr "Host remoto {{name}} no conectado"
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr "Nombre del host remoto"
 
-#: app/views/menu.html:647 app/views/menu.html:722
+#: app/views/menu.html:665 app/views/menu.html:740
 msgid "Remove"
 msgstr "Eliminar"
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr "Eliminar todo"
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
 msgstr "Cambiar todos"
 
@@ -927,11 +957,11 @@ msgstr "Cambiar todos"
 msgid "Replace One"
 msgstr "Cambiar uno"
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr "Resetear SVG"
 
-#: app/scripts/services/forms.js:442 app/views/design.html:243
+#: app/scripts/services/forms.js:442 app/views/design.html:241
 msgid "Royal Blue"
 msgstr "Añil"
 
@@ -943,7 +973,7 @@ msgstr "Ruso"
 msgid "Save"
 msgstr "Guardar"
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr "Guardar SVG"
 
@@ -955,11 +985,11 @@ msgstr "Guardar como"
 msgid "Save submodule"
 msgstr "Guardar submódulo"
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr "Seleccionar"
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr "Seleccionar todo"
 
@@ -975,11 +1005,11 @@ msgstr "Mostrar reloj"
 msgid "Slate Blue"
 msgstr "Azul pizarra"
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr "Azul pizarra"
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr "Código fuente"
 
@@ -991,31 +1021,31 @@ msgstr "Español"
 msgid "Spring Green"
 msgstr "Verde primavera"
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr "Verde primavera"
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr "Comenzar sintetizado"
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr "Comenzar carga"
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr "Comenzar verificación"
 
-#: app/scripts/services/forms.js:436 app/views/design.html:229
+#: app/scripts/services/forms.js:436 app/views/design.html:227
 msgid "Steel Blue"
 msgstr "Azul acero"
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr "Sincronizando ficheros remotos ..."
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
 msgstr "Información del sistema"
 
@@ -1031,11 +1061,11 @@ msgstr "Testbench"
 msgid "Thank you very much!"
 msgstr "¡Muchas gracias!"
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr "La colección {{name}} ya existe."
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
@@ -1043,19 +1073,19 @@ msgstr ""
 "La configuración actual de E/S de la FPGA se perderá. ¿Deseas cambiar a la "
 "placa {{name}}?"
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr "La toolchain será eliminada. ¿Deseas continuar?"
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr "Hay una nueva versión nightly disponible"
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr "Hay una nueva versión estable disponible"
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
@@ -1063,7 +1093,7 @@ msgstr ""
 "Esta operación de importación requiere una ruta del proyecto. Debes guardar "
 "el proyecto actual. ¿Deseas continuar?"
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr "Este proyecto está diseñado para la placa {{name}}."
 
@@ -1075,7 +1105,7 @@ msgstr ""
 "Este lanzamiento ha sido posible gracias al gran trabajo \n"
 "hecho por el grupo emergente de"
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 msgid ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
 "mode\", lock the keylock to do it."
@@ -1083,46 +1113,46 @@ msgstr ""
 "Para entrar al \"modo de edición\" del bloque más profundo, debes finalizar "
 "el \"modo de edición\" actual, bloqueando el candado."
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr "Para navegar por el diseño, debes cerrar el \"modo de edición\"."
 
 #: app/scripts/controllers/menu.js:349
 msgid ""
-"To save your design you need to lock the keylock and               go to top "
+"To save your design you need to lock the padlock and               go to top "
 "level design.<br/><br/>If you want to export               this submodule to "
 "a file, execute \"Save as\" command to do it."
 msgstr ""
 "Para guardar tu diseño, debes bloquear el candado e ir al diseño de nivel "
-"superior. <br/> <br/> Si deseas exportar este submódulo a un archivo, "
-"ejecuta el comando \"Guardar como\" para hacerlo."
+"superior.<br/><br/>Si deseas exportar este submódulo a un archivo, ejecuta "
+"el comando \"Guardar como\" para hacerlo."
 
-#: app/views/menu.html:320
+#: app/views/menu.html:338
 msgid "Toolbox"
 msgstr "Herramientas"
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr "Toolchain"
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr "Toolchain instalada"
 
-#: app/scripts/services/drivers.js:594 app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191 app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625 app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300 app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr "La toolchain no está instalada"
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr "Toolchain eliminada"
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr "La versión de la toolchain no coincide"
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr "Herramientas"
 
@@ -1130,11 +1160,11 @@ msgstr "Herramientas"
 msgid "Turkish"
 msgstr "Turco"
 
-#: app/scripts/services/forms.js:433 app/views/design.html:222
+#: app/scripts/services/forms.js:433 app/views/design.html:220
 msgid "Turquoise"
 msgstr "Turquesa"
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 msgid "UI theme"
 msgstr "Tema de la interfaz"
 
@@ -1142,56 +1172,56 @@ msgstr "Tema de la interfaz"
 msgid "Undo"
 msgstr "Deshacer"
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr "Placa desconocida"
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr "Formato de proyecto no admitido {{version}}"
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr "Sin título"
 
-#: app/views/menu.html:639
+#: app/views/menu.html:657
 msgid "Update (Latest stable)"
 msgstr "Actualización (Última estable)"
 
-#: app/scripts/controllers/menu.js:1354 app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371 app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr "Cargar"
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr "Carga realizada"
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr "Verificación realizada"
 
-#: app/views/design.html:510 app/views/menu.html:599
+#: app/views/design.html:498 app/views/menu.html:617
 msgid "Verify"
 msgstr "Verificar"
 
-#: app/scripts/services/utils.js:641 app/views/menu.html:832
+#: app/scripts/services/utils.js:636 app/views/menu.html:850
 msgid "Version"
 msgstr "Versión"
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr "Notas de la versión"
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr "Ver"
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr "Ver licencia"
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr "Advertencias detectadas en el diseño"
 
@@ -1209,61 +1239,71 @@ msgstr "Formato de bloque incorrecto: {{type}}"
 msgid "Wrong block name {{name}}"
 msgstr "Nombre del bloque {{name}} incorrecto"
 
-#: app/scripts/controllers/menu.js:1907
+#: app/scripts/controllers/menu.js:1925
 msgid "Wrong new name!"
 msgstr "¡Nombre nuevo incorrecto!"
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr "Formato de proyecto incorrecto: {{name}}"
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr "Nombre del host remoto incorrecto {{name}}"
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
 msgstr "¡Nombre de búsqueda incorrecto!"
 
-#: app/scripts/services/forms.js:412 app/views/design.html:166
+#: app/scripts/services/forms.js:412 app/views/design.html:164
 msgid "Yellow"
 msgstr "Amarillo"
 
-#: app/scripts/controllers/menu.js:394
+#: app/scripts/controllers/menu.js:409
 msgid ""
-"You are editing a submodule, if you save it, you save only               the "
-"submodule (in this situation \"save as\" works like               \"export "
-"module\"), Do you like to continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 msgstr ""
-"Estás editando un submódulo, si lo guardas, guardas solo el submódulo (en "
-"esta situación \"guardar como\" funciona como \"módulo de exportación\"), "
-"¿Te gustaría continuar?"
+"Estás editando un submódulo, si lo guardas, guardarás solo el submódulo (en "
+"esta situación \"guardar como\" funciona como “exportar módulo”). ¿Quieres "
+"continuar?"
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+msgstr ""
+"Estás navegando dentro del diseño, si quieres guardar el diseño entero, "
+"tienes que retroceder al nivel superior. Si quieres exportar este módulo "
+"como un archivo nuevo, desbloquea el módulo y utiliza “guardar como”"
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr "Puedes cargarlo como está o convertirlo para la placa {{name}}."
 
-#: app/scripts/controllers/menu.js:1328
+#: app/scripts/controllers/menu.js:1347
 msgid ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 msgstr ""
-"Solo puedes construir en el diseño de nivel superior. Dentro de los "
-"submódulos solo puedes <strong>Verificar</strong>"
+"Solo puedes sintetizar en el nivel superior del diseño. Dentro de los "
+"submódulos, solo puedes <strong>Verificar</strong>"
 
-#: app/scripts/controllers/menu.js:1355
+#: app/scripts/controllers/menu.js:1372
 msgid ""
-"You can only upload  your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
 msgstr ""
-"Solo puedes cargar su diseño en el diseño de nivel superior. Dentro de los "
-"submódulos solo puedes <strong>Verificar</strong>"
+"Solo puedes sintetizar en el nivel superior del diseño. Dentro de los "
+"submódulos, solo puedes <strong>Verificar</strong>"
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
-msgstr "Puedes leer las notas de lanzamiento aquí"
+msgstr "Puedes leer las notas de lanzamiento en la"
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr "Tus cambios se perderán si no los guardas"
 
@@ -1271,25 +1311,43 @@ msgstr "Tus cambios se perderán si no los guardas"
 msgid "back"
 msgstr "volver"
 
-#: app/scripts/services/drivers.js:412 app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439 app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr "Es necesario {{app}}."
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr "{{board}} datasheet no definido"
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr "{{board}} pinout no definido"
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr "Reglas de {{board}} no definidas"
 
-#: app/scripts/controllers/menu.js:483 app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499 app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr "{{name}} exportado"
+
+#~ msgid ": '}} {{'Unlock to edit block !"
+#~ msgstr ": '}} {{'¡Desbloquea para editar el bloque!"
+
+#~ msgid "CAUTION ! : Changes will also be applied in all the copied"
+#~ msgstr ""
+#~ "ATENCIÓN ! : Las modificaciones también se aplicarán en todas las copias "
+#~ "del bloque"
+
+#~ msgid "Read only"
+#~ msgstr "Solo lectura"
+
+#~ msgid ""
+#~ "You can only upload  your design at top-level design. Inside submodules "
+#~ "you only can <strong>Verify</strong>"
+#~ msgstr ""
+#~ "Solo puedes cargar su diseño en el diseño de nivel superior. Dentro de "
+#~ "los submódulos solo puedes <strong>Verificar</strong>"
 
 #~ msgid "Choose a color"
 #~ msgstr "Selecciona un color"

--- a/app/resources/locale/eu_ES/eu_ES.po
+++ b/app/resources/locale/eu_ES/eu_ES.po
@@ -12,15 +12,27 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: app/views/design.html:20
-msgid ": '}} {{'Unlock to edit block !"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
 msgstr ""
 
-#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr "<b>Deskonektatu</b> eta <b>berriro konektatu</b> plaka"
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
 msgstr "Icestudio informazioa"
 
@@ -28,11 +40,11 @@ msgstr "Icestudio informazioa"
 msgid "Acknowledgment"
 msgstr ""
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr "Gehitu"
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr "Gehi ezazu bloke bat hasteko"
 
@@ -44,24 +56,24 @@ msgstr "Blokea sortu"
 msgid "Address format"
 msgstr "Helbidearen formatua"
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr "Bildumak ezabatu dira"
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr "Gordetako bildumak galduko dira. Jarraitu nahi al duzu?"
 
-#: app/scripts/services/tools.js:1389
+#: app/scripts/services/tools.js:1500
 #, fuzzy
 msgid "At least Python 3.7 is required"
 msgstr "Python 2.7 behar da"
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr "Egilea"
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr "Oinarrizkoa"
 
@@ -73,6 +85,10 @@ msgstr "Euskara"
 msgid "Binary"
 msgstr "Bitarra"
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr ""
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -82,7 +98,7 @@ msgstr "Bitarra"
 msgid "Block updated"
 msgstr "Etiketa freskatua dago"
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr "{{name}} blokea inportatu duzu"
 
@@ -90,56 +106,52 @@ msgstr "{{name}} blokea inportatu duzu"
 msgid "Blocks"
 msgstr "Blokeak"
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr "Plaka"
 
-#: app/views/menu.html:367 app/views/menu.html:458
+#: app/views/menu.html:385 app/views/menu.html:476
 msgid "Board rules"
 msgstr "Plakaren arauak"
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr "Plakaren arauak desgaituta"
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr "Plakaren arauak gaituta"
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr "{{name}} plaka konektatu gabe dago"
 
-#: app/scripts/services/tools.js:607 app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718 app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr "{{name}} plaka ez dago erabilgarri"
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr "{{name}} plaka ez dago konektatuta"
 
-#: app/scripts/app.js:185 app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184 app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr "{{name}} plaka hautatu duzu"
 
-#: app/scripts/services/tools.js:596 app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707 app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr "Bootloader ez aktiboa"
 
-#: app/scripts/controllers/menu.js:1327 app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346 app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr "Sintetizatu"
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr "Sintetizatua egin da"
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr ""
-
-#: app/scripts/app.js:59 app/scripts/services/project.js:147
+#: app/scripts/app.js:58 app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr "Utzi"
 
@@ -147,16 +159,16 @@ msgstr "Utzi"
 msgid "Catalan"
 msgstr "Katalan"
 
-#: app/views/design.html:264
+#: app/views/design.html:262
 #, fuzzy
 msgid "Change Color"
 msgstr "Kolorea hauta ezazu"
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr "Interneteko sarbidea egiaztatu..."
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr "Python egiaztatu..."
 
@@ -169,21 +181,21 @@ msgstr "Txinera"
 msgid "Choose a color:"
 msgstr "Kolorea hauta ezazu"
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr ""
 "Klik egizu hemen <b>Icestudio aplikazioaren bertsio berria</b> deskargatzeko"
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr "Klik egizu hemen <b>driverrak eguneratzeko</b>"
 
-#: app/scripts/services/drivers.js:413 app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613 app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440 app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644 app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr "Instalatzeko hemen klik egin"
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr "Klik egizu ikusteko"
 
@@ -195,63 +207,63 @@ msgstr "Datu busentzat ordularia ez dago onetsia"
 msgid "Clone"
 msgstr "Klonatu"
 
-#: app/scripts/controllers/menu.js:565 app/views/version.html:80
+#: app/scripts/controllers/menu.js:581 app/views/version.html:80
 msgid "Close"
 msgstr "Itxi"
 
-#: app/views/design.html:324 app/views/menu.html:791
+#: app/views/design.html:314 app/views/menu.html:809
 msgid "Code"
 msgstr "Kodea"
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr "Bilduma"
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr "Bildumaren informazioa"
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr "{{collection}} bildumaren informazioa zehaztuta gabe dago"
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr "{{name}} bilduma gehitu da"
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr "{{name}} bilduma ez da ordeztu"
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr "{{name}} bilduma ezabatu da"
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr "{{name}} bilduma ordeztu da"
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr "{{name}} bilduma hautatu da"
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr "Bildumak"
 
-#: app/scripts/controllers/menu.js:1229 app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249 app/views/menu.html:489
 msgid "Command output"
 msgstr "Komando irteera"
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr "Komunitatearen foroa"
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr "Konfigurazioa ez da osatu"
 
-#: app/views/design.html:312 app/views/menu.html:783
+#: app/views/design.html:304 app/views/menu.html:801
 msgid "Constant"
 msgstr "Konstantea"
 
@@ -260,7 +272,7 @@ msgstr "Konstantea"
 msgid "Constant names"
 msgstr "Konstantea"
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr "Bihurtu"
 
@@ -268,11 +280,11 @@ msgstr "Bihurtu"
 msgid "Copy"
 msgstr "Kopiatu"
 
-#: app/scripts/services/forms.js:400 app/views/design.html:137
+#: app/scripts/services/forms.js:400 app/views/design.html:136
 msgid "Coral"
 msgstr "Korala"
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr "Env birtuala sortu..."
 
@@ -299,15 +311,15 @@ msgstr "Berde-iluna"
 msgid "Dark Orange"
 msgstr "Laranja-iluna"
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr "Berde-iluna"
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr "Laranja-iluna"
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr "Datu-fitxa"
 
@@ -315,41 +327,45 @@ msgstr "Datu-fitxa"
 msgid "Decimal"
 msgstr "Hamartarra"
 
-#: app/scripts/services/forms.js:394 app/views/design.html:123
+#: app/scripts/services/forms.js:394 app/views/design.html:122
 #, fuzzy
 msgid "Deep Pink"
 msgstr "Larrosa"
 
-#: app/scripts/services/forms.js:439 app/views/design.html:236
+#: app/scripts/services/forms.js:439 app/views/design.html:234
 #, fuzzy
 msgid "Deep Sky Blue"
 msgstr "Urdina"
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr "Lehenetsia"
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr ""
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr "Azalpena"
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr "Desgaitu"
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr "Aplikazioa itxi nahi al duzu?"
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr "{{name}} bilduma ezabatu nahi al duzu?"
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr "Ordeztu nahi al duzu?"
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr "Dokumentazioa"
 
@@ -357,21 +373,26 @@ msgstr "Dokumentazioa"
 msgid "Don't display"
 msgstr "Ez erakutsi"
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr "Driverrak"
 
 #: app/scripts/services/drivers.js:252 app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr "Driverrak desgaitu dira"
 
 #: app/scripts/services/drivers.js:230 app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr "Driverrak gaitu dira"
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+#, fuzzy
+msgid "Duplicate"
+msgstr "Irteera-etiketa"
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr "FPGAren E/S portuak bikoiztu dira"
 
@@ -388,11 +409,11 @@ msgstr "Holandako"
 msgid "Edit"
 msgstr "Aldatu"
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr "Bildumaren izena aldatu"
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr "Onartu"
 
@@ -425,15 +446,15 @@ msgstr "Sarrerako portuak sar itzazu"
 msgid "Enter the python path"
 msgstr "Kanpoko bildumen bidea sar ezazu"
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr "Urrutiko ostalariaren izena sar ezazu erabiltzailea@host"
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr "Errorea: {{error}}"
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr "Akatsak daude diseinuan"
 
@@ -441,7 +462,7 @@ msgstr "Akatsak daude diseinuan"
 msgid "Examples"
 msgstr "Adibideak"
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr "Exekutatu urrutiko {{label}} ..."
 
@@ -449,29 +470,29 @@ msgstr "Exekutatu urrutiko {{label}} ..."
 msgid "Export"
 msgstr "Esportatu"
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395 app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr "Azpimodulua esportatu"
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr "Kanpoko bildumak"
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr "Kanpoko bildumak eguneratu dira"
 
-#: app/views/menu.html:383
+#: app/views/menu.html:401
 #, fuzzy
 msgid "External plugins"
 msgstr "Kanpoko bildumak"
 
-#: app/scripts/controllers/menu.js:780
+#: app/scripts/controllers/menu.js:800
 #, fuzzy
 msgid "External plugins updated"
 msgstr "Kanpoko bildumak eguneratu dira"
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr "FPGAren E/S portuak definitu gabe daude"
 
@@ -479,7 +500,7 @@ msgstr "FPGAren E/S portuak definitu gabe daude"
 msgid "FPGA pin"
 msgstr "FPGA pina"
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr "FPGA baliabideak"
 
@@ -495,18 +516,18 @@ msgstr ""
 msgid "File"
 msgstr "Fitxategia"
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr ""
 "Proiektuaren direktorioan {{file}} fitxategia dagoeneko bada. Fitxategia "
 "ordeztu nahi al duzu?"
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr "Ez dago {{file}} izeneko fitxategirik"
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr "{{file}} fitxategia inportatu da"
 
@@ -514,7 +535,7 @@ msgstr "{{file}} fitxategia inportatu da"
 msgid "Find"
 msgstr ""
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr "Edukia doitu"
 
@@ -522,8 +543,8 @@ msgstr "Edukia doitu"
 msgid "French"
 msgstr "Frantsesa"
 
-#: app/scripts/services/forms.js:385 app/views/design.html:173
-#: app/views/design.html:98
+#: app/scripts/services/forms.js:385 app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr "Fuksia"
 
@@ -535,7 +556,7 @@ msgstr "Galegoa"
 msgid "German"
 msgstr "Alemaniako"
 
-#: app/scripts/services/forms.js:409 app/views/design.html:158
+#: app/scripts/services/forms.js:409 app/views/design.html:157
 msgid "Gold"
 msgstr "Urrea"
 
@@ -548,11 +569,11 @@ msgstr "Greziera"
 msgid "Green Yellow"
 msgstr "Berde-horia"
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr "Berde-horia"
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr "Laguntza"
 
@@ -565,34 +586,34 @@ msgstr "Hamaseitarra"
 msgid "Icestudio is part of"
 msgstr "Icestudioren hastapenak"
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid ""
 "If you have blank IN/OUT pins, it's because there is no equivalent in this "
 "board"
 msgstr "SARRERA/IRTEERA pinak hutsik badaude, zure plakan baliokiderik ez da"
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr "Irudia"
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr "{{name}} izeneko irudia gorde da"
 
-#: app/scripts/services/forms.js:388 app/views/design.html:109
+#: app/scripts/services/forms.js:388 app/views/design.html:108
 #, fuzzy
 msgid "Indian Red"
 msgstr "Gorri-indioa"
 
-#: app/views/design.html:330 app/views/menu.html:795
+#: app/views/design.html:319 app/views/menu.html:813
 msgid "Information"
 msgstr "Informazioa"
 
-#: app/views/design.html:282 app/views/menu.html:760
+#: app/views/design.html:279 app/views/menu.html:778
 msgid "Input"
 msgstr "Sarrera"
 
-#: app/views/design.html:294 app/views/menu.html:769
+#: app/views/design.html:289 app/views/menu.html:787
 msgid "Input label"
 msgstr "Sarrera-etiketa"
 
@@ -615,23 +636,23 @@ msgstr ""
 msgid "Input ports"
 msgstr "Sarrerako portuak sar itzazu"
 
-#: app/views/menu.html:635
+#: app/views/menu.html:653
 #, fuzzy
 msgid "Install (Stable)"
 msgstr "Instalatu"
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
 msgstr ""
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid ""
 "Install the <b>STABLE Toolchain</b>. This operation requires Internet "
 "connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
 "allow the toolchain installation</p> <p>Do you want to continue?</p>"
 msgstr ""
 
-#: app/scripts/services/tools.js:1144
+#: app/scripts/services/tools.js:1255
 #, fuzzy
 msgid ""
 "Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
@@ -640,7 +661,7 @@ msgstr ""
 "Toolchain-a eguneratuko da. Operazio horrek Interneteko sarbidea behar du. "
 "Jarraitu nahi al duzu?"
 
-#: app/scripts/services/tools.js:1166
+#: app/scripts/services/tools.js:1277
 #, fuzzy
 msgid ""
 "Install the LATEST STABLE toolchain. It will be downloaded. This operation "
@@ -649,52 +670,52 @@ msgstr ""
 "Toolchain-a eguneratuko da. Operazio horrek Interneteko sarbidea behar du. "
 "Jarraitu nahi al duzu?"
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr "Instalazioa amaitu da"
 
-#: app/scripts/services/tools.js:1274
+#: app/scripts/services/tools.js:1385
 #, fuzzy
 msgid "Installing"
 msgstr "Instalatu"
 
-#: app/scripts/services/drivers.js:421 app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447 app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr "Interneteko sarbidea behar da"
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr "<i>Pull up</i> konexio baliogabea:<br>blokea dagoeneko konektatua dago"
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr ""
 "<i>Pull up</i> konexio baliogabea:<br><i>sarrera</i> blokeak soilik dira "
 "onargarriak"
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr ""
 "Bloke konexio baliogabeak:<br><i>Pull up</i> -a dagoeneko konektatua dago"
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr "{{name}} bilduma baliogabea"
 
-#: app/scripts/services/graph.js:254 app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262 app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr "Konexio baliogabea"
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr "Konexio baliogabea: {{a}} → {{b}}"
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr "Sarrerako konexio anitzak baliogabeak"
 
-#: app/scripts/services/project.js:499 app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510 app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr "Proiektuaren formatua baliogabea da"
 
@@ -711,7 +732,7 @@ msgstr "Gaztelera"
 msgid "Korean"
 msgstr ""
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
 msgstr ""
 
@@ -720,7 +741,7 @@ msgstr ""
 msgid "Label updated"
 msgstr "Etiketa freskatua dago"
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr "Hizkuntza"
 
@@ -728,17 +749,17 @@ msgstr "Hizkuntza"
 msgid "Light"
 msgstr ""
 
-#: app/scripts/services/forms.js:448 app/views/design.html:257
+#: app/scripts/services/forms.js:448 app/views/design.html:255
 #, fuzzy
 msgid "Light Gray"
 msgstr "\"\""
 
-#: app/scripts/services/forms.js:430 app/views/design.html:215
+#: app/scripts/services/forms.js:430 app/views/design.html:213
 #, fuzzy
 msgid "Light Sea Green"
 msgstr "\"\""
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr "Kargatu"
 
@@ -746,20 +767,20 @@ msgstr "Kargatu"
 msgid "Local parameter"
 msgstr "Parametro lokala"
 
-#: app/views/menu.html:404
+#: app/views/menu.html:422
 #, fuzzy
 msgid "Logging enabled"
 msgstr "Driverrak gaitu dira"
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
 msgstr ""
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr "Busaren tamaina maximoa: 96 bit"
 
@@ -768,11 +789,11 @@ msgstr "Busaren tamaina maximoa: 96 bit"
 msgid "Medium Violet Red"
 msgstr "Bioleta"
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr "Bioleta"
 
-#: app/views/design.html:318 app/views/menu.html:787
+#: app/views/design.html:309 app/views/menu.html:805
 msgid "Memory"
 msgstr "Memoria"
 
@@ -781,7 +802,7 @@ msgstr "Memoria"
 msgid "Memory blocks"
 msgstr "Blokea inportatu"
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr "Izena"
 
@@ -789,7 +810,7 @@ msgstr "Izena"
 msgid "Name of the paired labels"
 msgstr ""
 
-#: app/scripts/services/forms.js:445 app/views/design.html:250
+#: app/scripts/services/forms.js:445 app/views/design.html:248
 msgid "Navy"
 msgstr "\"\""
 
@@ -803,15 +824,19 @@ msgstr ""
 
 #: app/views/design.html:80
 #, fuzzy
-msgid "New Name:"
+msgid "New Name"
 msgstr "Izena"
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr ""
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr "Ez dago gordeta bildumarik"
 
-#: app/scripts/app.js:58 app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57 app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr "Ados"
 
@@ -820,7 +845,7 @@ msgstr "Ados"
 msgid "Olive Drab"
 msgstr "Oliba-motela"
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr "Oliba-motela"
 
@@ -828,7 +853,7 @@ msgstr "Oliba-motela"
 msgid "Open"
 msgstr "Ireki"
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr "SVGa ireki"
 
@@ -837,19 +862,19 @@ msgstr "SVGa ireki"
 msgid "Orange Red"
 msgstr "Gorri-laranja"
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr "Gorri-laranja"
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr "Jatorrizko {{file}} fitxategia ez dago"
 
-#: app/views/design.html:288 app/views/menu.html:764
+#: app/views/design.html:284 app/views/menu.html:782
 msgid "Output"
 msgstr "Irteera"
 
-#: app/views/design.html:300 app/views/menu.html:773
+#: app/views/design.html:294 app/views/menu.html:791
 msgid "Output label"
 msgstr "Irteera-etiketa"
 
@@ -868,7 +893,7 @@ msgstr "Irteera-etiketa"
 msgid "Output ports"
 msgstr "Irteera-etiketa"
 
-#: app/views/design.html:306 app/views/menu.html:778
+#: app/views/design.html:299 app/views/menu.html:796
 msgid "Paired labels"
 msgstr ""
 
@@ -876,40 +901,44 @@ msgstr ""
 msgid "Paste"
 msgstr "Itsatsi"
 
-#: app/scripts/controllers/menu.js:731 app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853 app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751 app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873 app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr "Ez da {{path}} izeneko biderik"
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr "Mesedez {{cmd}} exekutatu"
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr "Lehentasunak"
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr ""
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr "Proiektuaren informazioa"
 
-#: app/scripts/controllers/menu.js:935 app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955 app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr "Proiektuaren informazioa eguneratu da"
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr "{{name}} proiektua kargatu da"
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr "{{name}} proiektua gorde da"
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
 msgstr ""
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
 msgstr ""
 
@@ -917,11 +946,7 @@ msgstr ""
 msgid "Quit"
 msgstr "Utzi"
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr "Irakurtzeko soilik"
-
-#: app/scripts/services/forms.js:391 app/views/design.html:116
+#: app/scripts/services/forms.js:391 app/views/design.html:115
 msgid "Red"
 msgstr "Gorria"
 
@@ -933,27 +958,27 @@ msgstr "Berregin"
 msgid "Release History WIKI"
 msgstr ""
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr "Berriro kargatu"
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr "{{name}} urrutiko ostalaria ez dago konektatua"
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr "Urrutiko ostalariaren izena"
 
-#: app/views/menu.html:647 app/views/menu.html:722
+#: app/views/menu.html:665 app/views/menu.html:740
 msgid "Remove"
 msgstr "Ezabatu"
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr "Dena ezabatu"
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
 msgstr ""
 
@@ -961,11 +986,11 @@ msgstr ""
 msgid "Replace One"
 msgstr ""
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr "SVGa berrezarri"
 
-#: app/scripts/services/forms.js:442 app/views/design.html:243
+#: app/scripts/services/forms.js:442 app/views/design.html:241
 #, fuzzy
 msgid "Royal Blue"
 msgstr "Urdina"
@@ -978,7 +1003,7 @@ msgstr "Errusiera"
 msgid "Save"
 msgstr "Gorde"
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr "SVGa gorde"
 
@@ -990,11 +1015,11 @@ msgstr "Gorde honela"
 msgid "Save submodule"
 msgstr "Azpimodulua gorde"
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr "Hautatu"
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr "Dena hautatu"
 
@@ -1011,11 +1036,11 @@ msgstr "Ordularia erakutsi"
 msgid "Slate Blue"
 msgstr "Urdin-arbela"
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr "Urdin-arbela"
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr "Iturburu kodea"
 
@@ -1028,32 +1053,32 @@ msgstr "Gaztelera"
 msgid "Spring Green"
 msgstr "Berde-udaberria"
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr "Berde-udaberria"
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr "Sintetizatua hasi"
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr "Karga hasi"
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr "Egiaztapena hasi"
 
-#: app/scripts/services/forms.js:436 app/views/design.html:229
+#: app/scripts/services/forms.js:436 app/views/design.html:227
 #, fuzzy
 msgid "Steel Blue"
 msgstr "Altzairu-urdina"
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr "Urrutiko fitxategiak sinkronizatu..."
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
 msgstr ""
 
@@ -1069,30 +1094,30 @@ msgstr "Testbench "
 msgid "Thank you very much!"
 msgstr ""
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr "{{name}} bilduma badago"
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
 msgstr ""
 "FPGAaren E/S konfigurazioa galduko da. {{name}} plaka aldatu nahi al duzu?"
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr "Toolchain-a ezabatuko da. Jarraitu nahi al duzu?"
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr "Nightly bertsio berria eskura duzu"
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr "Bertsio egonkor berria eskura duzu"
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
@@ -1100,7 +1125,7 @@ msgstr ""
 "Inportazio operazioak proiektu-bidea behar du.  Uneko proiektua gorde ezazu. "
 "Jarraitu nahi al duzu?"
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr "Proiektua {{name}} plakarentzat diseinatu da."
 
@@ -1110,7 +1135,7 @@ msgid ""
 "              done by an emerging team from"
 msgstr ""
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 msgid ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
 "mode\", lock the keylock to do it."
@@ -1118,14 +1143,14 @@ msgstr ""
 "Azpiko blokearen \"edizio modua\" -n sartzeko, egungo \"edizio modua\" "
 "amaitu behar duzu, kandadua blokeatuta."
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr "Diseinuan zehar nabigatzeko, \"edizio modua\" itxi ezazu."
 
 #: app/scripts/controllers/menu.js:349
 #, fuzzy
 msgid ""
-"To save your design you need to lock the keylock and               go to top "
+"To save your design you need to lock the padlock and               go to top "
 "level design.<br/><br/>If you want to export               this submodule to "
 "a file, execute \"Save as\" command to do it."
 msgstr ""
@@ -1133,33 +1158,33 @@ msgstr ""
 "Azpimodulua diseinu batera esportatu nahi baduzu, \"Gorde honela..\" agindua "
 "exekuta ezazu."
 
-#: app/views/menu.html:320
+#: app/views/menu.html:338
 #, fuzzy
 msgid "Toolbox"
 msgstr "Tresnak"
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr "Toolchain"
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr "Toolchain-a instalatu da"
 
-#: app/scripts/services/drivers.js:594 app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191 app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625 app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300 app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr "Toolchain-a ez da instalatu"
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr "Toolchain-a ezabatu da"
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr "Toolchainaren bertsioa ez dator bat"
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr "Tresnak"
 
@@ -1167,11 +1192,11 @@ msgstr "Tresnak"
 msgid "Turkish"
 msgstr ""
 
-#: app/scripts/services/forms.js:433 app/views/design.html:222
+#: app/scripts/services/forms.js:433 app/views/design.html:220
 msgid "Turquoise"
 msgstr "Turkesa"
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 msgid "UI theme"
 msgstr ""
 
@@ -1179,57 +1204,57 @@ msgstr ""
 msgid "Undo"
 msgstr "Desegin"
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr "Plaka ezezaguna"
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr "{{version}} formatua duen proiektua ez da onartzen"
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr "Izenik gabe"
 
-#: app/views/menu.html:639
+#: app/views/menu.html:657
 #, fuzzy
 msgid "Update (Latest stable)"
 msgstr "Blokearen izena egunera ezazu"
 
-#: app/scripts/controllers/menu.js:1354 app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371 app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr "Kargatu"
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr "Karga egin da"
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr "Egiaztapena egin da"
 
-#: app/views/design.html:510 app/views/menu.html:599
+#: app/views/design.html:498 app/views/menu.html:617
 msgid "Verify"
 msgstr "Egiaztatu"
 
-#: app/scripts/services/utils.js:641 app/views/menu.html:832
+#: app/scripts/services/utils.js:636 app/views/menu.html:850
 msgid "Version"
 msgstr "Bertsioa"
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr "Bertsioaren oharrak"
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr "Ikusi"
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr "Lizentzia ikusi"
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr "Diseinuan abisuak detektatu dira"
 
@@ -1248,63 +1273,72 @@ msgstr "Blokearen formatua okerra da: {{type}}"
 msgid "Wrong block name {{name}}"
 msgstr "{{name}} blokearen izena okerra da"
 
-#: app/scripts/controllers/menu.js:1907
+#: app/scripts/controllers/menu.js:1925
 #, fuzzy
 msgid "Wrong new name!"
 msgstr "Portuaren izena okerra da: {{name}}"
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr "Proiektuaren formatua okerra da: {{name}}"
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr "Urrutiko ostalariaren {{name}} izena okerra da"
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
 msgstr ""
 
-#: app/scripts/services/forms.js:412 app/views/design.html:166
+#: app/scripts/services/forms.js:412 app/views/design.html:164
 msgid "Yellow"
 msgstr "Horia"
 
-#: app/scripts/controllers/menu.js:394
+#: app/scripts/controllers/menu.js:409
 #, fuzzy
 msgid ""
-"You are editing a submodule, if you save it, you save only               the "
-"submodule (in this situation \"save as\" works like               \"export "
-"module\"), Do you like to continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 msgstr ""
 "Azpi modulua editatzen ari zara, gordetzen baduzu, azpimodulua gordeko duzu "
 "soilik (hala bada,  Gorde honela\" \"modulua esportatu\"ren antzera lan "
 "egiten du). Jarraitu nahi duzu?"
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+msgstr ""
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr "Dagoen moduan karga dezakezu edo {{name}} plakarako bihurtu"
 
-#: app/scripts/controllers/menu.js:1328
+#: app/scripts/controllers/menu.js:1347
+#, fuzzy
 msgid ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 msgstr ""
 "Goi mailako diseinuan soilik eraiki dezakezu. Azpimoduluen barnean, soilik "
 "<strong> baiezta dezakezu</strong>"
 
-#: app/scripts/controllers/menu.js:1355
+#: app/scripts/controllers/menu.js:1372
+#, fuzzy
 msgid ""
-"You can only upload  your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
 msgstr ""
-"Zure diseinua kargatzeko, goi mailako diseinuan egin behar duzu.  "
-"Azpimoduluen barnean, soilik <strong> baiezta dezakezu</strong>"
+"Goi mailako diseinuan soilik eraiki dezakezu. Azpimoduluen barnean, soilik "
+"<strong> baiezta dezakezu</strong>"
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr "Aldaketak galduko dituzu gordetzen ez badituzu"
 
@@ -1312,25 +1346,35 @@ msgstr "Aldaketak galduko dituzu gordetzen ez badituzu"
 msgid "back"
 msgstr "atzera"
 
-#: app/scripts/services/drivers.js:412 app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439 app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr "{{app}} behar da"
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr "{{board}} plakaren datasheet-a ez zehaztua"
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr "{{board}} plakaren pinout-a ez zehaztua"
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr "{{board}} plakaren arauak ez daude definituta"
 
-#: app/scripts/controllers/menu.js:483 app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499 app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr "{{name}} esportatu da"
+
+#~ msgid "Read only"
+#~ msgstr "Irakurtzeko soilik"
+
+#~ msgid ""
+#~ "You can only upload  your design at top-level design. Inside submodules "
+#~ "you only can <strong>Verify</strong>"
+#~ msgstr ""
+#~ "Zure diseinua kargatzeko, goi mailako diseinuan egin behar duzu.  "
+#~ "Azpimoduluen barnean, soilik <strong> baiezta dezakezu</strong>"
 
 #~ msgid "Choose a color"
 #~ msgstr "Kolorea hauta ezazu"

--- a/app/resources/locale/fr_FR/fr_FR.po
+++ b/app/resources/locale/fr_FR/fr_FR.po
@@ -12,16 +12,27 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: app/views/design.html:20
-#, fuzzy
-msgid ": '}} {{'Unlock to edit block !"
-msgstr "Déverrouillez pour éditer le bloc !"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
+msgstr ""
 
-#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr "<b>Débrancher</b> et <b>reconnecter</b> la carte"
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
 msgstr "À propos d'Icestudio"
 
@@ -29,11 +40,11 @@ msgstr "À propos d'Icestudio"
 msgid "Acknowledgment"
 msgstr ""
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr "Ajouter"
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr "Ajouter un bloc pour commencer"
 
@@ -45,24 +56,24 @@ msgstr "Ajouter un bloc"
 msgid "Address format"
 msgstr "Format de l'adresse"
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr "Toutes les collections ont été supprimées"
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr ""
 "Toutes les collections enregistrées seront perdues. Voulez-vous continuer ?"
 
-#: app/scripts/services/tools.js:1389
+#: app/scripts/services/tools.js:1500
 msgid "At least Python 3.7 is required"
 msgstr ""
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr "Auteur"
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr "Basique"
 
@@ -74,6 +85,10 @@ msgstr "Basque"
 msgid "Binary"
 msgstr "Binaire"
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr ""
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -83,7 +98,7 @@ msgstr "Binaire"
 msgid "Block updated"
 msgstr "Bloc mis à jour"
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr "Bloc {{name}} importé"
 
@@ -91,58 +106,52 @@ msgstr "Bloc {{name}} importé"
 msgid "Blocks"
 msgstr "Blocs"
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr "Carte"
 
-#: app/views/menu.html:367 app/views/menu.html:458
+#: app/views/menu.html:385 app/views/menu.html:476
 msgid "Board rules"
 msgstr "Règles de la carte"
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr "Règles de la carte désactivées"
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr "Règles de la carte activées"
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr "Carte {{name}} déconnectée"
 
-#: app/scripts/services/tools.js:607 app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718 app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr "Carte {{name}} non disponible"
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr "Carte {{name}} non connectée"
 
-#: app/scripts/app.js:185 app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184 app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr "Carte {{name}} séléctionnée"
 
-#: app/scripts/services/tools.js:596 app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707 app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr "Bootloader non activé"
 
-#: app/scripts/controllers/menu.js:1327 app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346 app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr "Construire"
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr "Construction terminée"
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr ""
-"ATTENTION ! : Les modifications seront également appliquées dans toutes les "
-"copies du bloc"
-
-#: app/scripts/app.js:59 app/scripts/services/project.js:147
+#: app/scripts/app.js:58 app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -150,15 +159,15 @@ msgstr "Annuler"
 msgid "Catalan"
 msgstr "Catalan"
 
-#: app/views/design.html:264
+#: app/views/design.html:262
 msgid "Change Color"
 msgstr "Recolorer"
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr "Vérifier la connexion Internet..."
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr "Vérifier Python..."
 
@@ -171,20 +180,20 @@ msgstr "Chinois"
 msgid "Choose a color:"
 msgstr "Choisir une couleur"
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr "Cliquer ici pour <b>télécharger une nouvelle version</b> de Icestudio"
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr "Cliquer ici pour <b>installer les drivers</b>"
 
-#: app/scripts/services/drivers.js:413 app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613 app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440 app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644 app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr "Cliquer ici pour l'installer"
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr "Cliquer ici pour ouvrir"
 
@@ -196,63 +205,63 @@ msgstr "Horloge non autorisée pour les bus de données"
 msgid "Clone"
 msgstr "Cloner"
 
-#: app/scripts/controllers/menu.js:565 app/views/version.html:80
+#: app/scripts/controllers/menu.js:581 app/views/version.html:80
 msgid "Close"
 msgstr "Fermer"
 
-#: app/views/design.html:324 app/views/menu.html:791
+#: app/views/design.html:314 app/views/menu.html:809
 msgid "Code"
 msgstr "Code"
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr "Collection"
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr "Informations sur la collection"
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr "Informations sur la collection {{name}} non définies"
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr "Collection {{name}} ajoutée"
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr "Collection {{name}} non remplacée"
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr "Collection {{name}} supprimée"
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr "Collection {{name}} remplacée"
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr "Collection {{name}} sélectionée"
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr "Collections"
 
-#: app/scripts/controllers/menu.js:1229 app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249 app/views/menu.html:489
 msgid "Command output"
 msgstr "Sortie de Commandes"
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr "Forum communautaire"
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr "Configuration incomplète"
 
-#: app/views/design.html:312 app/views/menu.html:783
+#: app/views/design.html:304 app/views/menu.html:801
 msgid "Constant"
 msgstr "Constante"
 
@@ -261,7 +270,7 @@ msgstr "Constante"
 msgid "Constant names"
 msgstr "Constante"
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr "Convertir"
 
@@ -269,11 +278,11 @@ msgstr "Convertir"
 msgid "Copy"
 msgstr "Copier"
 
-#: app/scripts/services/forms.js:400 app/views/design.html:137
+#: app/scripts/services/forms.js:400 app/views/design.html:136
 msgid "Coral"
 msgstr "Corail"
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr "Créer l'environnement virtuel..."
 
@@ -299,15 +308,15 @@ msgstr "Vert foncé"
 msgid "Dark Orange"
 msgstr "Orange foncé"
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr "Vert foncé"
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr "Orange foncé"
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr "Documentation"
 
@@ -315,41 +324,45 @@ msgstr "Documentation"
 msgid "Decimal"
 msgstr "Décimal"
 
-#: app/scripts/services/forms.js:394 app/views/design.html:123
+#: app/scripts/services/forms.js:394 app/views/design.html:122
 #, fuzzy
 msgid "Deep Pink"
 msgstr "Rose profond"
 
-#: app/scripts/services/forms.js:439 app/views/design.html:236
+#: app/scripts/services/forms.js:439 app/views/design.html:234
 #, fuzzy
 msgid "Deep Sky Blue"
 msgstr "Bleu ciel profond"
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr "Défaut"
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr ""
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr "Description"
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr "Désactiver"
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr "Voulez-vous fermer l'application ?"
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr "Voulez-vous supprimer la collection {{name}} ?"
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr "Voulez-vous le remplacer ?"
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr "Documentation"
 
@@ -357,21 +370,26 @@ msgstr "Documentation"
 msgid "Don't display"
 msgstr "Ne pas afficher"
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr "Pilote"
 
 #: app/scripts/services/drivers.js:252 app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr "Pilote désactivé"
 
 #: app/scripts/services/drivers.js:230 app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr "Pilote activé"
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+#, fuzzy
+msgid "Duplicate"
+msgstr "Label de sortie"
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr "Ports d'entrée/sortie FPGA dupliqués"
 
@@ -388,11 +406,11 @@ msgstr "Néerlandais"
 msgid "Edit"
 msgstr "Édition"
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr "Éditer le nom de la collection"
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr "Activer"
 
@@ -424,15 +442,15 @@ msgstr "Entrer les ports d'entrée"
 msgid "Enter the python path"
 msgstr "Entrer les ports d'entrée"
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr "Entrer le nom d'hôte distant user@host"
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr "Erreur : {{error}}"
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr "Erreurs détectées dans le design"
 
@@ -440,7 +458,7 @@ msgstr "Erreurs détectées dans le design"
 msgid "Examples"
 msgstr "Exemples"
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr "Exécuter à distance {{label}} ..."
 
@@ -448,27 +466,27 @@ msgstr "Exécuter à distance {{label}} ..."
 msgid "Export"
 msgstr "Exporter"
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395 app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr "Exporter le sous-module"
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr "Collections externes"
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr "Collections externes mises à jour"
 
-#: app/views/menu.html:383
+#: app/views/menu.html:401
 msgid "External plugins"
 msgstr "Plugins externes"
 
-#: app/scripts/controllers/menu.js:780
+#: app/scripts/controllers/menu.js:800
 msgid "External plugins updated"
 msgstr "Plugins externes mis a jour"
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr "Ports d'entrée/sortie FPGA non définis"
 
@@ -476,7 +494,7 @@ msgstr "Ports d'entrée/sortie FPGA non définis"
 msgid "FPGA pin"
 msgstr "Pin FPGA"
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr "Ressources FPGA"
 
@@ -492,18 +510,18 @@ msgstr ""
 msgid "File"
 msgstr "Fichier"
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr ""
 "Le fichier {{file}} existe déjà dans le chemin du projet. Voulez vous le "
 "remplacer ?"
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr "Le fichier {{file}} n'existe pas"
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr "Fichier {{file}} importé"
 
@@ -511,7 +529,7 @@ msgstr "Fichier {{file}} importé"
 msgid "Find"
 msgstr "Chercher"
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr "Adapter le contenu"
 
@@ -519,8 +537,8 @@ msgstr "Adapter le contenu"
 msgid "French"
 msgstr "Français"
 
-#: app/scripts/services/forms.js:385 app/views/design.html:173
-#: app/views/design.html:98
+#: app/scripts/services/forms.js:385 app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr "Fuchsia"
 
@@ -532,7 +550,7 @@ msgstr "Galicien"
 msgid "German"
 msgstr "Allemand"
 
-#: app/scripts/services/forms.js:409 app/views/design.html:158
+#: app/scripts/services/forms.js:409 app/views/design.html:157
 msgid "Gold"
 msgstr "Or"
 
@@ -545,11 +563,11 @@ msgstr "Grec"
 msgid "Green Yellow"
 msgstr "Jaune-vert"
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr "Jaune-vert"
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr "Aide"
 
@@ -562,7 +580,7 @@ msgstr "Hexadécimal"
 msgid "Icestudio is part of"
 msgstr "Icestudio Inception"
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid ""
 "If you have blank IN/OUT pins, it's because there is no equivalent in this "
 "board"
@@ -570,28 +588,28 @@ msgstr ""
 "Si vous avez des pins d'entrée/sortie vides, c'est qu'il n'y a pas "
 "d'équivalent pour cette carte"
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr "Image"
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr "Image {{name}} sauvegardée"
 
-#: app/scripts/services/forms.js:388 app/views/design.html:109
+#: app/scripts/services/forms.js:388 app/views/design.html:108
 #, fuzzy
 msgid "Indian Red"
 msgstr "Rouge indien"
 
-#: app/views/design.html:330 app/views/menu.html:795
+#: app/views/design.html:319 app/views/menu.html:813
 msgid "Information"
 msgstr "Information"
 
-#: app/views/design.html:282 app/views/menu.html:760
+#: app/views/design.html:279 app/views/menu.html:778
 msgid "Input"
 msgstr "Entrée"
 
-#: app/views/design.html:294 app/views/menu.html:769
+#: app/views/design.html:289 app/views/menu.html:787
 msgid "Input label"
 msgstr "Label d'entrée"
 
@@ -614,22 +632,22 @@ msgstr ""
 msgid "Input ports"
 msgstr "Entrer les ports d'entrée"
 
-#: app/views/menu.html:635
+#: app/views/menu.html:653
 msgid "Install (Stable)"
 msgstr ""
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
 msgstr ""
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid ""
 "Install the <b>STABLE Toolchain</b>. This operation requires Internet "
 "connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
 "allow the toolchain installation</p> <p>Do you want to continue?</p>"
 msgstr ""
 
-#: app/scripts/services/tools.js:1144
+#: app/scripts/services/tools.js:1255
 msgid ""
 "Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
 "requires Internet connection. Do you want to continue?"
@@ -637,7 +655,7 @@ msgstr ""
 "La toolchain va être mise à jour. Cette opération a besoin d'une connexion "
 "Internet.Voulez-vous continuer ?"
 
-#: app/scripts/services/tools.js:1166
+#: app/scripts/services/tools.js:1277
 msgid ""
 "Install the LATEST STABLE toolchain. It will be downloaded. This operation "
 "requires Internet connection. Do you want to continue?"
@@ -645,50 +663,50 @@ msgstr ""
 "Installer la derniere toolchain stable. Cette opération a besoin d'une "
 "connexion Internet.Voulez-vous continuer ?"
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr "Installation terminée"
 
-#: app/scripts/services/tools.js:1274
+#: app/scripts/services/tools.js:1385
 msgid "Installing"
 msgstr "Installation"
 
-#: app/scripts/services/drivers.js:421 app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447 app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr "Une connexion Internet est requise"
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr "Connexion de <i>Pull up</i> invalide:<br>le bloc est déjà connecté"
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr ""
 "Connexion de <i>Pull up</i> invalide:<br>seules les <i>entrées</i> sont "
 "autorisées"
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr "Connexion de bloc invalide:<br> <i>Pull up</i> déjà connectée"
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr "Collection {{name}} invalide"
 
-#: app/scripts/services/graph.js:254 app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262 app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr "Connexion invalide"
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr "Connexion invalide: {{a}} → {{b}}"
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr "Connexions de multiples entrées invalides"
 
-#: app/scripts/services/project.js:499 app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510 app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr "Format de projet invalide"
 
@@ -705,7 +723,7 @@ msgstr "Espagnol"
 msgid "Korean"
 msgstr ""
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
 msgstr "Chercher Label"
 
@@ -714,7 +732,7 @@ msgstr "Chercher Label"
 msgid "Label updated"
 msgstr "Bloc mis à jour"
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr "Langue"
 
@@ -722,17 +740,17 @@ msgstr "Langue"
 msgid "Light"
 msgstr ""
 
-#: app/scripts/services/forms.js:448 app/views/design.html:257
+#: app/scripts/services/forms.js:448 app/views/design.html:255
 #, fuzzy
 msgid "Light Gray"
 msgstr "Vert mer clair"
 
-#: app/scripts/services/forms.js:430 app/views/design.html:215
+#: app/scripts/services/forms.js:430 app/views/design.html:213
 #, fuzzy
 msgid "Light Sea Green"
 msgstr "Vert mer clair"
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr "Charger"
 
@@ -740,19 +758,19 @@ msgstr "Charger"
 msgid "Local parameter"
 msgstr "Paramètre local"
 
-#: app/views/menu.html:404
+#: app/views/menu.html:422
 msgid "Logging enabled"
 msgstr ""
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
 msgstr ""
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr "Taille maximale du bus : 96 bits"
 
@@ -761,11 +779,11 @@ msgstr "Taille maximale du bus : 96 bits"
 msgid "Medium Violet Red"
 msgstr "Rouge-violet moyen"
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr "Rouge-violet moyen"
 
-#: app/views/design.html:318 app/views/menu.html:787
+#: app/views/design.html:309 app/views/menu.html:805
 msgid "Memory"
 msgstr "Mémoire"
 
@@ -774,7 +792,7 @@ msgstr "Mémoire"
 msgid "Memory blocks"
 msgstr "Importer un bloc"
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr "Nom"
 
@@ -782,7 +800,7 @@ msgstr "Nom"
 msgid "Name of the paired labels"
 msgstr ""
 
-#: app/scripts/services/forms.js:445 app/views/design.html:250
+#: app/scripts/services/forms.js:445 app/views/design.html:248
 msgid "Navy"
 msgstr "Bleu marine"
 
@@ -795,15 +813,20 @@ msgid "New Color:"
 msgstr "New Couleur:"
 
 #: app/views/design.html:80
-msgid "New Name:"
+#, fuzzy
+msgid "New Name"
 msgstr "Nouveau Nom:"
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr ""
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr "Pas de collections sauvegardées"
 
-#: app/scripts/app.js:58 app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57 app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr "OK"
 
@@ -812,7 +835,7 @@ msgstr "OK"
 msgid "Olive Drab"
 msgstr "Vert olive"
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr "Vert olive"
 
@@ -820,7 +843,7 @@ msgstr "Vert olive"
 msgid "Open"
 msgstr "Ouvrir"
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr "Ouvrir SVG"
 
@@ -829,19 +852,19 @@ msgstr "Ouvrir SVG"
 msgid "Orange Red"
 msgstr "Rouge-orangé"
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr "Rouge-orangé"
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr "Le fichier original {{file}} n'existe pas"
 
-#: app/views/design.html:288 app/views/menu.html:764
+#: app/views/design.html:284 app/views/menu.html:782
 msgid "Output"
 msgstr "Sortie"
 
-#: app/views/design.html:300 app/views/menu.html:773
+#: app/views/design.html:294 app/views/menu.html:791
 msgid "Output label"
 msgstr "Label de sortie"
 
@@ -860,7 +883,7 @@ msgstr "Label de sortie"
 msgid "Output ports"
 msgstr "Label de sortie"
 
-#: app/views/design.html:306 app/views/menu.html:778
+#: app/views/design.html:299 app/views/menu.html:796
 msgid "Paired labels"
 msgstr ""
 
@@ -868,40 +891,44 @@ msgstr ""
 msgid "Paste"
 msgstr "Coller"
 
-#: app/scripts/controllers/menu.js:731 app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853 app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751 app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873 app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr "Le chemin {{path}} n'existe pas"
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr "Veuillez exécuter : {{cmd}}"
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr "Préférences"
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr ""
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr "Informations du projet"
 
-#: app/scripts/controllers/menu.js:935 app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955 app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr "Informations du projet mises à jour"
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr "Projet {{name}} chargé"
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr "Projet {{name}} sauvegardé"
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
 msgstr ""
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
 msgstr ""
 
@@ -909,11 +936,7 @@ msgstr ""
 msgid "Quit"
 msgstr "Quitter"
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr "Lecture seule"
-
-#: app/scripts/services/forms.js:391 app/views/design.html:116
+#: app/scripts/services/forms.js:391 app/views/design.html:115
 msgid "Red"
 msgstr "Rouge"
 
@@ -925,27 +948,27 @@ msgstr "Refaire"
 msgid "Release History WIKI"
 msgstr ""
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr "Recharger"
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr "Hôte distant {{name}} non connecté"
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr "Nom d'hôte distant"
 
-#: app/views/menu.html:647 app/views/menu.html:722
+#: app/views/menu.html:665 app/views/menu.html:740
 msgid "Remove"
 msgstr "Supprimer"
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr "Supprimer tout"
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
 msgstr "Remplacer tous"
 
@@ -953,11 +976,11 @@ msgstr "Remplacer tous"
 msgid "Replace One"
 msgstr "Remplacer un"
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr "Réinitialiser le SVG"
 
-#: app/scripts/services/forms.js:442 app/views/design.html:243
+#: app/scripts/services/forms.js:442 app/views/design.html:241
 #, fuzzy
 msgid "Royal Blue"
 msgstr "Bleu royal"
@@ -970,7 +993,7 @@ msgstr "Russe"
 msgid "Save"
 msgstr "Sauvegarder"
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr "Sauvegarder le SVG"
 
@@ -982,11 +1005,11 @@ msgstr "Sauvegarder sous"
 msgid "Save submodule"
 msgstr "Sauvegarder le sous-module"
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr "Sélectionner"
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr "Sélectionner tout"
 
@@ -1003,11 +1026,11 @@ msgstr "Montrer l'horloge"
 msgid "Slate Blue"
 msgstr "Bleu ardoise"
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr "Bleu ardoise"
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr "Code source"
 
@@ -1020,32 +1043,32 @@ msgstr "Espagnol"
 msgid "Spring Green"
 msgstr "Vert printanier"
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr "Vert printanier"
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr "Début de la construction"
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr "Début du téléchargement"
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr "Début de la vérification"
 
-#: app/scripts/services/forms.js:436 app/views/design.html:229
+#: app/scripts/services/forms.js:436 app/views/design.html:227
 #, fuzzy
 msgid "Steel Blue"
 msgstr "Bleu métallisé"
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr "Synchroniser les fichiers distants ..."
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
 msgstr ""
 
@@ -1061,11 +1084,11 @@ msgstr "Testbench"
 msgid "Thank you very much!"
 msgstr ""
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr "La collection {{name}} existe déjà."
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
@@ -1073,19 +1096,19 @@ msgstr ""
 "La configuration actuelle des entrées/sorties du FPGA va être perdue. Voulez-"
 "vous changer pour la carte {{name}}?"
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr "La toolchain va être supprimée. Voulez-vous continuer ?"
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr "Il y a une nouvelle version nightly disponible"
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr "Il y a une nouvelle version stable disponible"
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
@@ -1093,7 +1116,7 @@ msgstr ""
 "Cette opération d'importation requiert un chemin de projet. Vous devez "
 "sauvegarder le projet actuel. Voulez vous continuer ?"
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr "Ce projet est conçu pour la carte {{name}}"
 
@@ -1103,7 +1126,7 @@ msgid ""
 "              done by an emerging team from"
 msgstr ""
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 msgid ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
 "mode\", lock the keylock to do it."
@@ -1111,14 +1134,14 @@ msgstr ""
 "Pour rentrer en \"mode édition\" du bloc de niveau inférieur, vous devez "
 "terminer le \"mode édition\" courant et verrouiller le cadenas."
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr "Pour explorer le design, vous devez fermer le \"mode édition\"."
 
 #: app/scripts/controllers/menu.js:349
 #, fuzzy
 msgid ""
-"To save your design you need to lock the keylock and               go to top "
+"To save your design you need to lock the padlock and               go to top "
 "level design.<br/><br/>If you want to export               this submodule to "
 "a file, execute \"Save as\" command to do it."
 msgstr ""
@@ -1126,32 +1149,32 @@ msgstr ""
 "design de plus haut-niveau.<br/><br/>Si vous voulez exporter ce sous-module "
 "dans un fichier, exécutez la commande \"Sauvegarder sous\"."
 
-#: app/views/menu.html:320
+#: app/views/menu.html:338
 msgid "Toolbox"
 msgstr "Boite a Outils"
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr "Toolchain"
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr "La toolchain est installée"
 
-#: app/scripts/services/drivers.js:594 app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191 app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625 app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300 app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr "La toolchain n'est pas installée"
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr "Toolchain supprimée"
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr "La version de la toolchain ne correspond pas"
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr "Outils"
 
@@ -1159,11 +1182,11 @@ msgstr "Outils"
 msgid "Turkish"
 msgstr ""
 
-#: app/scripts/services/forms.js:433 app/views/design.html:222
+#: app/scripts/services/forms.js:433 app/views/design.html:220
 msgid "Turquoise"
 msgstr "Turquoise"
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 msgid "UI theme"
 msgstr ""
 
@@ -1171,56 +1194,56 @@ msgstr ""
 msgid "Undo"
 msgstr "Revenir en arrière"
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr "Carte inconnue"
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr "Format {{version}} de projet non supporté"
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr "Sans titre"
 
-#: app/views/menu.html:639
+#: app/views/menu.html:657
 msgid "Update (Latest stable)"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1354 app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371 app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr "Télécharger"
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr "Téléchargement terminé"
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr "Vérification faite"
 
-#: app/views/design.html:510 app/views/menu.html:599
+#: app/views/design.html:498 app/views/menu.html:617
 msgid "Verify"
 msgstr "Vérifier"
 
-#: app/scripts/services/utils.js:641 app/views/menu.html:832
+#: app/scripts/services/utils.js:636 app/views/menu.html:850
 msgid "Version"
 msgstr "Version"
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr "Notes de version"
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr "Vue"
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr "Voir la licence"
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr "Avertissements détectés dans le design"
 
@@ -1239,65 +1262,74 @@ msgstr "Mauvais format de bloc: {{type}}"
 msgid "Wrong block name {{name}}"
 msgstr "Mauvais nom de bloc {{name}}"
 
-#: app/scripts/controllers/menu.js:1907
+#: app/scripts/controllers/menu.js:1925
 #, fuzzy
 msgid "Wrong new name!"
 msgstr "Mauvais nom de port {{name}}"
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr "Mauvais format de projet: {{name}}"
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr "Mauvais nom d'hôte distant {{name}}"
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
 msgstr ""
 
-#: app/scripts/services/forms.js:412 app/views/design.html:166
+#: app/scripts/services/forms.js:412 app/views/design.html:164
 msgid "Yellow"
 msgstr "Jaune"
 
-#: app/scripts/controllers/menu.js:394
+#: app/scripts/controllers/menu.js:409
 #, fuzzy
 msgid ""
-"You are editing a submodule, if you save it, you save only               the "
-"submodule (in this situation \"save as\" works like               \"export "
-"module\"), Do you like to continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 msgstr ""
 "Vous êtes en train d'éditer un sous-module, si vous le sauvegardez, vous "
 "sauvegardez uniquement le sous-module (dans ce cas, \"sauvegarder sous\" "
 "fonctionne comme la commande \"exporter le sous-module\"). Voulez-vous "
 "continuer ?"
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+msgstr ""
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr ""
 "Vous pouvez le charger tel quel ou le convertir pour la carte {{name}}."
 
-#: app/scripts/controllers/menu.js:1328
+#: app/scripts/controllers/menu.js:1347
+#, fuzzy
 msgid ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 msgstr ""
 "Vous pouvez uniquement construire sur le design de plus haut-niveau. Dans "
 "les sous-modules, vous pouvez uniquement <strong>Vérifier</strong>"
 
-#: app/scripts/controllers/menu.js:1355
+#: app/scripts/controllers/menu.js:1372
+#, fuzzy
 msgid ""
-"You can only upload  your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
 msgstr ""
-"Vous pouvez uniquement charger votre design au design de plus haut-niveau. "
-"Dans les sous-modules, vous pouvez uniquement <strong>Vérifier</strong>"
+"Vous pouvez uniquement construire sur le design de plus haut-niveau. Dans "
+"les sous-modules, vous pouvez uniquement <strong>Vérifier</strong>"
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr "Vos modifications seront perdues si vous ne les sauvegardez pas"
 
@@ -1305,25 +1337,45 @@ msgstr "Vos modifications seront perdues si vous ne les sauvegardez pas"
 msgid "back"
 msgstr "retour"
 
-#: app/scripts/services/drivers.js:412 app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439 app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr "{{app}} est requis."
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr "Documentation {{board}} non définie"
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr "Pinout {{board}} non défini"
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr "Règles {{board}} non définies"
 
-#: app/scripts/controllers/menu.js:483 app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499 app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr "{{name}} exporté"
+
+#, fuzzy
+#~ msgid ": '}} {{'Unlock to edit block !"
+#~ msgstr "Déverrouillez pour éditer le bloc !"
+
+#~ msgid "CAUTION ! : Changes will also be applied in all the copied"
+#~ msgstr ""
+#~ "ATTENTION ! : Les modifications seront également appliquées dans toutes "
+#~ "les copies du bloc"
+
+#~ msgid "Read only"
+#~ msgstr "Lecture seule"
+
+#~ msgid ""
+#~ "You can only upload  your design at top-level design. Inside submodules "
+#~ "you only can <strong>Verify</strong>"
+#~ msgstr ""
+#~ "Vous pouvez uniquement charger votre design au design de plus haut-"
+#~ "niveau. Dans les sous-modules, vous pouvez uniquement <strong>Vérifier</"
+#~ "strong>"
 
 #~ msgid "Choose a color"
 #~ msgstr "Choisir une couleur"

--- a/app/resources/locale/gl_ES/gl_ES.po
+++ b/app/resources/locale/gl_ES/gl_ES.po
@@ -12,15 +12,27 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: app/views/design.html:20
-msgid ": '}} {{'Unlock to edit block !"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
 msgstr ""
 
-#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr "<b>Desconecte</b> e <b>conecte de novo</b> a placa"
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
 msgstr "Acerca de Icestudio"
 
@@ -28,11 +40,11 @@ msgstr "Acerca de Icestudio"
 msgid "Acknowledgment"
 msgstr ""
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr "Engadir"
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr "Engada un bloque para comezar"
 
@@ -44,24 +56,24 @@ msgstr "Engadir como bloque"
 msgid "Address format"
 msgstr "Formato do enderezo de memoria"
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr "Elimináronse todas as coleccións"
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr "Perderanse todas as coleccións gardadas. Desexa continuar?"
 
-#: app/scripts/services/tools.js:1389
+#: app/scripts/services/tools.js:1500
 #, fuzzy
 msgid "At least Python 3.7 is required"
 msgstr "Requírese Python 2.7"
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr "Autor"
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr "Básico"
 
@@ -73,6 +85,10 @@ msgstr "Euskera"
 msgid "Binary"
 msgstr "Binario"
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr ""
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -82,7 +98,7 @@ msgstr "Binario"
 msgid "Block updated"
 msgstr "Bloque actualizado"
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr "Importouse o bloque {{name}}"
 
@@ -90,56 +106,52 @@ msgstr "Importouse o bloque {{name}}"
 msgid "Blocks"
 msgstr "Bloques"
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr "Placa"
 
-#: app/views/menu.html:367 app/views/menu.html:458
+#: app/views/menu.html:385 app/views/menu.html:476
 msgid "Board rules"
 msgstr "Regras da placa"
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr "Deshabilitáronse as regras da placa"
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr "Habilitáronse as regras da placa"
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr "Desconectouse a placa {{name}}"
 
-#: app/scripts/services/tools.js:607 app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718 app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr "A placa {{name}} non está dispoñible"
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr "Non se puido conectar á placa {{name}}"
 
-#: app/scripts/app.js:185 app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184 app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr "Seleccionouse a placa {{name}}"
 
-#: app/scripts/services/tools.js:596 app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707 app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr "O bootloader non está activo"
 
-#: app/scripts/controllers/menu.js:1327 app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346 app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr "Sintetizar"
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr "Sintetizado realizado"
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr ""
-
-#: app/scripts/app.js:59 app/scripts/services/project.js:147
+#: app/scripts/app.js:58 app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -147,15 +159,15 @@ msgstr "Cancelar"
 msgid "Catalan"
 msgstr "Catalán"
 
-#: app/views/design.html:264
+#: app/views/design.html:262
 msgid "Change Color"
 msgstr ""
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr "Comprobando a conexión a Internet..."
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr "Comprobando Python..."
 
@@ -167,20 +179,20 @@ msgstr "Chinés"
 msgid "Choose a color:"
 msgstr ""
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr "Fai clic aquí para <b>descargar unha nova versión<b> de Icestudio"
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr "Fai clic aquí para <b>configurar os drivers</b>"
 
-#: app/scripts/services/drivers.js:413 app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613 app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440 app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644 app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr "Fai clic aquí para instalarlo"
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr "Fai clic aquí para ver"
 
@@ -192,63 +204,63 @@ msgstr "Non está permitido o reloxo nos buses de datos"
 msgid "Clone"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:565 app/views/version.html:80
+#: app/scripts/controllers/menu.js:581 app/views/version.html:80
 msgid "Close"
 msgstr "Pechar"
 
-#: app/views/design.html:324 app/views/menu.html:791
+#: app/views/design.html:314 app/views/menu.html:809
 msgid "Code"
 msgstr "Código"
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr "Colección"
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr "Información da colección"
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr "Non se definiu a información da colección {{collection}}"
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr "Engadiuse a colección {{name}}"
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr "Non se trocou a colección {{name}}"
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr "Eliminouse a colección {{name}}"
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr "Trocouse a colección {{name}}"
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr "Seleccionouse a colección {{name}}"
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr "Coleccións"
 
-#: app/scripts/controllers/menu.js:1229 app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249 app/views/menu.html:489
 msgid "Command output"
 msgstr "Saída de comandos"
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr "Foro da comunidade"
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr "Configuración non completada"
 
-#: app/views/design.html:312 app/views/menu.html:783
+#: app/views/design.html:304 app/views/menu.html:801
 msgid "Constant"
 msgstr "Constante"
 
@@ -257,7 +269,7 @@ msgstr "Constante"
 msgid "Constant names"
 msgstr "Constante"
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr "Converter"
 
@@ -265,11 +277,11 @@ msgstr "Converter"
 msgid "Copy"
 msgstr "Copiar"
 
-#: app/scripts/services/forms.js:400 app/views/design.html:137
+#: app/scripts/services/forms.js:400 app/views/design.html:136
 msgid "Coral"
 msgstr ""
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr "Creando o contorno virtual..."
 
@@ -294,15 +306,15 @@ msgstr ""
 msgid "Dark Orange"
 msgstr ""
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr ""
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr ""
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr "Folla de datos"
 
@@ -310,39 +322,43 @@ msgstr "Folla de datos"
 msgid "Decimal"
 msgstr "Decimal"
 
-#: app/scripts/services/forms.js:394 app/views/design.html:123
+#: app/scripts/services/forms.js:394 app/views/design.html:122
 msgid "Deep Pink"
 msgstr ""
 
-#: app/scripts/services/forms.js:439 app/views/design.html:236
+#: app/scripts/services/forms.js:439 app/views/design.html:234
 msgid "Deep Sky Blue"
 msgstr ""
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr "Predeterminado"
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr ""
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr "Descripción"
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr "Deshabilitar"
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr "Desexa pechar a aplicación?"
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr "Desexa eliminar a colección {{name}}?"
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr "Desexa trocalo?"
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr "Documentación"
 
@@ -350,21 +366,26 @@ msgstr "Documentación"
 msgid "Don't display"
 msgstr ""
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr "Controladores"
 
 #: app/scripts/services/drivers.js:252 app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr "Deshabilitáronse os controladores"
 
 #: app/scripts/services/drivers.js:230 app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr "Habilitáronse os controladores"
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+#, fuzzy
+msgid "Duplicate"
+msgstr "Os portos E/S da FPGA están duplicados"
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr "Os portos E/S da FPGA están duplicados"
 
@@ -381,11 +402,11 @@ msgstr "Holandés"
 msgid "Edit"
 msgstr "Editar"
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr "Editar o nome da colección"
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr "Habilitar"
 
@@ -418,15 +439,15 @@ msgstr "Introduza os portos de entrada"
 msgid "Enter the python path"
 msgstr "Introduza a ruta ás coleccións externas"
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr "Introduza o nome do equipo remoto: usuario@equipo"
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr "Erro: {{error}}"
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr "Erros detectados no deseño"
 
@@ -434,7 +455,7 @@ msgstr "Erros detectados no deseño"
 msgid "Examples"
 msgstr "Exemplos"
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr "Executando {{label}} remoto..."
 
@@ -442,29 +463,29 @@ msgstr "Executando {{label}} remoto..."
 msgid "Export"
 msgstr "Exportar"
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395 app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr ""
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr "Coleccións externas"
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr "Colecións externas actualizadas"
 
-#: app/views/menu.html:383
+#: app/views/menu.html:401
 #, fuzzy
 msgid "External plugins"
 msgstr "Coleccións externas"
 
-#: app/scripts/controllers/menu.js:780
+#: app/scripts/controllers/menu.js:800
 #, fuzzy
 msgid "External plugins updated"
 msgstr "Colecións externas actualizadas"
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr "Portos E/S da FPGA non definidos"
 
@@ -472,7 +493,7 @@ msgstr "Portos E/S da FPGA non definidos"
 msgid "FPGA pin"
 msgstr "Pin da FPGA"
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr "Recursos da FPGA"
 
@@ -488,16 +509,16 @@ msgstr ""
 msgid "File"
 msgstr "Ficheiro"
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr "Xa existe o ficheiro {{file}} no cartafol do proxecto. Desexa trocalo?"
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr "Non existe o ficheiro {{file}}"
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr "Importouse o ficheiro {{file}}"
 
@@ -505,7 +526,7 @@ msgstr "Importouse o ficheiro {{file}}"
 msgid "Find"
 msgstr ""
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr "Axustar contido"
 
@@ -513,8 +534,8 @@ msgstr "Axustar contido"
 msgid "French"
 msgstr "Francés"
 
-#: app/scripts/services/forms.js:385 app/views/design.html:173
-#: app/views/design.html:98
+#: app/scripts/services/forms.js:385 app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr ""
 
@@ -526,7 +547,7 @@ msgstr "Galego"
 msgid "German"
 msgstr "Alemán"
 
-#: app/scripts/services/forms.js:409 app/views/design.html:158
+#: app/scripts/services/forms.js:409 app/views/design.html:157
 msgid "Gold"
 msgstr ""
 
@@ -538,11 +559,11 @@ msgstr ""
 msgid "Green Yellow"
 msgstr ""
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr ""
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr "Axuda"
 
@@ -554,33 +575,33 @@ msgstr "Hexadecimal"
 msgid "Icestudio is part of"
 msgstr ""
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid ""
 "If you have blank IN/OUT pins, it's because there is no equivalent in this "
 "board"
 msgstr ""
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr "Imaxe"
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr "Gardouse a imaxe {{name}}"
 
-#: app/scripts/services/forms.js:388 app/views/design.html:109
+#: app/scripts/services/forms.js:388 app/views/design.html:108
 msgid "Indian Red"
 msgstr ""
 
-#: app/views/design.html:330 app/views/menu.html:795
+#: app/views/design.html:319 app/views/menu.html:813
 msgid "Information"
 msgstr "Información"
 
-#: app/views/design.html:282 app/views/menu.html:760
+#: app/views/design.html:279 app/views/menu.html:778
 msgid "Input"
 msgstr "Entrada"
 
-#: app/views/design.html:294 app/views/menu.html:769
+#: app/views/design.html:289 app/views/menu.html:787
 msgid "Input label"
 msgstr ""
 
@@ -603,23 +624,23 @@ msgstr ""
 msgid "Input ports"
 msgstr "Introduza os portos de entrada"
 
-#: app/views/menu.html:635
+#: app/views/menu.html:653
 #, fuzzy
 msgid "Install (Stable)"
 msgstr "Instalar"
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
 msgstr ""
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid ""
 "Install the <b>STABLE Toolchain</b>. This operation requires Internet "
 "connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
 "allow the toolchain installation</p> <p>Do you want to continue?</p>"
 msgstr ""
 
-#: app/scripts/services/tools.js:1144
+#: app/scripts/services/tools.js:1255
 #, fuzzy
 msgid ""
 "Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
@@ -628,7 +649,7 @@ msgstr ""
 "Vaise actualizar a cadea de ferramentas. Esta operación require dunha "
 "conexión a Internet. Desexa continuar?"
 
-#: app/scripts/services/tools.js:1166
+#: app/scripts/services/tools.js:1277
 #, fuzzy
 msgid ""
 "Install the LATEST STABLE toolchain. It will be downloaded. This operation "
@@ -637,53 +658,53 @@ msgstr ""
 "Vaise actualizar a cadea de ferramentas. Esta operación require dunha "
 "conexión a Internet. Desexa continuar?"
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr "Instalación completada"
 
-#: app/scripts/services/tools.js:1274
+#: app/scripts/services/tools.js:1385
 #, fuzzy
 msgid "Installing"
 msgstr "Instalar"
 
-#: app/scripts/services/drivers.js:421 app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447 app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr "Requírese dunha conexión a Internet"
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr ""
 "A conexión <i>pull-up</i> non é válida:<br>o bloque xa se atopa conectado"
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr ""
 "A conexión <i>pull-up</i> non é válida:<br>tan só permítense os bloques "
 "<i>Entrada</i>"
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr ""
 "A conexión do bloque non é válida:<br>xa existe unha conexión <i>pull-up</i>"
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr "A colección {{name}} non é válida"
 
-#: app/scripts/services/graph.js:254 app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262 app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr "Conexión non válida"
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr "Conexión non válida: {{a}} → {{b}}"
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr "Conexións de entrada múltiple non válida"
 
-#: app/scripts/services/project.js:499 app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510 app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr "O formato do proxecto non é válido"
 
@@ -700,7 +721,7 @@ msgstr "Castelán"
 msgid "Korean"
 msgstr ""
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
 msgstr ""
 
@@ -709,7 +730,7 @@ msgstr ""
 msgid "Label updated"
 msgstr "Bloque actualizado"
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr "Idioma"
 
@@ -717,15 +738,15 @@ msgstr "Idioma"
 msgid "Light"
 msgstr ""
 
-#: app/scripts/services/forms.js:448 app/views/design.html:257
+#: app/scripts/services/forms.js:448 app/views/design.html:255
 msgid "Light Gray"
 msgstr ""
 
-#: app/scripts/services/forms.js:430 app/views/design.html:215
+#: app/scripts/services/forms.js:430 app/views/design.html:213
 msgid "Light Sea Green"
 msgstr ""
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr "Cargar"
 
@@ -733,20 +754,20 @@ msgstr "Cargar"
 msgid "Local parameter"
 msgstr "Parámetro local"
 
-#: app/views/menu.html:404
+#: app/views/menu.html:422
 #, fuzzy
 msgid "Logging enabled"
 msgstr "Habilitáronse os controladores"
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
 msgstr ""
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr "Tamaño máximo do bus: 96 bits"
 
@@ -754,11 +775,11 @@ msgstr "Tamaño máximo do bus: 96 bits"
 msgid "Medium Violet Red"
 msgstr ""
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr ""
 
-#: app/views/design.html:318 app/views/menu.html:787
+#: app/views/design.html:309 app/views/menu.html:805
 msgid "Memory"
 msgstr "Memoria"
 
@@ -767,7 +788,7 @@ msgstr "Memoria"
 msgid "Memory blocks"
 msgstr "Introduza os bloques de memoria"
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr "Nome"
 
@@ -775,7 +796,7 @@ msgstr "Nome"
 msgid "Name of the paired labels"
 msgstr ""
 
-#: app/scripts/services/forms.js:445 app/views/design.html:250
+#: app/scripts/services/forms.js:445 app/views/design.html:248
 msgid "Navy"
 msgstr ""
 
@@ -789,15 +810,19 @@ msgstr ""
 
 #: app/views/design.html:80
 #, fuzzy
-msgid "New Name:"
+msgid "New Name"
 msgstr "Nome"
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr ""
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr "Non hay coleccións gardadas"
 
-#: app/scripts/app.js:58 app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57 app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr "Aceptar"
 
@@ -805,7 +830,7 @@ msgstr "Aceptar"
 msgid "Olive Drab"
 msgstr ""
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr ""
 
@@ -813,7 +838,7 @@ msgstr ""
 msgid "Open"
 msgstr "Abrir"
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr "Abrir SVG"
 
@@ -821,19 +846,19 @@ msgstr "Abrir SVG"
 msgid "Orange Red"
 msgstr ""
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr ""
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr "Non existe o ficheiro {{name}} orixinal"
 
-#: app/views/design.html:288 app/views/menu.html:764
+#: app/views/design.html:284 app/views/menu.html:782
 msgid "Output"
 msgstr "Saída"
 
-#: app/views/design.html:300 app/views/menu.html:773
+#: app/views/design.html:294 app/views/menu.html:791
 msgid "Output label"
 msgstr ""
 
@@ -851,7 +876,7 @@ msgstr ""
 msgid "Output ports"
 msgstr "Saída"
 
-#: app/views/design.html:306 app/views/menu.html:778
+#: app/views/design.html:299 app/views/menu.html:796
 msgid "Paired labels"
 msgstr ""
 
@@ -859,40 +884,44 @@ msgstr ""
 msgid "Paste"
 msgstr "Pegar"
 
-#: app/scripts/controllers/menu.js:731 app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853 app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751 app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873 app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr "Non existe a ruta {{path}}"
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr "Por favor executa: {{cmd}}"
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr ""
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr "Información do proxecto"
 
-#: app/scripts/controllers/menu.js:935 app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955 app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr "Información do proxecto actualizada"
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr "Cargouse o proxecto {{name}}"
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr "Gardouse o proxecto {{name}}"
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
 msgstr ""
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
 msgstr ""
 
@@ -900,11 +929,7 @@ msgstr ""
 msgid "Quit"
 msgstr "Saír"
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr "Só lectura"
-
-#: app/scripts/services/forms.js:391 app/views/design.html:116
+#: app/scripts/services/forms.js:391 app/views/design.html:115
 #, fuzzy
 msgid "Red"
 msgstr "Refacer"
@@ -917,27 +942,27 @@ msgstr "Refacer"
 msgid "Release History WIKI"
 msgstr ""
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr "Recargar"
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr "Non se puido conectar ó equipo remoto {{name}}"
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr "Nome do equipo remoto"
 
-#: app/views/menu.html:647 app/views/menu.html:722
+#: app/views/menu.html:665 app/views/menu.html:740
 msgid "Remove"
 msgstr "Eliminar"
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr "Eliminar todo"
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
 msgstr ""
 
@@ -945,11 +970,11 @@ msgstr ""
 msgid "Replace One"
 msgstr ""
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr "Restablecer SVG"
 
-#: app/scripts/services/forms.js:442 app/views/design.html:243
+#: app/scripts/services/forms.js:442 app/views/design.html:241
 msgid "Royal Blue"
 msgstr ""
 
@@ -961,7 +986,7 @@ msgstr ""
 msgid "Save"
 msgstr "Gardar"
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr "Gardar SVG"
 
@@ -973,11 +998,11 @@ msgstr "Gardar como"
 msgid "Save submodule"
 msgstr ""
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr "Seleccionar"
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr "Seleccionar todo"
 
@@ -993,11 +1018,11 @@ msgstr "Mostrar reloxo"
 msgid "Slate Blue"
 msgstr ""
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr ""
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr "Código fonte"
 
@@ -1009,31 +1034,31 @@ msgstr "Castelán"
 msgid "Spring Green"
 msgstr ""
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr "Iniciando o sintetizado"
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr "Iniciando a carga"
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr "Iniciando a verificación"
 
-#: app/scripts/services/forms.js:436 app/views/design.html:229
+#: app/scripts/services/forms.js:436 app/views/design.html:227
 msgid "Steel Blue"
 msgstr ""
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr "Sincronizando ficheiros remotos..."
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
 msgstr ""
 
@@ -1049,11 +1074,11 @@ msgstr "Testbench"
 msgid "Thank you very much!"
 msgstr ""
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr "Xa existe a colección {{name}}."
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
@@ -1061,19 +1086,19 @@ msgstr ""
 "Perderase a configuración actual de E/S da FPGA. Desexa cambiar á placa "
 "{{name}}?"
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr "Vaise eliminar a cadea de ferramentas. Desexa continuar?"
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr ""
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr ""
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
@@ -1081,7 +1106,7 @@ msgstr ""
 "É necesario gardar o proxecto actual xa que a operación de importación "
 "require dun cartafol do proxecto. Desexa continuar?"
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr "Este proxecto está deseñado para a placa {{name}}"
 
@@ -1091,50 +1116,50 @@ msgid ""
 "              done by an emerging team from"
 msgstr ""
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 msgid ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
 "mode\", lock the keylock to do it."
 msgstr ""
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr ""
 
 #: app/scripts/controllers/menu.js:349
 msgid ""
-"To save your design you need to lock the keylock and               go to top "
+"To save your design you need to lock the padlock and               go to top "
 "level design.<br/><br/>If you want to export               this submodule to "
 "a file, execute \"Save as\" command to do it."
 msgstr ""
 
-#: app/views/menu.html:320
+#: app/views/menu.html:338
 #, fuzzy
 msgid "Toolbox"
 msgstr "Ferramentas"
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr "Cadea de ferramentas"
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr "Instalouse a cadea de ferramentas"
 
-#: app/scripts/services/drivers.js:594 app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191 app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625 app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300 app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr "Non se instalou a cadea de ferramentas"
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr "Eliminouse a cadea de ferramentas"
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr "A versión da cadea de ferramentas non coincide"
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr "Ferramentas"
 
@@ -1142,11 +1167,11 @@ msgstr "Ferramentas"
 msgid "Turkish"
 msgstr ""
 
-#: app/scripts/services/forms.js:433 app/views/design.html:222
+#: app/scripts/services/forms.js:433 app/views/design.html:220
 msgid "Turquoise"
 msgstr ""
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 msgid "UI theme"
 msgstr ""
 
@@ -1154,57 +1179,57 @@ msgstr ""
 msgid "Undo"
 msgstr "Desfacer"
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr "Placa desconocida"
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr "Non está soportado o formato {{version}} do proxecto."
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr "Sen título"
 
-#: app/views/menu.html:639
+#: app/views/menu.html:657
 #, fuzzy
 msgid "Update (Latest stable)"
 msgstr "Actualizar o nome do bloque"
 
-#: app/scripts/controllers/menu.js:1354 app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371 app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr "Cargar"
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr "Carga realizada"
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr "Verificación realizada"
 
-#: app/views/design.html:510 app/views/menu.html:599
+#: app/views/design.html:498 app/views/menu.html:617
 msgid "Verify"
 msgstr "Verificar"
 
-#: app/scripts/services/utils.js:641 app/views/menu.html:832
+#: app/scripts/services/utils.js:636 app/views/menu.html:850
 msgid "Version"
 msgstr "Versión"
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr ""
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr "Ver"
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr "Ver licenza"
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr "Advertencias detectadas no deseño"
 
@@ -1223,55 +1248,62 @@ msgstr "Formato de bloque incorrecto: {{type}}"
 msgid "Wrong block name {{name}}"
 msgstr "O nome do bloque {{name}} non é correcto"
 
-#: app/scripts/controllers/menu.js:1907
+#: app/scripts/controllers/menu.js:1925
 #, fuzzy
 msgid "Wrong new name!"
 msgstr "O nome do porto {{name}} non é correcto"
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr "O formato do proxecto {{name}} non é correcto"
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr "O nome do equipo remoto {{name}} non é correcto"
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
 msgstr ""
 
-#: app/scripts/services/forms.js:412 app/views/design.html:166
+#: app/scripts/services/forms.js:412 app/views/design.html:164
 msgid "Yellow"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:394
+#: app/scripts/controllers/menu.js:409
 msgid ""
-"You are editing a submodule, if you save it, you save only               the "
-"submodule (in this situation \"save as\" works like               \"export "
-"module\"), Do you like to continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 msgstr ""
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+msgstr ""
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr "Pode cargalo como está ou convertelo para a placa {{name}}."
 
-#: app/scripts/controllers/menu.js:1328
+#: app/scripts/controllers/menu.js:1347
 msgid ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1355
+#: app/scripts/controllers/menu.js:1372
 msgid ""
-"You can only upload  your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
 msgstr ""
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr "Os cambios realizados perderanse se non se gardan"
 
@@ -1279,25 +1311,28 @@ msgstr "Os cambios realizados perderanse se non se gardan"
 msgid "back"
 msgstr "atrás"
 
-#: app/scripts/services/drivers.js:412 app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439 app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr "Precisase {{app}}."
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr "Non se definiu a folla de datos para a placa {{board}}"
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr "Non se definiu o pinout para a placa {{board}}"
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr "Non se definiron as regras para a placa {{board}}"
 
-#: app/scripts/controllers/menu.js:483 app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499 app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr "Exportouse {{name}}"
+
+#~ msgid "Read only"
+#~ msgstr "Só lectura"
 
 #~ msgid "Duplicated block attributes"
 #~ msgstr "Os atributos do bloque están duplicados"

--- a/app/resources/locale/it_IT/it_IT.po
+++ b/app/resources/locale/it_IT/it_IT.po
@@ -12,15 +12,27 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: app/views/design.html:20
-msgid ": '}} {{'Unlock to edit block !"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
 msgstr ""
 
-#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr "<b> Scollegare </b> e <b> ricollegare </b> la scheda"
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
 msgstr "Informazioni su Icestudio"
 
@@ -28,11 +40,11 @@ msgstr "Informazioni su Icestudio"
 msgid "Acknowledgment"
 msgstr "Riconoscimenti"
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr "Aggiungi"
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr "Aggiungere un blocco per iniziare"
 
@@ -44,24 +56,24 @@ msgstr "Aggiungi come blocco"
 msgid "Address format"
 msgstr "Codifica dell'indirizzo"
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr "Tutte le collezioni sono state rimosse"
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr "Tutte le connessioni memorizzate saranno perse. Vuoi continuare?"
 
-#: app/scripts/services/tools.js:1389
+#: app/scripts/services/tools.js:1500
 #, fuzzy
 msgid "At least Python 3.7 is required"
 msgstr "È richiesto almeno Python 3.5"
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr "Autore"
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr "Base"
 
@@ -73,6 +85,10 @@ msgstr "Basco"
 msgid "Binary"
 msgstr "Binario"
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr ""
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -82,7 +98,7 @@ msgstr "Binario"
 msgid "Block updated"
 msgstr "Aggiorna blocco"
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr "Blocco {{name}} importato"
 
@@ -90,56 +106,52 @@ msgstr "Blocco {{name}} importato"
 msgid "Blocks"
 msgstr "Blocchi"
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr "Scheda"
 
-#: app/views/menu.html:367 app/views/menu.html:458
+#: app/views/menu.html:385 app/views/menu.html:476
 msgid "Board rules"
 msgstr "Regole della scheda"
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr "Regola della scheda disabilitate"
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr "Regole della scheda abilitate"
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr "Scheda {{name}} disconnessa"
 
-#: app/scripts/services/tools.js:607 app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718 app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr "Scheda {{name}} non disponibile"
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr "Scheda {{name}} non connessa"
 
-#: app/scripts/app.js:185 app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184 app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr "Scheda {{name}} selezionata"
 
-#: app/scripts/services/tools.js:596 app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707 app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr "Bootloader non attivo"
 
-#: app/scripts/controllers/menu.js:1327 app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346 app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr "Compila"
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr "Compilazione terminata"
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr ""
-
-#: app/scripts/app.js:59 app/scripts/services/project.js:147
+#: app/scripts/app.js:58 app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr "Cancella"
 
@@ -147,16 +159,16 @@ msgstr "Cancella"
 msgid "Catalan"
 msgstr "Catalano"
 
-#: app/views/design.html:264
+#: app/views/design.html:262
 #, fuzzy
 msgid "Change Color"
 msgstr "Scegli un colore"
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr "Sto controllando la connessione a internet..."
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr "Sto controllando Python..."
 
@@ -169,20 +181,20 @@ msgstr "Cinese"
 msgid "Choose a color:"
 msgstr "Scegli un colore"
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr "Clicca qui per <b>scaricare la versione più recente</b> di Icestudio"
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr "Clicca qui per <b>impostare i drivers</b>"
 
-#: app/scripts/services/drivers.js:413 app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613 app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440 app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644 app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr "Clicca qui per installarla"
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr "Clicca qui per visualizzarlo"
 
@@ -194,64 +206,64 @@ msgstr "Segnale di clock non permesso nei segnali di bus"
 msgid "Clone"
 msgstr "Clona"
 
-#: app/scripts/controllers/menu.js:565 app/views/version.html:80
+#: app/scripts/controllers/menu.js:581 app/views/version.html:80
 msgid "Close"
 msgstr "Chiudi"
 
-#: app/views/design.html:324 app/views/menu.html:791
+#: app/views/design.html:314 app/views/menu.html:809
 msgid "Code"
 msgstr "Codice"
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr "Collezione"
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr "Informazioni della collezione"
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr ""
 "Le informazioni della collezione {{collection}} non sono state definite"
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr "Collezione {{name}} aggiunta"
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr "Collezione {{name}} non rimpiazzata"
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr "Collezione {{name}} rimossa"
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr "Collezione {{name}} rimpiazzata"
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr "Scheda {{name}} selezionata"
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr "Collezioni"
 
-#: app/scripts/controllers/menu.js:1229 app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249 app/views/menu.html:489
 msgid "Command output"
 msgstr "Output dei comandi"
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr "Forum della comunità"
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr "Configurazione non completata"
 
-#: app/views/design.html:312 app/views/menu.html:783
+#: app/views/design.html:304 app/views/menu.html:801
 msgid "Constant"
 msgstr "Costante"
 
@@ -260,7 +272,7 @@ msgstr "Costante"
 msgid "Constant names"
 msgstr "Costante"
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr "Converti"
 
@@ -268,11 +280,11 @@ msgstr "Converti"
 msgid "Copy"
 msgstr "Copia"
 
-#: app/scripts/services/forms.js:400 app/views/design.html:137
+#: app/scripts/services/forms.js:400 app/views/design.html:136
 msgid "Coral"
 msgstr "Corallo"
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr "Creazione della virtualenv..."
 
@@ -298,15 +310,15 @@ msgstr "VerdeScuro"
 msgid "Dark Orange"
 msgstr "ArancioneScuro"
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr "VerdeScuro"
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr "ArancioneScuro"
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr "Scheda tecnica"
 
@@ -314,41 +326,45 @@ msgstr "Scheda tecnica"
 msgid "Decimal"
 msgstr "Decimale"
 
-#: app/scripts/services/forms.js:394 app/views/design.html:123
+#: app/scripts/services/forms.js:394 app/views/design.html:122
 #, fuzzy
 msgid "Deep Pink"
 msgstr "RosaScuro"
 
-#: app/scripts/services/forms.js:439 app/views/design.html:236
+#: app/scripts/services/forms.js:439 app/views/design.html:234
 #, fuzzy
 msgid "Deep Sky Blue"
 msgstr "BluCieloProfondo"
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr "Predefinito"
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr ""
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr "Descrizione"
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr "Disattiva"
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr "Vuoi chiudere l'applicazione?"
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr "Vuoi rimuovere la collezione {{name}}?"
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr "Vuoi sostituirlo?"
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr "Documentazione"
 
@@ -356,21 +372,26 @@ msgstr "Documentazione"
 msgid "Don't display"
 msgstr "Non mostrare"
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr "Drivers"
 
 #: app/scripts/services/drivers.js:252 app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr "Drivers disabilitati"
 
 #: app/scripts/services/drivers.js:230 app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr "Drivers abilitati"
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+#, fuzzy
+msgid "Duplicate"
+msgstr "Etichetta di Output"
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr "Porte I/O dell'FPGA duplicate"
 
@@ -387,11 +408,11 @@ msgstr "Olandese"
 msgid "Edit"
 msgstr "Modifica"
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr "Modifica il nome della collezione"
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr "Abilita"
 
@@ -423,15 +444,15 @@ msgstr "Inserire il nome delle porte di ingresso"
 msgid "Enter the python path"
 msgstr "Inserisci il percorso file di python con versione > 3.8"
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr "Inserisci il nome dell'host remoto user@host"
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr "Errore: {{error}}"
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr "Errori trovati nel design"
 
@@ -439,7 +460,7 @@ msgstr "Errori trovati nel design"
 msgid "Examples"
 msgstr "Esempi"
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr "Sto eseguendo {{label}} remotamente…"
 
@@ -447,27 +468,27 @@ msgstr "Sto eseguendo {{label}} remotamente…"
 msgid "Export"
 msgstr "Esporta"
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395 app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr "Esporta sottomodulo"
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr "Collezioni esterne"
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr "Connessioni esterne aggiornate"
 
-#: app/views/menu.html:383
+#: app/views/menu.html:401
 msgid "External plugins"
 msgstr "Plugin esterni"
 
-#: app/scripts/controllers/menu.js:780
+#: app/scripts/controllers/menu.js:800
 msgid "External plugins updated"
 msgstr "Plugin esterni aggiornati"
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr "Porta I/O dell'FPGA non definita"
 
@@ -475,7 +496,7 @@ msgstr "Porta I/O dell'FPGA non definita"
 msgid "FPGA pin"
 msgstr "Pin FPGA"
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr "Risorse FPGA"
 
@@ -491,16 +512,16 @@ msgstr ""
 msgid "File"
 msgstr "File"
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr "File {{file}} esiste già nella cartella. Vuoi rimpiazzarlo?"
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr "File {{file}} non esiste"
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr "File {{file}} importato"
 
@@ -508,7 +529,7 @@ msgstr "File {{file}} importato"
 msgid "Find"
 msgstr ""
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr "Adatta ai contenuti"
 
@@ -516,8 +537,8 @@ msgstr "Adatta ai contenuti"
 msgid "French"
 msgstr "Francese"
 
-#: app/scripts/services/forms.js:385 app/views/design.html:173
-#: app/views/design.html:98
+#: app/scripts/services/forms.js:385 app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr "Fuchsia"
 
@@ -529,7 +550,7 @@ msgstr "Galiziano"
 msgid "German"
 msgstr "Tedesco"
 
-#: app/scripts/services/forms.js:409 app/views/design.html:158
+#: app/scripts/services/forms.js:409 app/views/design.html:157
 msgid "Gold"
 msgstr "Oro"
 
@@ -542,11 +563,11 @@ msgstr "Greco"
 msgid "Green Yellow"
 msgstr "VerdeAcido"
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr "VerdeAcido"
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr "Aiuto"
 
@@ -558,35 +579,35 @@ msgstr "Esadecimale"
 msgid "Icestudio is part of"
 msgstr ""
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid ""
 "If you have blank IN/OUT pins, it's because there is no equivalent in this "
 "board"
 msgstr ""
 "Se hai pin IN/OUT vuoti, è perché non esiste un equivalente in questa scheda"
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr "Immagine"
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr "Immagine {{name}} salvata"
 
-#: app/scripts/services/forms.js:388 app/views/design.html:109
+#: app/scripts/services/forms.js:388 app/views/design.html:108
 #, fuzzy
 msgid "Indian Red"
 msgstr "RossoIndiano"
 
-#: app/views/design.html:330 app/views/menu.html:795
+#: app/views/design.html:319 app/views/menu.html:813
 msgid "Information"
 msgstr "Informazioni"
 
-#: app/views/design.html:282 app/views/menu.html:760
+#: app/views/design.html:279 app/views/menu.html:778
 msgid "Input"
 msgstr "Ingresso"
 
-#: app/views/design.html:294 app/views/menu.html:769
+#: app/views/design.html:289 app/views/menu.html:787
 msgid "Input label"
 msgstr "Etichetta di Input"
 
@@ -609,23 +630,23 @@ msgstr ""
 msgid "Input ports"
 msgstr "Inserire il nome delle porte di ingresso"
 
-#: app/views/menu.html:635
+#: app/views/menu.html:653
 #, fuzzy
 msgid "Install (Stable)"
 msgstr "Installa"
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
 msgstr ""
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid ""
 "Install the <b>STABLE Toolchain</b>. This operation requires Internet "
 "connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
 "allow the toolchain installation</p> <p>Do you want to continue?</p>"
 msgstr ""
 
-#: app/scripts/services/tools.js:1144
+#: app/scripts/services/tools.js:1255
 #, fuzzy
 msgid ""
 "Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
@@ -634,7 +655,7 @@ msgstr ""
 "La toolchain sarà aggiornata. Questa operazione richiede una connessione a "
 "Internet. Vuoi continuare?"
 
-#: app/scripts/services/tools.js:1166
+#: app/scripts/services/tools.js:1277
 #, fuzzy
 msgid ""
 "Install the LATEST STABLE toolchain. It will be downloaded. This operation "
@@ -643,51 +664,51 @@ msgstr ""
 "La toolchain sarà aggiornata. Questa operazione richiede una connessione a "
 "Internet. Vuoi continuare?"
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr "Installazione completata"
 
-#: app/scripts/services/tools.js:1274
+#: app/scripts/services/tools.js:1385
 #, fuzzy
 msgid "Installing"
 msgstr "Installa"
 
-#: app/scripts/services/drivers.js:421 app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447 app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr "Connessione a internet necessaria"
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr "Connessione di tipo <i>Pull up</i> invalida:<br>blocco già connesso"
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr ""
 "Connessione di tipo <i>Pull up</i> invalida:<br>solo i blocchi di "
 "<i>ingresso</i> sono permessi"
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr "Connessione al blocco invalida:<br><i>Pull up</i> già connesso"
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr "Collezione invalida {{name}}"
 
-#: app/scripts/services/graph.js:254 app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262 app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr "Connessione invalida"
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr "Connessione invalida: {{a}} → {{b}}"
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr "Connessioni di multipli ingressi invalidi"
 
-#: app/scripts/services/project.js:499 app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510 app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr "Formato del progetto invalido"
 
@@ -704,7 +725,7 @@ msgstr "Spagnolo"
 msgid "Korean"
 msgstr "Coreano"
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
 msgstr ""
 
@@ -713,7 +734,7 @@ msgstr ""
 msgid "Label updated"
 msgstr "Aggiorna blocco"
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr "Lingua"
 
@@ -721,17 +742,17 @@ msgstr "Lingua"
 msgid "Light"
 msgstr "Chiaro"
 
-#: app/scripts/services/forms.js:448 app/views/design.html:257
+#: app/scripts/services/forms.js:448 app/views/design.html:255
 #, fuzzy
 msgid "Light Gray"
 msgstr "Chiaro"
 
-#: app/scripts/services/forms.js:430 app/views/design.html:215
+#: app/scripts/services/forms.js:430 app/views/design.html:213
 #, fuzzy
 msgid "Light Sea Green"
 msgstr "VerdeAcqua"
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr "Carica"
 
@@ -739,20 +760,20 @@ msgstr "Carica"
 msgid "Local parameter"
 msgstr "Parametri locali"
 
-#: app/views/menu.html:404
+#: app/views/menu.html:422
 #, fuzzy
 msgid "Logging enabled"
 msgstr "Drivers abilitati"
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
 msgstr ""
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr "Dimensione massima del bus: 96 bits"
 
@@ -761,11 +782,11 @@ msgstr "Dimensione massima del bus: 96 bits"
 msgid "Medium Violet Red"
 msgstr "RossoViolaceo"
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr "RossoViolaceo"
 
-#: app/views/design.html:318 app/views/menu.html:787
+#: app/views/design.html:309 app/views/menu.html:805
 msgid "Memory"
 msgstr "Memoria"
 
@@ -774,7 +795,7 @@ msgstr "Memoria"
 msgid "Memory blocks"
 msgstr "Inserire il nome dei blocchi di memoria"
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr "Nome"
 
@@ -782,7 +803,7 @@ msgstr "Nome"
 msgid "Name of the paired labels"
 msgstr ""
 
-#: app/scripts/services/forms.js:445 app/views/design.html:250
+#: app/scripts/services/forms.js:445 app/views/design.html:248
 msgid "Navy"
 msgstr "BluIntenso"
 
@@ -796,15 +817,19 @@ msgstr ""
 
 #: app/views/design.html:80
 #, fuzzy
-msgid "New Name:"
+msgid "New Name"
 msgstr "Nome"
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr ""
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr "Nessuna connessione memorizzata"
 
-#: app/scripts/app.js:58 app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57 app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr "OK"
 
@@ -813,7 +838,7 @@ msgstr "OK"
 msgid "Olive Drab"
 msgstr "VerdeOlivo"
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr "VerdeOlivo"
 
@@ -821,7 +846,7 @@ msgstr "VerdeOlivo"
 msgid "Open"
 msgstr "Apri"
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr "Apri SVG"
 
@@ -830,19 +855,19 @@ msgstr "Apri SVG"
 msgid "Orange Red"
 msgstr "RossoArancio"
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr "RossoArancio"
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr "Filo originale {{file}} non esiste più"
 
-#: app/views/design.html:288 app/views/menu.html:764
+#: app/views/design.html:284 app/views/menu.html:782
 msgid "Output"
 msgstr "Uscita"
 
-#: app/views/design.html:300 app/views/menu.html:773
+#: app/views/design.html:294 app/views/menu.html:791
 msgid "Output label"
 msgstr "Etichetta di Output"
 
@@ -861,7 +886,7 @@ msgstr "Etichetta di Output"
 msgid "Output ports"
 msgstr "Etichetta di Output"
 
-#: app/views/design.html:306 app/views/menu.html:778
+#: app/views/design.html:299 app/views/menu.html:796
 msgid "Paired labels"
 msgstr ""
 
@@ -869,40 +894,44 @@ msgstr ""
 msgid "Paste"
 msgstr "Incolla"
 
-#: app/scripts/controllers/menu.js:731 app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853 app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751 app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873 app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr "IL percorso {{path}}è inesistente"
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr "Prego eseguire: {{cmd}}"
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr ""
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr "Informazioni del progetto"
 
-#: app/scripts/controllers/menu.js:935 app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955 app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr "Informazioni del progetto aggionate"
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr "Progetto {{name}} caricato"
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr "Progetto {{name}} salvato"
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
 msgstr "Ambiente Python aggiornato"
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
 msgstr "Ambiente Python"
 
@@ -910,11 +939,7 @@ msgstr "Ambiente Python"
 msgid "Quit"
 msgstr "Esci"
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr "Solo lettura"
-
-#: app/scripts/services/forms.js:391 app/views/design.html:116
+#: app/scripts/services/forms.js:391 app/views/design.html:115
 msgid "Red"
 msgstr "Rosso"
 
@@ -926,27 +951,27 @@ msgstr "Ripeti"
 msgid "Release History WIKI"
 msgstr ""
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr "Ricarica"
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr "Host remoto {{name}} non connesso"
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr "Nome dell'host remoto"
 
-#: app/views/menu.html:647 app/views/menu.html:722
+#: app/views/menu.html:665 app/views/menu.html:740
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr "Rimuovi tutti"
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
 msgstr ""
 
@@ -954,11 +979,11 @@ msgstr ""
 msgid "Replace One"
 msgstr ""
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr "Ripristina SVG"
 
-#: app/scripts/services/forms.js:442 app/views/design.html:243
+#: app/scripts/services/forms.js:442 app/views/design.html:241
 #, fuzzy
 msgid "Royal Blue"
 msgstr "BluReale"
@@ -971,7 +996,7 @@ msgstr "Russo"
 msgid "Save"
 msgstr "Salva"
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr "Salva come SVG"
 
@@ -983,11 +1008,11 @@ msgstr "Salva come"
 msgid "Save submodule"
 msgstr "Salva sotto modulo"
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr "Seleziona"
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr "Seleziona tutto"
 
@@ -1004,11 +1029,11 @@ msgstr "Mostra segnale di clock"
 msgid "Slate Blue"
 msgstr "BluArdesia"
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr "BluArdesia"
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr "Codice sorgente"
 
@@ -1021,32 +1046,32 @@ msgstr "Spagnolo"
 msgid "Spring Green"
 msgstr "VerdePrimavera"
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr "VerdePrimavera"
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr "Inizia compilazione"
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr "Inizia caricamento"
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr "Inizia verifica"
 
-#: app/scripts/services/forms.js:436 app/views/design.html:229
+#: app/scripts/services/forms.js:436 app/views/design.html:227
 #, fuzzy
 msgid "Steel Blue"
 msgstr "BluAcciaio"
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr "Sto sincronizzando i file remoti…"
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
 msgstr ""
 
@@ -1063,11 +1088,11 @@ msgstr "Testbench"
 msgid "Thank you very much!"
 msgstr ". Grazie mille"
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr "La collezione {{name}} esiste già."
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
@@ -1075,19 +1100,19 @@ msgstr ""
 "La corrente configurazione degli I/O dell'FPGA sarà persa. Vuoi passare alla "
 "scheda {{name}}?"
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr "La toolchain sarà rimossa. Vuoi continuare?"
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr "C'è una nuova versione nightly disponibile"
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr "C'è una nuova versione stabile disponibile"
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
@@ -1095,7 +1120,7 @@ msgstr ""
 "L'importazione richiede il percorso del progetto. Devi salvare il progetto "
 "corrente. Vuoi continuare?"
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr "Questo progetto è stato progettato per la scheda {{name}}"
 
@@ -1105,7 +1130,7 @@ msgid ""
 "              done by an emerging team from"
 msgstr ""
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 msgid ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
 "mode\", lock the keylock to do it."
@@ -1114,7 +1139,7 @@ msgstr ""
 "necessario completare la \"modalità modifica\" corrente, chiudi il "
 "catenaccio per farlo."
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr ""
 "Per navigare attraverso progetti, devi prima chiudere la \"modalità modifica"
@@ -1123,7 +1148,7 @@ msgstr ""
 #: app/scripts/controllers/menu.js:349
 #, fuzzy
 msgid ""
-"To save your design you need to lock the keylock and               go to top "
+"To save your design you need to lock the padlock and               go to top "
 "level design.<br/><br/>If you want to export               this submodule to "
 "a file, execute \"Save as\" command to do it."
 msgstr ""
@@ -1131,33 +1156,33 @@ msgstr ""
 "design padre.<br/><br/>Se si desidera esportare questo sottomodulo su un "
 "file, eseguire il comando \"Salva con nome\" per farlo."
 
-#: app/views/menu.html:320
+#: app/views/menu.html:338
 #, fuzzy
 msgid "Toolbox"
 msgstr "Strumenti"
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr "Toolchain"
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr "Toolchain installata"
 
-#: app/scripts/services/drivers.js:594 app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191 app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625 app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300 app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr "Toolchain non installata"
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr "Toolchain rimossa"
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr "La versione della Toolchain non corrisponde"
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr "Strumenti"
 
@@ -1165,11 +1190,11 @@ msgstr "Strumenti"
 msgid "Turkish"
 msgstr ""
 
-#: app/scripts/services/forms.js:433 app/views/design.html:222
+#: app/scripts/services/forms.js:433 app/views/design.html:220
 msgid "Turquoise"
 msgstr "Turchese"
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 msgid "UI theme"
 msgstr "Tema UI"
 
@@ -1177,57 +1202,57 @@ msgstr "Tema UI"
 msgid "Undo"
 msgstr "Annulla"
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr "Scheda sconosciuta"
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr "Formato del progetto non supportato {{version}}"
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr "Senza titolo"
 
-#: app/views/menu.html:639
+#: app/views/menu.html:657
 #, fuzzy
 msgid "Update (Latest stable)"
 msgstr "Aggiorna il nome del blocco"
 
-#: app/scripts/controllers/menu.js:1354 app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371 app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr "Carica"
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr "Caricamento completato"
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr "Verifica completata"
 
-#: app/views/design.html:510 app/views/menu.html:599
+#: app/views/design.html:498 app/views/menu.html:617
 msgid "Verify"
 msgstr "Verifica"
 
-#: app/scripts/services/utils.js:641 app/views/menu.html:832
+#: app/scripts/services/utils.js:636 app/views/menu.html:850
 msgid "Version"
 msgstr "Versione"
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr "Note sulla versione"
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr "Visualizza"
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr "Visualizza licenza"
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr "Si sono rilevate delle avvertenze nel design"
 
@@ -1246,63 +1271,72 @@ msgstr "Formato del blocco erratot: {{type}}"
 msgid "Wrong block name {{name}}"
 msgstr "Nome del blocco {{name}} errato"
 
-#: app/scripts/controllers/menu.js:1907
+#: app/scripts/controllers/menu.js:1925
 #, fuzzy
 msgid "Wrong new name!"
 msgstr "Nome della porta {{name}} errata"
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr "Formato del progetto errato: {{name}}"
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr "Nome dell'host remoto {{name}} errato"
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
 msgstr ""
 
-#: app/scripts/services/forms.js:412 app/views/design.html:166
+#: app/scripts/services/forms.js:412 app/views/design.html:164
 msgid "Yellow"
 msgstr "Giallo"
 
-#: app/scripts/controllers/menu.js:394
+#: app/scripts/controllers/menu.js:409
 #, fuzzy
 msgid ""
-"You are editing a submodule, if you save it, you save only               the "
-"submodule (in this situation \"save as\" works like               \"export "
-"module\"), Do you like to continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 msgstr ""
 "Si sta modificando un sottomodulo, se lo si salva, si salverà solo il "
 "sottomodulo (in questa situazione \"salva con nome\" funziona come \"esporta "
 "modulo\"), Continuare?"
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+msgstr ""
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr "Puoi caricarlo così come è o convertirlo per la scheda {{name}}"
 
-#: app/scripts/controllers/menu.js:1328
+#: app/scripts/controllers/menu.js:1347
+#, fuzzy
 msgid ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 msgstr ""
 "Puoi costruire solo sul design di primo livello. All'interno dei sottomodi è "
 "solo possibile <strong>Verificare</strong>"
 
-#: app/scripts/controllers/menu.js:1355
+#: app/scripts/controllers/menu.js:1372
+#, fuzzy
 msgid ""
-"You can only upload  your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
 msgstr ""
-"Puoi caricare solo il  design di primo livello. All'interno dei sottomodi è "
+"Puoi costruire solo sul design di primo livello. All'interno dei sottomodi è "
 "solo possibile <strong>Verificare</strong>"
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr "I tuoi progressi saranno perduti se non li salvi"
 
@@ -1310,25 +1344,35 @@ msgstr "I tuoi progressi saranno perduti se non li salvi"
 msgid "back"
 msgstr "indietro"
 
-#: app/scripts/services/drivers.js:412 app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439 app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr "{{app}} è richiesta."
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr "La scheda tecnica di {{board}} non è definita"
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr "{{board}} piedinatura non definita"
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr "Regole di {{board}} non definite"
 
-#: app/scripts/controllers/menu.js:483 app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499 app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr "{{name}} esportato"
+
+#~ msgid "Read only"
+#~ msgstr "Solo lettura"
+
+#~ msgid ""
+#~ "You can only upload  your design at top-level design. Inside submodules "
+#~ "you only can <strong>Verify</strong>"
+#~ msgstr ""
+#~ "Puoi caricare solo il  design di primo livello. All'interno dei sottomodi "
+#~ "è solo possibile <strong>Verificare</strong>"
 
 #~ msgid "Choose a color"
 #~ msgstr "Scegli un colore"

--- a/app/resources/locale/ja_JP/ja_JP.po
+++ b/app/resources/locale/ja_JP/ja_JP.po
@@ -12,15 +12,27 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: app/views/design.html:20
-msgid ": '}} {{'Unlock to edit block !"
-msgstr ": '}} {{'ブロックを編集するにはロックを解除してください！"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
+msgstr ""
 
-#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr "ボードの<b>ケーブルを抜き</b>、<b>再接続</b>してください"
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
 msgstr "Icestudio について"
 
@@ -28,11 +40,11 @@ msgstr "Icestudio について"
 msgid "Acknowledgment"
 msgstr "謝辞"
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr "追加"
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr "ブロックを追加して始める"
 
@@ -44,23 +56,23 @@ msgstr "ブロックとして追加"
 msgid "Address format"
 msgstr "アドレスフォーマット"
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr "すべてのコレクションが削除されました"
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr "保存されているコレクションはすべて失われます。継続しますか？"
 
-#: app/scripts/services/tools.js:1389
+#: app/scripts/services/tools.js:1500
 msgid "At least Python 3.7 is required"
 msgstr "Python 3.7 以上が必要です"
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr "作者"
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr ""
 
@@ -72,6 +84,10 @@ msgstr "バスク語"
 msgid "Binary"
 msgstr "2進数"
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr ""
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -81,7 +97,7 @@ msgstr "2進数"
 msgid "Block updated"
 msgstr "ブロックが更新されました"
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr "ブロック {{name}} がインポートされました"
 
@@ -89,56 +105,52 @@ msgstr "ブロック {{name}} がインポートされました"
 msgid "Blocks"
 msgstr "ブロック"
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr "ボード"
 
-#: app/views/menu.html:367 app/views/menu.html:458
+#: app/views/menu.html:385 app/views/menu.html:476
 msgid "Board rules"
 msgstr "ボードルール"
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr "ボードルールが無効です"
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr "ボードルールが有効です"
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr "ボード {{name}} が切断されました"
 
-#: app/scripts/services/tools.js:607 app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718 app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr "ボード {{name}} は使えません"
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr "ボード {{name}} が接続されていません"
 
-#: app/scripts/app.js:185 app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184 app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr "ボード {{name}} が選択されました"
 
-#: app/scripts/services/tools.js:596 app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707 app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr "ブートローダがアクティブでない"
 
-#: app/scripts/controllers/menu.js:1327 app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346 app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr "ビルド"
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr "ビルド完了"
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr "注意！変更内容はコピーしたものすべてに適用されます"
-
-#: app/scripts/app.js:59 app/scripts/services/project.js:147
+#: app/scripts/app.js:58 app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr "キャンセル"
 
@@ -146,15 +158,15 @@ msgstr "キャンセル"
 msgid "Catalan"
 msgstr "カタロニア語"
 
-#: app/views/design.html:264
+#: app/views/design.html:262
 msgid "Change Color"
 msgstr "色を変更"
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr "インターネット接続を確認中…"
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr "Python を確認中…"
 
@@ -167,20 +179,20 @@ msgstr "中国語"
 msgid "Choose a color:"
 msgstr "色を選択"
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr "ここをクリックして Icestudio の <b> 新バージョン </b> をダウンロード"
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr "ここをクリックして<b>ドライバをセットアップ</b>"
 
-#: app/scripts/services/drivers.js:413 app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613 app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440 app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644 app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr "ここをクリックしてインストール"
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr "ここをクリックして閲覧"
 
@@ -192,63 +204,63 @@ msgstr "データバスにクロックを使用不可"
 msgid "Clone"
 msgstr "クローン"
 
-#: app/scripts/controllers/menu.js:565 app/views/version.html:80
+#: app/scripts/controllers/menu.js:581 app/views/version.html:80
 msgid "Close"
 msgstr "閉じる"
 
-#: app/views/design.html:324 app/views/menu.html:791
+#: app/views/design.html:314 app/views/menu.html:809
 msgid "Code"
 msgstr "コード"
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr "コレクション"
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr "コレクションの詳細"
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr "コレクション {{collection}} の詳細が見つかりません"
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr "コレクション {{name}} が追加されました"
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr "コレクション {{name}} が置き換えられませんでした"
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr "コレクション {{name}} が削除されました"
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr "コレクション {{name}} が置き換えられました"
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr "コレクション {{name}} が選択されました"
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr "コレクション"
 
-#: app/scripts/controllers/menu.js:1229 app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249 app/views/menu.html:489
 msgid "Command output"
 msgstr "コマンド出力"
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr "コミュニティフォーラム"
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr "設定が完了していません"
 
-#: app/views/design.html:312 app/views/menu.html:783
+#: app/views/design.html:304 app/views/menu.html:801
 msgid "Constant"
 msgstr "定数"
 
@@ -257,7 +269,7 @@ msgstr "定数"
 msgid "Constant names"
 msgstr "定数"
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr "変換"
 
@@ -265,11 +277,11 @@ msgstr "変換"
 msgid "Copy"
 msgstr "コピー"
 
-#: app/scripts/services/forms.js:400 app/views/design.html:137
+#: app/scripts/services/forms.js:400 app/views/design.html:136
 msgid "Coral"
 msgstr ""
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr "仮想環境を生成…"
 
@@ -293,15 +305,15 @@ msgstr ""
 msgid "Dark Orange"
 msgstr ""
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr ""
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr ""
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr "データシート"
 
@@ -309,39 +321,43 @@ msgstr "データシート"
 msgid "Decimal"
 msgstr "10進数"
 
-#: app/scripts/services/forms.js:394 app/views/design.html:123
+#: app/scripts/services/forms.js:394 app/views/design.html:122
 msgid "Deep Pink"
 msgstr ""
 
-#: app/scripts/services/forms.js:439 app/views/design.html:236
+#: app/scripts/services/forms.js:439 app/views/design.html:234
 msgid "Deep Sky Blue"
 msgstr ""
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr "デフォルト"
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr ""
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr "説明"
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr "無効化"
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr "アプリケーションを終了しますか？"
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr "コレクション {{name}} を削除しますか？"
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr "置き換えますか？"
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr "ドキュメント"
 
@@ -349,21 +365,26 @@ msgstr "ドキュメント"
 msgid "Don't display"
 msgstr "表示しない"
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr "ドライバ"
 
 #: app/scripts/services/drivers.js:252 app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr "ドライバが無効です"
 
 #: app/scripts/services/drivers.js:230 app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr "ドライバが有効です"
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+#, fuzzy
+msgid "Duplicate"
+msgstr "出力ラベル"
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr "FPGA の I/O ポートが重複しています"
 
@@ -380,11 +401,11 @@ msgstr "オランダ語"
 msgid "Edit"
 msgstr "編集"
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr "コレクションの名前を編集"
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr "有効化"
 
@@ -416,15 +437,15 @@ msgstr "入力ポートを入力"
 msgid "Enter the python path"
 msgstr "バージョン3.8以上のpythonのパスを入力"
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr "リモートホスト名を入力 user@host"
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr "エラー：{{error}}"
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr "設計にエラーが発見されました"
 
@@ -432,7 +453,7 @@ msgstr "設計にエラーが発見されました"
 msgid "Examples"
 msgstr "例"
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr "リモート {{label}} で実行…"
 
@@ -440,27 +461,27 @@ msgstr "リモート {{label}} で実行…"
 msgid "Export"
 msgstr "エクスポート"
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395 app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr "サブモジュールをエクスポート"
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr "外部接続"
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr "外部接続が更新されました"
 
-#: app/views/menu.html:383
+#: app/views/menu.html:401
 msgid "External plugins"
 msgstr "外部プラグイン"
 
-#: app/scripts/controllers/menu.js:780
+#: app/scripts/controllers/menu.js:800
 msgid "External plugins updated"
 msgstr "外部プラグインが更新されました"
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr "FPGA !/O ポートが未定義"
 
@@ -468,7 +489,7 @@ msgstr "FPGA !/O ポートが未定義"
 msgid "FPGA pin"
 msgstr "FPGA ピン"
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr "FPGA リソース"
 
@@ -484,17 +505,17 @@ msgstr ""
 msgid "File"
 msgstr "ファイル"
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr ""
 "ファイル {{file}} はプロジェクトパスに既に存在しています。置き換えますか？"
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr "ファイル {{file}} が存在しません"
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr "ファイル {{file}} がインポートされました"
 
@@ -502,7 +523,7 @@ msgstr "ファイル {{file}} がインポートされました"
 msgid "Find"
 msgstr "探す"
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr ""
 
@@ -510,8 +531,8 @@ msgstr ""
 msgid "French"
 msgstr "フランス語"
 
-#: app/scripts/services/forms.js:385 app/views/design.html:173
-#: app/views/design.html:98
+#: app/scripts/services/forms.js:385 app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr ""
 
@@ -523,7 +544,7 @@ msgstr "ガリシア語"
 msgid "German"
 msgstr "ドイツ語"
 
-#: app/scripts/services/forms.js:409 app/views/design.html:158
+#: app/scripts/services/forms.js:409 app/views/design.html:157
 msgid "Gold"
 msgstr ""
 
@@ -535,11 +556,11 @@ msgstr "ギリシャ語"
 msgid "Green Yellow"
 msgstr ""
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr ""
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr "ヘルプ"
 
@@ -551,33 +572,33 @@ msgstr "16進数"
 msgid "Icestudio is part of"
 msgstr ""
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid ""
 "If you have blank IN/OUT pins, it's because there is no equivalent in this "
 "board"
 msgstr "IN/OUTピンが空白であるのは、このボードに該当するピンがないためです"
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr "画像"
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr "画像 {{name}} が保存されました"
 
-#: app/scripts/services/forms.js:388 app/views/design.html:109
+#: app/scripts/services/forms.js:388 app/views/design.html:108
 msgid "Indian Red"
 msgstr ""
 
-#: app/views/design.html:330 app/views/menu.html:795
+#: app/views/design.html:319 app/views/menu.html:813
 msgid "Information"
 msgstr "情報"
 
-#: app/views/design.html:282 app/views/menu.html:760
+#: app/views/design.html:279 app/views/menu.html:778
 msgid "Input"
 msgstr "入力"
 
-#: app/views/design.html:294 app/views/menu.html:769
+#: app/views/design.html:289 app/views/menu.html:787
 msgid "Input label"
 msgstr "入力ラベル"
 
@@ -600,15 +621,15 @@ msgstr ""
 msgid "Input ports"
 msgstr "入力ポートを入力"
 
-#: app/views/menu.html:635
+#: app/views/menu.html:653
 msgid "Install (Stable)"
 msgstr "インストール（安定版）"
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
 msgstr "インストール（開発版）"
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid ""
 "Install the <b>STABLE Toolchain</b>. This operation requires Internet "
 "connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
@@ -619,7 +640,7 @@ msgstr ""
 "するために、VPNがあれば切断する必要があります </p> <p>\n"
 "このまま続けますか？</p>"
 
-#: app/scripts/services/tools.js:1144
+#: app/scripts/services/tools.js:1255
 msgid ""
 "Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
 "requires Internet connection. Do you want to continue?"
@@ -627,7 +648,7 @@ msgstr ""
 "「開発版の」ツールチェインをインストールします。ダウンロードされます。この操"
 "作にはインターネット接続が必要です。続行しますか？"
 
-#: app/scripts/services/tools.js:1166
+#: app/scripts/services/tools.js:1277
 msgid ""
 "Install the LATEST STABLE toolchain. It will be downloaded. This operation "
 "requires Internet connection. Do you want to continue?"
@@ -635,48 +656,48 @@ msgstr ""
 "「安定版の」ツールチェインをインストールします。ダウンロードされます。この操"
 "作にはインターネット接続が必要です。続行しますか？"
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr "インストールが完了しました"
 
-#: app/scripts/services/tools.js:1274
+#: app/scripts/services/tools.js:1385
 msgid "Installing"
 msgstr "インストール中"
 
-#: app/scripts/services/drivers.js:421 app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447 app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr "インターネット接続が必要"
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr "無効な <I>プルアップ</i> 接続：<br>ブロックが既に接続されています"
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr "無効な <I>プルアップ</i> 接続：<br>入力ブロックのみ可能です"
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr "無効なブロック接続：<br><I>プルアップ</i> が既に接続されています"
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr "無効な接続 {{name}}"
 
-#: app/scripts/services/graph.js:254 app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262 app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr "無効な接続"
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr "無効な接続：{{a}} → {{b}}"
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr "無効な複数の入力接続"
 
-#: app/scripts/services/project.js:499 app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510 app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr "無効なプロジェクトフォーマット"
 
@@ -693,7 +714,7 @@ msgstr "スペイン語"
 msgid "Korean"
 msgstr "韓国語"
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
 msgstr "ラベル検索"
 
@@ -701,7 +722,7 @@ msgstr "ラベル検索"
 msgid "Label updated"
 msgstr "ラベルが更新されました"
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr "言語"
 
@@ -709,16 +730,16 @@ msgstr "言語"
 msgid "Light"
 msgstr "ライト"
 
-#: app/scripts/services/forms.js:448 app/views/design.html:257
+#: app/scripts/services/forms.js:448 app/views/design.html:255
 #, fuzzy
 msgid "Light Gray"
 msgstr "ライト"
 
-#: app/scripts/services/forms.js:430 app/views/design.html:215
+#: app/scripts/services/forms.js:430 app/views/design.html:213
 msgid "Light Sea Green"
 msgstr ""
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr "ロード"
 
@@ -726,19 +747,19 @@ msgstr "ロード"
 msgid "Local parameter"
 msgstr "ローカルパラメタ"
 
-#: app/views/menu.html:404
+#: app/views/menu.html:422
 msgid "Logging enabled"
 msgstr "ログ記録を有効化"
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
 msgstr "ログファイル"
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
 msgstr "ログファイルが更新されました"
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr "最大のバス幅：96 ビット"
 
@@ -746,11 +767,11 @@ msgstr "最大のバス幅：96 ビット"
 msgid "Medium Violet Red"
 msgstr ""
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr ""
 
-#: app/views/design.html:318 app/views/menu.html:787
+#: app/views/design.html:309 app/views/menu.html:805
 msgid "Memory"
 msgstr "メモリ"
 
@@ -759,7 +780,7 @@ msgstr "メモリ"
 msgid "Memory blocks"
 msgstr "メモリブロックの入力"
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr "名前"
 
@@ -767,7 +788,7 @@ msgstr "名前"
 msgid "Name of the paired labels"
 msgstr ""
 
-#: app/scripts/services/forms.js:445 app/views/design.html:250
+#: app/scripts/services/forms.js:445 app/views/design.html:248
 msgid "Navy"
 msgstr ""
 
@@ -780,15 +801,20 @@ msgid "New Color:"
 msgstr "新しい色："
 
 #: app/views/design.html:80
-msgid "New Name:"
+#, fuzzy
+msgid "New Name"
 msgstr "新しい名前："
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr ""
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr ""
 
-#: app/scripts/app.js:58 app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57 app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr ""
 
@@ -796,7 +822,7 @@ msgstr ""
 msgid "Olive Drab"
 msgstr ""
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr ""
 
@@ -804,7 +830,7 @@ msgstr ""
 msgid "Open"
 msgstr "開く"
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr "SVG を開く"
 
@@ -812,19 +838,19 @@ msgstr "SVG を開く"
 msgid "Orange Red"
 msgstr ""
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr ""
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr "オリジナルのファイル{{file}}が存在しない"
 
-#: app/views/design.html:288 app/views/menu.html:764
+#: app/views/design.html:284 app/views/menu.html:782
 msgid "Output"
 msgstr "出力"
 
-#: app/views/design.html:300 app/views/menu.html:773
+#: app/views/design.html:294 app/views/menu.html:791
 msgid "Output label"
 msgstr "出力ラベル"
 
@@ -843,7 +869,7 @@ msgstr "出力ラベル"
 msgid "Output ports"
 msgstr "出力ラベル"
 
-#: app/views/design.html:306 app/views/menu.html:778
+#: app/views/design.html:299 app/views/menu.html:796
 msgid "Paired labels"
 msgstr ""
 
@@ -851,40 +877,44 @@ msgstr ""
 msgid "Paste"
 msgstr "ペースト"
 
-#: app/scripts/controllers/menu.js:731 app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853 app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751 app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873 app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr "パス {{path}} が存在しません"
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr "実行してください： {{cmd}}"
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr "環境設定"
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr ""
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr "プロジェクトの情報"
 
-#: app/scripts/controllers/menu.js:935 app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955 app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr "プロジェクトの情報が更新されました"
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr "プロジェクト {{name}} がロードされました"
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr "プロジェクト {{name}} が保存されました"
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
 msgstr "Python 環境がアップデートされました"
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
 msgstr "Python 環境"
 
@@ -892,11 +922,7 @@ msgstr "Python 環境"
 msgid "Quit"
 msgstr "やめる"
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr "読み取り専用"
-
-#: app/scripts/services/forms.js:391 app/views/design.html:116
+#: app/scripts/services/forms.js:391 app/views/design.html:115
 #, fuzzy
 msgid "Red"
 msgstr "やり直す"
@@ -909,27 +935,27 @@ msgstr "やり直す"
 msgid "Release History WIKI"
 msgstr ""
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr "リロード"
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr "リモートホスト {{name}} は接続されていません"
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr "ホスト名を削除"
 
-#: app/views/menu.html:647 app/views/menu.html:722
+#: app/views/menu.html:665 app/views/menu.html:740
 msgid "Remove"
 msgstr "削除"
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr "全て削除"
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
 msgstr "全て置き換える"
 
@@ -937,11 +963,11 @@ msgstr "全て置き換える"
 msgid "Replace One"
 msgstr "置き換える"
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr "SVGをリセット"
 
-#: app/scripts/services/forms.js:442 app/views/design.html:243
+#: app/scripts/services/forms.js:442 app/views/design.html:241
 msgid "Royal Blue"
 msgstr ""
 
@@ -953,7 +979,7 @@ msgstr "ロシア語"
 msgid "Save"
 msgstr "保存"
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr "SVG を保存"
 
@@ -965,11 +991,11 @@ msgstr "名前を付けて保存"
 msgid "Save submodule"
 msgstr "サブモジュールを保存"
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr "選択"
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr "全て選択"
 
@@ -985,11 +1011,11 @@ msgstr "クロックを確認"
 msgid "Slate Blue"
 msgstr ""
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr ""
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr "ソースコード"
 
@@ -1001,31 +1027,31 @@ msgstr "スペイン語"
 msgid "Spring Green"
 msgstr ""
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr "ビルド開始"
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr "アップロード開始"
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr "検証を開始"
 
-#: app/scripts/services/forms.js:436 app/views/design.html:229
+#: app/scripts/services/forms.js:436 app/views/design.html:227
 msgid "Steel Blue"
 msgstr ""
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr "リモートのファイルを同期…"
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
 msgstr "システム情報"
 
@@ -1041,29 +1067,29 @@ msgstr "テストベンチ"
 msgid "Thank you very much!"
 msgstr ""
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr "コレクション {{name}} は既に存在します。"
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
 msgstr "現在の FPGA I/O 設定が失われます。 ボードを {{name}} に変更しますか？"
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr "ツールチェーンが削除されます。続けますか？"
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr "新しいナイトリー版が利用可能です"
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr "新しい安定版が利用可能です"
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
@@ -1071,7 +1097,7 @@ msgstr ""
 "このインポート操作には、プロジェクトのパスが必要です。現在のプロジェクトを保"
 "存する必要があります。続行しますか？"
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr "このプロジェクトはボード {{name}} 向けです。"
 
@@ -1081,7 +1107,7 @@ msgid ""
 "              done by an emerging team from"
 msgstr ""
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 msgid ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
 "mode\", lock the keylock to do it."
@@ -1089,14 +1115,14 @@ msgstr ""
 "内側のブロックの「編集モード」に入るには、現在の「編集モード」を終了させ、"
 "キーロックをかけて行う必要があります。"
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr "デザインを操作するには、「編集モード」を終了する必要があります。"
 
 #: app/scripts/controllers/menu.js:349
 #, fuzzy
 msgid ""
-"To save your design you need to lock the keylock and               go to top "
+"To save your design you need to lock the padlock and               go to top "
 "level design.<br/><br/>If you want to export               this submodule to "
 "a file, execute \"Save as\" command to do it."
 msgstr ""
@@ -1104,32 +1130,32 @@ msgstr ""
 "要があります。<br/><br/>このサブモジュールをファイルに書き出したい場合は、"
 "「名前を付けて保存」を実行してください。"
 
-#: app/views/menu.html:320
+#: app/views/menu.html:338
 msgid "Toolbox"
 msgstr "ツールボックス"
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr "ツールチェーン"
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr "ツールチェーンがインストールされました"
 
-#: app/scripts/services/drivers.js:594 app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191 app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625 app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300 app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr "ツールチェーンがインストールされていません"
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr "ツールチェーンが削除されました"
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr "ツールチェーンのバージョンが適合しません"
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr "ツール"
 
@@ -1137,11 +1163,11 @@ msgstr "ツール"
 msgid "Turkish"
 msgstr "トルコ語"
 
-#: app/scripts/services/forms.js:433 app/views/design.html:222
+#: app/scripts/services/forms.js:433 app/views/design.html:220
 msgid "Turquoise"
 msgstr ""
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 msgid "UI theme"
 msgstr "UI テーマ"
 
@@ -1149,56 +1175,56 @@ msgstr "UI テーマ"
 msgid "Undo"
 msgstr "戻す"
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr "不明なボード"
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr "非対応のプロジェクトフォーマット {{version}}"
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr "無名"
 
-#: app/views/menu.html:639
+#: app/views/menu.html:657
 msgid "Update (Latest stable)"
 msgstr "アップデート（最新の安定版）"
 
-#: app/scripts/controllers/menu.js:1354 app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371 app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr "アップロード"
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr "アップロード完了"
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr "検証完了"
 
-#: app/views/design.html:510 app/views/menu.html:599
+#: app/views/design.html:498 app/views/menu.html:617
 msgid "Verify"
 msgstr "検証"
 
-#: app/scripts/services/utils.js:641 app/views/menu.html:832
+#: app/scripts/services/utils.js:636 app/views/menu.html:850
 msgid "Version"
 msgstr "バージョン"
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr "バージョン情報"
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr "表示"
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr "ライセンスを確認"
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr "デザインで検出された警告"
 
@@ -1217,62 +1243,71 @@ msgstr "誤ったブロックフォーマット：{{type}}"
 msgid "Wrong block name {{name}}"
 msgstr "誤ったブロック名：{{name}}"
 
-#: app/scripts/controllers/menu.js:1907
+#: app/scripts/controllers/menu.js:1925
 msgid "Wrong new name!"
 msgstr "誤った名前！"
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr "誤ったプロジェクトフォーマット：{{name}}"
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr "誤ったリモートホスト名 {{name}}"
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
 msgstr "誤った検索名！"
 
-#: app/scripts/services/forms.js:412 app/views/design.html:166
+#: app/scripts/services/forms.js:412 app/views/design.html:164
 msgid "Yellow"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:394
+#: app/scripts/controllers/menu.js:409
 #, fuzzy
 msgid ""
-"You are editing a submodule, if you save it, you save only               the "
-"submodule (in this situation \"save as\" works like               \"export "
-"module\"), Do you like to continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 msgstr ""
 "サブモジュールを編集している場合、保存するとサブモジュールだけが保存されます"
 "（この場合、「名前を付けて保存」は「モジュールのエクスポート」のように機能し"
 "ます）。続けますか？"
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+msgstr ""
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr "そのまま読み込むか、ボード {{name}} 用に変換することができます。"
 
-#: app/scripts/controllers/menu.js:1328
+#: app/scripts/controllers/menu.js:1347
+#, fuzzy
 msgid ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 msgstr ""
 "ビルドはトップレベルでのみ可能です。サブモジュールでは<strong>検証</strong>の"
 "み可能です"
 
-#: app/scripts/controllers/menu.js:1355
+#: app/scripts/controllers/menu.js:1372
+#, fuzzy
 msgid ""
-"You can only upload  your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
 msgstr ""
-"アップロードはトップレベルでのみ可能です。サブモジュールでは<strong>検証</"
-"strong>のみ可能です"
+"ビルドはトップレベルでのみ可能です。サブモジュールでは<strong>検証</strong>の"
+"み可能です"
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr "保存しないと変更内容が失われます"
 
@@ -1280,25 +1315,41 @@ msgstr "保存しないと変更内容が失われます"
 msgid "back"
 msgstr "戻る"
 
-#: app/scripts/services/drivers.js:412 app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439 app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr "{{app}} が必要です。"
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr "{{board}} のデータシートが未定義"
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr "{{board}} のピンアウトが未定義"
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr "{{board}} のルールが未定義"
 
-#: app/scripts/controllers/menu.js:483 app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499 app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr "{{name}} がエクスポートされました"
+
+#~ msgid ": '}} {{'Unlock to edit block !"
+#~ msgstr ": '}} {{'ブロックを編集するにはロックを解除してください！"
+
+#~ msgid "CAUTION ! : Changes will also be applied in all the copied"
+#~ msgstr "注意！変更内容はコピーしたものすべてに適用されます"
+
+#~ msgid "Read only"
+#~ msgstr "読み取り専用"
+
+#~ msgid ""
+#~ "You can only upload  your design at top-level design. Inside submodules "
+#~ "you only can <strong>Verify</strong>"
+#~ msgstr ""
+#~ "アップロードはトップレベルでのみ可能です。サブモジュールでは<strong>検証</"
+#~ "strong>のみ可能です"
 
 #~ msgid "Choose a color"
 #~ msgstr "色を選択"

--- a/app/resources/locale/ko_KR/ko_KR.po
+++ b/app/resources/locale/ko_KR/ko_KR.po
@@ -15,15 +15,27 @@ msgstr ""
 "X-Crowdin-Language: ko\n"
 "X-Crowdin-File: kr_ko.po\n"
 
-#: app/views/design.html:20
-msgid ": '}} {{'Unlock to edit block !"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
 msgstr ""
 
-#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr "<b>플러그</b>와<b>를 다시 연결하세요</b>"
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
 msgstr "Icestudio에 대해"
 
@@ -31,11 +43,11 @@ msgstr "Icestudio에 대해"
 msgid "Acknowledgment"
 msgstr ""
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr "더하기"
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr "시작하기 위해 블럭 더하기"
 
@@ -47,24 +59,24 @@ msgstr "블럭으로 더하기"
 msgid "Address format"
 msgstr "주소 구성 방식 "
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr "선택한 것들 모두 지우기"
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr "저장된 모든 컬렉션이 손실될 것입니다. 계속하시곘습니까? "
 
-#: app/scripts/services/tools.js:1389
+#: app/scripts/services/tools.js:1500
 #, fuzzy
 msgid "At least Python 3.7 is required"
 msgstr "파이썬 2.7이 필요합니다"
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr "작가 "
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr "기초 "
 
@@ -76,6 +88,10 @@ msgstr "바스크"
 msgid "Binary"
 msgstr "2진수 "
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr ""
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -85,7 +101,7 @@ msgstr "2진수 "
 msgid "Block updated"
 msgstr "블록 업데이트 "
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr "블록 {{name}} 가져오기"
 
@@ -93,56 +109,52 @@ msgstr "블록 {{name}} 가져오기"
 msgid "Blocks"
 msgstr "블록들 "
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr "보드 "
 
-#: app/views/menu.html:367 app/views/menu.html:458
+#: app/views/menu.html:385 app/views/menu.html:476
 msgid "Board rules"
 msgstr "보드 규칙"
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr "보드 규칙이 지켜지지 않았습니다"
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr "보드 룰을 사용할 수 있습니다"
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr "보드 {{name}} 연결불량 "
 
-#: app/scripts/services/tools.js:607 app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718 app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr "보드 {{name}} 불가능"
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr "보드 {{name}} 연결되지 않았음"
 
-#: app/scripts/app.js:185 app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184 app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr "보드 {{name}} 선택됨 "
 
-#: app/scripts/services/tools.js:596 app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707 app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr "부트로더가 활성화되지 않음 "
 
-#: app/scripts/controllers/menu.js:1327 app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346 app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr "만들기"
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr "만들기 완료 "
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr ""
-
-#: app/scripts/app.js:59 app/scripts/services/project.js:147
+#: app/scripts/app.js:58 app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr "취소 "
 
@@ -150,16 +162,16 @@ msgstr "취소 "
 msgid "Catalan"
 msgstr "카탈란어"
 
-#: app/views/design.html:264
+#: app/views/design.html:262
 #, fuzzy
 msgid "Change Color"
 msgstr "색깔을 선택하세요"
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr "인터넷 연결을 확인하세요."
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr "파이썬을 확인하세요."
 
@@ -172,20 +184,20 @@ msgstr "중국"
 msgid "Choose a color:"
 msgstr "색깔을 선택하세요"
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr "여기를 클릭하여 <b> 새로운 버전을 다운받으세요. </b>"
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr "여기를 클릭하여 <b>드라이버를 설정하세요.</b>"
 
-#: app/scripts/services/drivers.js:413 app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613 app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440 app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644 app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr "설치하려면 여기를 클릭하세요"
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr "확인하려면 여기를 클릭하세요"
 
@@ -197,63 +209,63 @@ msgstr "데이터 버스에는 클럭이 허용되지 않습니다"
 msgid "Clone"
 msgstr "복제 "
 
-#: app/scripts/controllers/menu.js:565 app/views/version.html:80
+#: app/scripts/controllers/menu.js:581 app/views/version.html:80
 msgid "Close"
 msgstr "닫기"
 
-#: app/views/design.html:324 app/views/menu.html:791
+#: app/views/design.html:314 app/views/menu.html:809
 msgid "Code"
 msgstr "코드"
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr "컬렉션 "
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr "컬렉션 정보"
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr "컬렉션 {{collection}} 정보가 정의되지 않았습니다"
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr "컬렉션 {{name}} 추가"
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr "컬렉션 {{name}} 이 교체되지 않았음"
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr "컬렉션 {{name}}  삭제 "
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr "컬렉션 {{name}}  교체"
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr "컬렉션 {{name}} 선택 "
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr "컬렉션들 "
 
-#: app/scripts/controllers/menu.js:1229 app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249 app/views/menu.html:489
 msgid "Command output"
 msgstr "명령 출력"
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr "커뮤니티 포럼"
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr "구성이 완료되지 않음"
 
-#: app/views/design.html:312 app/views/menu.html:783
+#: app/views/design.html:304 app/views/menu.html:801
 msgid "Constant"
 msgstr "정수"
 
@@ -262,7 +274,7 @@ msgstr "정수"
 msgid "Constant names"
 msgstr "정수"
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr "변환"
 
@@ -270,11 +282,11 @@ msgstr "변환"
 msgid "Copy"
 msgstr "복사하기 "
 
-#: app/scripts/services/forms.js:400 app/views/design.html:137
+#: app/scripts/services/forms.js:400 app/views/design.html:136
 msgid "Coral"
 msgstr "코랄"
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr "virtualenv를 생성하기..."
 
@@ -301,15 +313,15 @@ msgstr "암녹색"
 msgid "Dark Orange"
 msgstr "다크오렌지"
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr "암녹색"
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr "다크오렌지"
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr "데이터시트"
 
@@ -317,41 +329,45 @@ msgstr "데이터시트"
 msgid "Decimal"
 msgstr "10진수"
 
-#: app/scripts/services/forms.js:394 app/views/design.html:123
+#: app/scripts/services/forms.js:394 app/views/design.html:122
 #, fuzzy
 msgid "Deep Pink"
 msgstr "진분홍"
 
-#: app/scripts/services/forms.js:439 app/views/design.html:236
+#: app/scripts/services/forms.js:439 app/views/design.html:234
 #, fuzzy
 msgid "Deep Sky Blue"
 msgstr "진파랑"
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr "기본값"
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr ""
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr "설명"
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr "불가"
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr "응용 프로그램을 닫으시겠습니까?"
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr "{{name}} 컬렉션을 삭제하시겠습니까?"
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr "교체하시겠습니까?"
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr "문ㅅ"
 
@@ -359,21 +375,26 @@ msgstr "문ㅅ"
 msgid "Don't display"
 msgstr "표시 안 함"
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr "드라이버"
 
 #: app/scripts/services/drivers.js:252 app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr "드라이버 오류"
 
 #: app/scripts/services/drivers.js:230 app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr "드라이버 가능"
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+#, fuzzy
+msgid "Duplicate"
+msgstr "출력 라벨"
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr "복사된 FPGA I/O 포트"
 
@@ -390,11 +411,11 @@ msgstr "네덜란드어"
 msgid "Edit"
 msgstr "편집"
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr "컬렉션 이름 편집"
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr "가능"
 
@@ -427,15 +448,15 @@ msgstr "입력 포트 입력"
 msgid "Enter the python path"
 msgstr "외부 수집 경로 입력"
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr "원격 호스트 이름 user@host를 입력하십시오"
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr "에러:{{error}}"
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr "디자인에서 에러가 발생하였습니다"
 
@@ -443,7 +464,7 @@ msgstr "디자인에서 에러가 발생하였습니다"
 msgid "Examples"
 msgstr "예시"
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr "원격 {{label}} 시행..."
 
@@ -451,29 +472,29 @@ msgstr "원격 {{label}} 시행..."
 msgid "Export"
 msgstr "추출하다"
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395 app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr "서브모듈을 추출하기"
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr "외부의 콜렉션들"
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr "외부의 콜렉션들이 업데이트 되었습니다"
 
-#: app/views/menu.html:383
+#: app/views/menu.html:401
 #, fuzzy
 msgid "External plugins"
 msgstr "외부의 콜렉션들"
 
-#: app/scripts/controllers/menu.js:780
+#: app/scripts/controllers/menu.js:800
 #, fuzzy
 msgid "External plugins updated"
 msgstr "외부의 콜렉션들이 업데이트 되었습니다"
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr "FPGA I/O 포트가 정의되지 않음"
 
@@ -481,7 +502,7 @@ msgstr "FPGA I/O 포트가 정의되지 않음"
 msgid "FPGA pin"
 msgstr "FPGA 핀"
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr "FPGA 리소스들"
 
@@ -497,16 +518,16 @@ msgstr ""
 msgid "File"
 msgstr "파일"
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr "{{file}} 파일이 프로젝트 경로에 이미 존재합니다. 교체하시겠습니까?"
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr "{{file}}이 존재하지 않음"
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr "{{file}}파일 가져오기"
 
@@ -514,7 +535,7 @@ msgstr "{{file}}파일 가져오기"
 msgid "Find"
 msgstr ""
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr "콘텐츠 맞춤"
 
@@ -522,8 +543,8 @@ msgstr "콘텐츠 맞춤"
 msgid "French"
 msgstr "프랑스어"
 
-#: app/scripts/services/forms.js:385 app/views/design.html:173
-#: app/views/design.html:98
+#: app/scripts/services/forms.js:385 app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr "후치아"
 
@@ -535,7 +556,7 @@ msgstr "갈리시아어"
 msgid "German"
 msgstr "독일어"
 
-#: app/scripts/services/forms.js:409 app/views/design.html:158
+#: app/scripts/services/forms.js:409 app/views/design.html:157
 msgid "Gold"
 msgstr "황금"
 
@@ -548,11 +569,11 @@ msgstr "그리스어"
 msgid "Green Yellow"
 msgstr "녹노랑"
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr "녹노랑"
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr "도움"
 
@@ -565,34 +586,34 @@ msgstr "16진수의"
 msgid "Icestudio is part of"
 msgstr "Icestudio 시작"
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid ""
 "If you have blank IN/OUT pins, it's because there is no equivalent in this "
 "board"
 msgstr "빈 IN/OUT 핀이 있는 경우, 이 보드에 동일한 핀이 없기 때문이다"
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr "사진"
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr "사진 {{name}}이 저장되었음"
 
-#: app/scripts/services/forms.js:388 app/views/design.html:109
+#: app/scripts/services/forms.js:388 app/views/design.html:108
 #, fuzzy
 msgid "Indian Red"
 msgstr "인디안 빨강"
 
-#: app/views/design.html:330 app/views/menu.html:795
+#: app/views/design.html:319 app/views/menu.html:813
 msgid "Information"
 msgstr "정보"
 
-#: app/views/design.html:282 app/views/menu.html:760
+#: app/views/design.html:279 app/views/menu.html:778
 msgid "Input"
 msgstr "입력"
 
-#: app/views/design.html:294 app/views/menu.html:769
+#: app/views/design.html:289 app/views/menu.html:787
 msgid "Input label"
 msgstr "입력 라벨"
 
@@ -615,23 +636,23 @@ msgstr ""
 msgid "Input ports"
 msgstr "입력 포트 입력"
 
-#: app/views/menu.html:635
+#: app/views/menu.html:653
 #, fuzzy
 msgid "Install (Stable)"
 msgstr "설치"
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
 msgstr ""
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid ""
 "Install the <b>STABLE Toolchain</b>. This operation requires Internet "
 "connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
 "allow the toolchain installation</p> <p>Do you want to continue?</p>"
 msgstr ""
 
-#: app/scripts/services/tools.js:1144
+#: app/scripts/services/tools.js:1255
 #, fuzzy
 msgid ""
 "Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
@@ -640,7 +661,7 @@ msgstr ""
 "툴체인 업데이트 예정입니다. 이 작업은 인터넷 연결이 필요합니다. 계속하시겠습"
 "니까?"
 
-#: app/scripts/services/tools.js:1166
+#: app/scripts/services/tools.js:1277
 #, fuzzy
 msgid ""
 "Install the LATEST STABLE toolchain. It will be downloaded. This operation "
@@ -649,49 +670,49 @@ msgstr ""
 "툴체인 업데이트 예정입니다. 이 작업은 인터넷 연결이 필요합니다. 계속하시겠습"
 "니까?"
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr "설치 완료"
 
-#: app/scripts/services/tools.js:1274
+#: app/scripts/services/tools.js:1385
 #, fuzzy
 msgid "Installing"
 msgstr "설치"
 
-#: app/scripts/services/drivers.js:421 app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447 app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr "인터넷 연결 필요"
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr "잘못된 <i>풀 업 </i> 연결: <br> 블록이 이미 연결됨"
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr "잘못된 <i>풀 업 </i> 연결: <i>만 허용됨"
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr "잘못된 블록 연결: <br><i>Pull up </i>가 이미 연결됨"
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr "잘못된 컬렉션 {{name}}"
 
-#: app/scripts/services/graph.js:254 app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262 app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr "잘못 된 연결"
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr "잘못된 연결: {{a} → {{b}}"
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr "잘못된 다중 입력 연결"
 
-#: app/scripts/services/project.js:499 app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510 app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr "잘못된 프로젝트 형식"
 
@@ -708,7 +729,7 @@ msgstr "스페인어"
 msgid "Korean"
 msgstr ""
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
 msgstr ""
 
@@ -717,7 +738,7 @@ msgstr ""
 msgid "Label updated"
 msgstr "블록 업데이트 "
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr "언어"
 
@@ -725,17 +746,17 @@ msgstr "언어"
 msgid "Light"
 msgstr ""
 
-#: app/scripts/services/forms.js:448 app/views/design.html:257
+#: app/scripts/services/forms.js:448 app/views/design.html:255
 #, fuzzy
 msgid "Light Gray"
 msgstr "밝은 바다 초록"
 
-#: app/scripts/services/forms.js:430 app/views/design.html:215
+#: app/scripts/services/forms.js:430 app/views/design.html:213
 #, fuzzy
 msgid "Light Sea Green"
 msgstr "밝은 바다 초록"
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr "로드"
 
@@ -743,20 +764,20 @@ msgstr "로드"
 msgid "Local parameter"
 msgstr "지역 변수"
 
-#: app/views/menu.html:404
+#: app/views/menu.html:422
 #, fuzzy
 msgid "Logging enabled"
 msgstr "드라이버 가능"
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
 msgstr ""
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr "최대 버스 크기: 96비트"
 
@@ -765,11 +786,11 @@ msgstr "최대 버스 크기: 96비트"
 msgid "Medium Violet Red"
 msgstr "미디엄 바이올렛 레드"
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr "미디엄 바이올렛 레드"
 
-#: app/views/design.html:318 app/views/menu.html:787
+#: app/views/design.html:309 app/views/menu.html:805
 msgid "Memory"
 msgstr "메모리"
 
@@ -778,7 +799,7 @@ msgstr "메모리"
 msgid "Memory blocks"
 msgstr "메모리 블록 입력"
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr "이름"
 
@@ -786,7 +807,7 @@ msgstr "이름"
 msgid "Name of the paired labels"
 msgstr ""
 
-#: app/scripts/services/forms.js:445 app/views/design.html:250
+#: app/scripts/services/forms.js:445 app/views/design.html:248
 msgid "Navy"
 msgstr "남색"
 
@@ -800,15 +821,19 @@ msgstr ""
 
 #: app/views/design.html:80
 #, fuzzy
-msgid "New Name:"
+msgid "New Name"
 msgstr "이름"
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr ""
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr "저장된 컬렉션 없음"
 
-#: app/scripts/app.js:58 app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57 app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr "알겠습니다"
 
@@ -817,7 +842,7 @@ msgstr "알겠습니다"
 msgid "Olive Drab"
 msgstr "생기없는 올리브"
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr "생기없는 올리브"
 
@@ -825,7 +850,7 @@ msgstr "생기없는 올리브"
 msgid "Open"
 msgstr "열기"
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr "SVG 열기"
 
@@ -834,19 +859,19 @@ msgstr "SVG 열기"
 msgid "Orange Red"
 msgstr "오렌지 레드"
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr "오렌지 레드"
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr "원본 파일 {{file}} 이 존재하지 않습니다"
 
-#: app/views/design.html:288 app/views/menu.html:764
+#: app/views/design.html:284 app/views/menu.html:782
 msgid "Output"
 msgstr "출력"
 
-#: app/views/design.html:300 app/views/menu.html:773
+#: app/views/design.html:294 app/views/menu.html:791
 msgid "Output label"
 msgstr "출력 라벨"
 
@@ -865,7 +890,7 @@ msgstr "출력 라벨"
 msgid "Output ports"
 msgstr "출력 라벨"
 
-#: app/views/design.html:306 app/views/menu.html:778
+#: app/views/design.html:299 app/views/menu.html:796
 msgid "Paired labels"
 msgstr ""
 
@@ -873,40 +898,44 @@ msgstr ""
 msgid "Paste"
 msgstr "붙여넣기"
 
-#: app/scripts/controllers/menu.js:731 app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853 app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751 app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873 app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr "경로 {{path}} 가 존재하지 않습니다"
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr "작동: {{cmd}}"
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr "선호"
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr ""
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr "프로젝트 정보"
 
-#: app/scripts/controllers/menu.js:935 app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955 app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr "프로젝트 정보가 업데이트되었습니다"
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr "프로젝트 {{name}}이 로드되었습니다"
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr "프로젝트 {{name}}이 저장되었습니다"
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
 msgstr ""
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
 msgstr ""
 
@@ -914,11 +943,7 @@ msgstr ""
 msgid "Quit"
 msgstr "끝내기"
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr "읽기 전용"
-
-#: app/scripts/services/forms.js:391 app/views/design.html:116
+#: app/scripts/services/forms.js:391 app/views/design.html:115
 msgid "Red"
 msgstr "빨강"
 
@@ -930,27 +955,27 @@ msgstr "다시하기"
 msgid "Release History WIKI"
 msgstr ""
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr "다시로드하기"
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr "원격 호스트 {{name}}이 연결되지 않음"
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr "원격 호스트이름"
 
-#: app/views/menu.html:647 app/views/menu.html:722
+#: app/views/menu.html:665 app/views/menu.html:740
 msgid "Remove"
 msgstr "지우기"
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr "모두 지우기"
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
 msgstr ""
 
@@ -958,11 +983,11 @@ msgstr ""
 msgid "Replace One"
 msgstr ""
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr "SVG 재설정"
 
-#: app/scripts/services/forms.js:442 app/views/design.html:243
+#: app/scripts/services/forms.js:442 app/views/design.html:241
 #, fuzzy
 msgid "Royal Blue"
 msgstr "로얄 블루"
@@ -975,7 +1000,7 @@ msgstr "러시아어"
 msgid "Save"
 msgstr "저장하다"
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr "SVG 저장"
 
@@ -987,11 +1012,11 @@ msgstr "다른이름으로 저장하기"
 msgid "Save submodule"
 msgstr "서브모듈 저장"
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr "선택"
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr "모두 선택"
 
@@ -1008,11 +1033,11 @@ msgstr "시계를 표시"
 msgid "Slate Blue"
 msgstr "슬레이트 블루"
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr "슬레이트 블루"
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr "소스코드"
 
@@ -1025,32 +1050,32 @@ msgstr "스페인어"
 msgid "Spring Green"
 msgstr "봄 초록"
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr "봄 초록"
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr "빌드 시작"
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr "업로드 시작"
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr "검증 시작"
 
-#: app/scripts/services/forms.js:436 app/views/design.html:229
+#: app/scripts/services/forms.js:436 app/views/design.html:227
 #, fuzzy
 msgid "Steel Blue"
 msgstr "파란금속"
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr "원격 파일 동기화..."
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
 msgstr ""
 
@@ -1066,29 +1091,29 @@ msgstr "테스트벤치"
 msgid "Thank you very much!"
 msgstr ""
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr "컬렉션 {{name}}이(가) 이미 존재합니다."
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
 msgstr "현재 FPGA I/O 구성이 손실됩ㄴ다. {{name}}보드로 변경하시겠습니까?"
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr "툴체인이 제거됩니다. 계속하시겠습니까?"
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr "새로운 야간 버전이 출시되었다"
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr "새로운 안정한 버전이 출시되었다"
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
@@ -1096,7 +1121,7 @@ msgstr ""
 "이 가져오기 작업에는 프로젝트 경로가 필요합니다. 현재 프로젝트를 저장해야 합"
 "니다. 계속하시겠습니까?"
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr "이 프로젝트는 {{name}}보드에 맞게 설계되었다."
 
@@ -1106,7 +1131,7 @@ msgid ""
 "              done by an emerging team from"
 msgstr ""
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 msgid ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
 "mode\", lock the keylock to do it."
@@ -1114,14 +1139,14 @@ msgstr ""
 "\"편집 모드\"의 깊은 블락에 들어가기위해서, 현재 \"편집모드\"를 키 락으로 잠"
 "가야 합니다"
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr "디자인을 보기위해서는, \"편집모드\"를 닫아야합니다."
 
 #: app/scripts/controllers/menu.js:349
 #, fuzzy
 msgid ""
-"To save your design you need to lock the keylock and               go to top "
+"To save your design you need to lock the padlock and               go to top "
 "level design.<br/><br/>If you want to export               this submodule to "
 "a file, execute \"Save as\" command to do it."
 msgstr ""
@@ -1129,33 +1154,33 @@ msgstr ""
 "모듈을 파일로 내보내려면 \"다른 이름으로 저장\" 명령을 실행하여 파일을 내보내"
 "십시오."
 
-#: app/views/menu.html:320
+#: app/views/menu.html:338
 #, fuzzy
 msgid "Toolbox"
 msgstr "도구들"
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr "툴체인"
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr "툴체인이 설치됨"
 
-#: app/scripts/services/drivers.js:594 app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191 app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625 app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300 app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr "툴체인이 설치되지 않았음"
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr "툴체인이 제거되었음"
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr "Toolchain 버전이 일치하지 않음"
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr "도구들"
 
@@ -1163,11 +1188,11 @@ msgstr "도구들"
 msgid "Turkish"
 msgstr ""
 
-#: app/scripts/services/forms.js:433 app/views/design.html:222
+#: app/scripts/services/forms.js:433 app/views/design.html:220
 msgid "Turquoise"
 msgstr "터키옥"
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 msgid "UI theme"
 msgstr ""
 
@@ -1175,57 +1200,57 @@ msgstr ""
 msgid "Undo"
 msgstr "뒤로가기"
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr "알 수 없는 보드"
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr "지원되지 않는 프로젝트 형식 {{version}}"
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr "제목이 없음"
 
-#: app/views/menu.html:639
+#: app/views/menu.html:657
 #, fuzzy
 msgid "Update (Latest stable)"
 msgstr "블럭 이름 업데이트"
 
-#: app/scripts/controllers/menu.js:1354 app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371 app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr "업로드"
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr "업로드 완료"
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr "검증 완료"
 
-#: app/views/design.html:510 app/views/menu.html:599
+#: app/views/design.html:498 app/views/menu.html:617
 msgid "Verify"
 msgstr "입증하다"
 
-#: app/scripts/services/utils.js:641 app/views/menu.html:832
+#: app/scripts/services/utils.js:636 app/views/menu.html:850
 msgid "Version"
 msgstr "버전"
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr "버전 노트"
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr "보기"
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr "라이선스 보기"
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr "설계에서 경고가 감지되었습니다"
 
@@ -1244,62 +1269,71 @@ msgstr "잘못된 블록 형식: {{type}}"
 msgid "Wrong block name {{name}}"
 msgstr "잘못된 블럭 이름{{name}}"
 
-#: app/scripts/controllers/menu.js:1907
+#: app/scripts/controllers/menu.js:1925
 #, fuzzy
 msgid "Wrong new name!"
 msgstr "잘못 된 포트 이름{{name}}"
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr "잘못된 프로젝트 형식: {{name}}"
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr "잘못된 원격 호스트 이름 {{name}}"
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
 msgstr ""
 
-#: app/scripts/services/forms.js:412 app/views/design.html:166
+#: app/scripts/services/forms.js:412 app/views/design.html:164
 msgid "Yellow"
 msgstr "노란색"
 
-#: app/scripts/controllers/menu.js:394
+#: app/scripts/controllers/menu.js:409
 #, fuzzy
 msgid ""
-"You are editing a submodule, if you save it, you save only               the "
-"submodule (in this situation \"save as\" works like               \"export "
-"module\"), Do you like to continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 msgstr ""
 "서브모듈을 편집하는 중에 서브모듈만 저장하면(이 경우 \"추출 된 모듈\"과 같은 "
 "\"저장\"이 작동함), 계속하시겠습니까?"
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+msgstr ""
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr "그대로 로드하거나 {{name}}보드로 변환 할 수 있다."
 
-#: app/scripts/controllers/menu.js:1328
+#: app/scripts/controllers/menu.js:1347
+#, fuzzy
 msgid ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 msgstr ""
 "최상위 레벨 디자인만을 빌드할 수 있습니다.서브모듈은 오직 입증만 <strong> 가"
 "능합니다"
 
-#: app/scripts/controllers/menu.js:1355
+#: app/scripts/controllers/menu.js:1372
+#, fuzzy
 msgid ""
-"You can only upload  your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
 msgstr ""
-"최고 수준의 설계에서만 디자인을 업로드할 수 있습니다.하위 모듈 내부에서는 "
-"<strong>만 확인할 수 있음"
+"최상위 레벨 디자인만을 빌드할 수 있습니다.서브모듈은 오직 입증만 <strong> 가"
+"능합니다"
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr "변경사항을 저장하지 않으면 변경내용이 손실 될 것입니다"
 
@@ -1307,25 +1341,35 @@ msgstr "변경사항을 저장하지 않으면 변경내용이 손실 될 것입
 msgid "back"
 msgstr "뒤로가기"
 
-#: app/scripts/services/drivers.js:412 app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439 app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr "{{앱}}이 필요합니다."
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr "{{board}}데이터시트가 정의되지 않았습니다"
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr "{{board}}핀아웃이 정의되지 않았습니다"
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr "{{board}} 규칙이 정의되지 않았습니다"
 
-#: app/scripts/controllers/menu.js:483 app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499 app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr "{{name}} 이 추출되었습니다"
+
+#~ msgid "Read only"
+#~ msgstr "읽기 전용"
+
+#~ msgid ""
+#~ "You can only upload  your design at top-level design. Inside submodules "
+#~ "you only can <strong>Verify</strong>"
+#~ msgstr ""
+#~ "최고 수준의 설계에서만 디자인을 업로드할 수 있습니다.하위 모듈 내부에서는 "
+#~ "<strong>만 확인할 수 있음"
 
 #~ msgid "Choose a color"
 #~ msgstr "색깔을 선택하세요"

--- a/app/resources/locale/nl_NL/nl_NL.po
+++ b/app/resources/locale/nl_NL/nl_NL.po
@@ -12,15 +12,27 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: app/views/design.html:20
-msgid ": '}} {{'Unlock to edit block !"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
 msgstr ""
 
-#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr "<b>Unplug</b> en <b>sluit</b> het bord <b>opnieuw aan</b>"
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
 msgstr "Over Icestudio"
 
@@ -28,11 +40,11 @@ msgstr "Over Icestudio"
 msgid "Acknowledgment"
 msgstr ""
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr "Plaatsen"
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr "Plaats een blok om te beginnen"
 
@@ -44,24 +56,24 @@ msgstr "Plaatsen als blok"
 msgid "Address format"
 msgstr "Adresformaat"
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr "Alle collecties zijn verwijderd"
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr "Alle opgeslagen collecties worden verwijderd. Doorgaan?"
 
-#: app/scripts/services/tools.js:1389
+#: app/scripts/services/tools.js:1500
 #, fuzzy
 msgid "At least Python 3.7 is required"
 msgstr "Python 2.7 is vereist"
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr "Auteur"
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr "Standaard"
 
@@ -73,6 +85,10 @@ msgstr "Baskisch"
 msgid "Binary"
 msgstr "Binaire"
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr ""
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -82,7 +98,7 @@ msgstr "Binaire"
 msgid "Block updated"
 msgstr "Blok bijgewerkt"
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr "Blok {{name}} geïmporteerd"
 
@@ -90,56 +106,52 @@ msgstr "Blok {{name}} geïmporteerd"
 msgid "Blocks"
 msgstr "Blokken"
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr "Bord"
 
-#: app/views/menu.html:367 app/views/menu.html:458
+#: app/views/menu.html:385 app/views/menu.html:476
 msgid "Board rules"
 msgstr "Bord regels"
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr "Bord regels gedesactiveerd"
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr "Bord regels geactiveerd"
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr "Bord {{name}} verbinding verbroken"
 
-#: app/scripts/services/tools.js:607 app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718 app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr "Bord {{naam}} niet beschikbaar"
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr "Bord {{naam}} niet aangesloten"
 
-#: app/scripts/app.js:185 app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184 app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr "Bord {{name}} geselecteerd"
 
-#: app/scripts/services/tools.js:596 app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707 app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr "Bootloader niet actief"
 
-#: app/scripts/controllers/menu.js:1327 app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346 app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr "Maken"
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr "Maken voltooid"
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr ""
-
-#: app/scripts/app.js:59 app/scripts/services/project.js:147
+#: app/scripts/app.js:58 app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr "Annuleren"
 
@@ -147,15 +159,15 @@ msgstr "Annuleren"
 msgid "Catalan"
 msgstr "Catalaans"
 
-#: app/views/design.html:264
+#: app/views/design.html:262
 msgid "Change Color"
 msgstr ""
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr "Controleer de Internet verbinding..."
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr "Controleer python..."
 
@@ -167,20 +179,20 @@ msgstr "Chinees"
 msgid "Choose a color:"
 msgstr ""
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr "Klik hier om <b>een nieuwe versie van IceStudio te downloaden</b>"
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr "Klik hier om <b>nieuwe drivers te installeren</b>"
 
-#: app/scripts/services/drivers.js:413 app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613 app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440 app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644 app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr "Klik hier om te installeren"
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr "Klik hier om te bekijken"
 
@@ -192,63 +204,63 @@ msgstr "Klok is niet toegestaan op databussen"
 msgid "Clone"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:565 app/views/version.html:80
+#: app/scripts/controllers/menu.js:581 app/views/version.html:80
 msgid "Close"
 msgstr "Sluiten"
 
-#: app/views/design.html:324 app/views/menu.html:791
+#: app/views/design.html:314 app/views/menu.html:809
 msgid "Code"
 msgstr "Code"
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr "Collectie"
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr "Collectie-informatie"
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr "Collectie {{collection}} informatie niet gedefinieerd"
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr "Collectie {{name}} toegevoegd"
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr "Collectie {{name}} niet vervangen"
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr "Collectie {{name}} verwijderd"
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr "Collectie {{name}} vervangen"
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr "Collectie {{name}} geselecteerd"
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr "Collecties"
 
-#: app/scripts/controllers/menu.js:1229 app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249 app/views/menu.html:489
 msgid "Command output"
 msgstr "Commando resultaat"
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr "Gemeenschapsforum"
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr "Configuratie niet voltooid"
 
-#: app/views/design.html:312 app/views/menu.html:783
+#: app/views/design.html:304 app/views/menu.html:801
 msgid "Constant"
 msgstr "Constant"
 
@@ -257,7 +269,7 @@ msgstr "Constant"
 msgid "Constant names"
 msgstr "Constant"
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr "Converteren"
 
@@ -265,11 +277,11 @@ msgstr "Converteren"
 msgid "Copy"
 msgstr "Kopiëren"
 
-#: app/scripts/services/forms.js:400 app/views/design.html:137
+#: app/scripts/services/forms.js:400 app/views/design.html:136
 msgid "Coral"
 msgstr ""
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr "Creëer virtualenv..."
 
@@ -294,15 +306,15 @@ msgstr ""
 msgid "Dark Orange"
 msgstr ""
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr ""
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr ""
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr "Datasheet"
 
@@ -310,39 +322,43 @@ msgstr "Datasheet"
 msgid "Decimal"
 msgstr "Decimaal"
 
-#: app/scripts/services/forms.js:394 app/views/design.html:123
+#: app/scripts/services/forms.js:394 app/views/design.html:122
 msgid "Deep Pink"
 msgstr ""
 
-#: app/scripts/services/forms.js:439 app/views/design.html:236
+#: app/scripts/services/forms.js:439 app/views/design.html:234
 msgid "Deep Sky Blue"
 msgstr ""
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr "Standaard"
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr ""
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr "Beschrijving"
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr "Desactiveren"
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr "Programma sluiten?"
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr "Collectie {{name}} verwijderen?"
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr "Vervangen?"
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr "Documentatie"
 
@@ -350,21 +366,26 @@ msgstr "Documentatie"
 msgid "Don't display"
 msgstr ""
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr "Drivers"
 
 #: app/scripts/services/drivers.js:252 app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr "Drivers gedesactiveerd"
 
 #: app/scripts/services/drivers.js:230 app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr "Drivers geactiveerd"
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+#, fuzzy
+msgid "Duplicate"
+msgstr "Dubbele FPGA I/O poorten"
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr "Dubbele FPGA I/O poorten"
 
@@ -381,11 +402,11 @@ msgstr "Nederlands"
 msgid "Edit"
 msgstr "Bewerken"
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr "Bewerk de naam van de collectie"
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr "Activeren"
 
@@ -418,15 +439,15 @@ msgstr "Voer de ingangspoorten in"
 msgid "Enter the python path"
 msgstr "Voer het pad naar de externe collectie in"
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr "Voer de externe hostnaam user@host in"
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr "Fout: {{error}}"
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr "Het ontwerp bevat fouten"
 
@@ -434,7 +455,7 @@ msgstr "Het ontwerp bevat fouten"
 msgid "Examples"
 msgstr "Voorbeelden"
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr "Executeer externe {{label}} ..."
 
@@ -442,29 +463,29 @@ msgstr "Executeer externe {{label}} ..."
 msgid "Export"
 msgstr "Exporteren"
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395 app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr ""
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr "Externe collecties"
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr "Externe collecties bijgewerkt"
 
-#: app/views/menu.html:383
+#: app/views/menu.html:401
 #, fuzzy
 msgid "External plugins"
 msgstr "Externe collecties"
 
-#: app/scripts/controllers/menu.js:780
+#: app/scripts/controllers/menu.js:800
 #, fuzzy
 msgid "External plugins updated"
 msgstr "Externe collecties bijgewerkt"
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr "FPGA I/O poorten zijn niet gedefinieerd"
 
@@ -472,7 +493,7 @@ msgstr "FPGA I/O poorten zijn niet gedefinieerd"
 msgid "FPGA pin"
 msgstr "FPGA pin"
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr "FPGA resources"
 
@@ -488,16 +509,16 @@ msgstr ""
 msgid "File"
 msgstr "Bestand"
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr "Bestand {{file}} is al aanwezig in het projectpad. Vervangen?"
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr "Bestand {{file}} bestaat niet"
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr "Bestand {{file}} geïmporteerd"
 
@@ -505,7 +526,7 @@ msgstr "Bestand {{file}} geïmporteerd"
 msgid "Find"
 msgstr ""
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr "Maak passend"
 
@@ -513,8 +534,8 @@ msgstr "Maak passend"
 msgid "French"
 msgstr "Frans"
 
-#: app/scripts/services/forms.js:385 app/views/design.html:173
-#: app/views/design.html:98
+#: app/scripts/services/forms.js:385 app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr ""
 
@@ -526,7 +547,7 @@ msgstr "Galicisch"
 msgid "German"
 msgstr "Duits"
 
-#: app/scripts/services/forms.js:409 app/views/design.html:158
+#: app/scripts/services/forms.js:409 app/views/design.html:157
 msgid "Gold"
 msgstr ""
 
@@ -538,11 +559,11 @@ msgstr ""
 msgid "Green Yellow"
 msgstr ""
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr ""
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr "Help"
 
@@ -554,33 +575,33 @@ msgstr "Hexadecimaal"
 msgid "Icestudio is part of"
 msgstr ""
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid ""
 "If you have blank IN/OUT pins, it's because there is no equivalent in this "
 "board"
 msgstr ""
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr "Afbeelding"
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr "Afbeelding {{name}} opgeslagen"
 
-#: app/scripts/services/forms.js:388 app/views/design.html:109
+#: app/scripts/services/forms.js:388 app/views/design.html:108
 msgid "Indian Red"
 msgstr ""
 
-#: app/views/design.html:330 app/views/menu.html:795
+#: app/views/design.html:319 app/views/menu.html:813
 msgid "Information"
 msgstr "Informatie"
 
-#: app/views/design.html:282 app/views/menu.html:760
+#: app/views/design.html:279 app/views/menu.html:778
 msgid "Input"
 msgstr "Ingang"
 
-#: app/views/design.html:294 app/views/menu.html:769
+#: app/views/design.html:289 app/views/menu.html:787
 msgid "Input label"
 msgstr ""
 
@@ -603,23 +624,23 @@ msgstr ""
 msgid "Input ports"
 msgstr "Voer de ingangspoorten in"
 
-#: app/views/menu.html:635
+#: app/views/menu.html:653
 #, fuzzy
 msgid "Install (Stable)"
 msgstr "Installeren"
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
 msgstr ""
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid ""
 "Install the <b>STABLE Toolchain</b>. This operation requires Internet "
 "connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
 "allow the toolchain installation</p> <p>Do you want to continue?</p>"
 msgstr ""
 
-#: app/scripts/services/tools.js:1144
+#: app/scripts/services/tools.js:1255
 #, fuzzy
 msgid ""
 "Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
@@ -628,7 +649,7 @@ msgstr ""
 "De toolchain wordt bijgewerkt. Hiervoor is een internetverbinding vereist. "
 "Doorgaan?"
 
-#: app/scripts/services/tools.js:1166
+#: app/scripts/services/tools.js:1277
 #, fuzzy
 msgid ""
 "Install the LATEST STABLE toolchain. It will be downloaded. This operation "
@@ -637,51 +658,51 @@ msgstr ""
 "De toolchain wordt bijgewerkt. Hiervoor is een internetverbinding vereist. "
 "Doorgaan?"
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr "Installatie voltooid"
 
-#: app/scripts/services/tools.js:1274
+#: app/scripts/services/tools.js:1385
 #, fuzzy
 msgid "Installing"
 msgstr "Installeren"
 
-#: app/scripts/services/drivers.js:421 app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447 app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr "Internet verbinding vereist"
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr "Ongeldige <i>pull up</i> aansluiting:<br>blok is al aangesloten"
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr ""
 "Ongeldige <i>pull up</i> aansluiting:<br>alleen <i>ingangsblokken</i> zijn "
 "toegestaan"
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr "Ongeldige blokaansluiting:<br><i>pull up</i> is al aangesloten"
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr "Ongeldige collectie {{name}}"
 
-#: app/scripts/services/graph.js:254 app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262 app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr "Ongeldige aansluiting"
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr "Ongeldige aansluiting: {{a}} → {{b}}"
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr "Ongeldige meervoudige ingangsaansluitingen"
 
-#: app/scripts/services/project.js:499 app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510 app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr "Ongeldig projectformaat"
 
@@ -698,7 +719,7 @@ msgstr "Spaans"
 msgid "Korean"
 msgstr ""
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
 msgstr ""
 
@@ -707,7 +728,7 @@ msgstr ""
 msgid "Label updated"
 msgstr "Blok bijgewerkt"
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr "Taal"
 
@@ -715,15 +736,15 @@ msgstr "Taal"
 msgid "Light"
 msgstr ""
 
-#: app/scripts/services/forms.js:448 app/views/design.html:257
+#: app/scripts/services/forms.js:448 app/views/design.html:255
 msgid "Light Gray"
 msgstr ""
 
-#: app/scripts/services/forms.js:430 app/views/design.html:215
+#: app/scripts/services/forms.js:430 app/views/design.html:213
 msgid "Light Sea Green"
 msgstr ""
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr "Laden"
 
@@ -731,20 +752,20 @@ msgstr "Laden"
 msgid "Local parameter"
 msgstr "Lokale parameter"
 
-#: app/views/menu.html:404
+#: app/views/menu.html:422
 #, fuzzy
 msgid "Logging enabled"
 msgstr "Drivers geactiveerd"
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
 msgstr ""
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr "Maximale busbreedte: 96 bits"
 
@@ -752,11 +773,11 @@ msgstr "Maximale busbreedte: 96 bits"
 msgid "Medium Violet Red"
 msgstr ""
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr ""
 
-#: app/views/design.html:318 app/views/menu.html:787
+#: app/views/design.html:309 app/views/menu.html:805
 msgid "Memory"
 msgstr "Geheugen"
 
@@ -765,7 +786,7 @@ msgstr "Geheugen"
 msgid "Memory blocks"
 msgstr "Voer de geheugenblokken in"
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr "Naam"
 
@@ -773,7 +794,7 @@ msgstr "Naam"
 msgid "Name of the paired labels"
 msgstr ""
 
-#: app/scripts/services/forms.js:445 app/views/design.html:250
+#: app/scripts/services/forms.js:445 app/views/design.html:248
 msgid "Navy"
 msgstr ""
 
@@ -787,15 +808,19 @@ msgstr ""
 
 #: app/views/design.html:80
 #, fuzzy
-msgid "New Name:"
+msgid "New Name"
 msgstr "Naam"
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr ""
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr "Geen collecties"
 
-#: app/scripts/app.js:58 app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57 app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr "OK"
 
@@ -803,7 +828,7 @@ msgstr "OK"
 msgid "Olive Drab"
 msgstr ""
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr ""
 
@@ -811,7 +836,7 @@ msgstr ""
 msgid "Open"
 msgstr "Openen"
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr "Open SVG"
 
@@ -819,19 +844,19 @@ msgstr "Open SVG"
 msgid "Orange Red"
 msgstr ""
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr ""
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr "Originele bestand {{file}} bestaat niet"
 
-#: app/views/design.html:288 app/views/menu.html:764
+#: app/views/design.html:284 app/views/menu.html:782
 msgid "Output"
 msgstr "Uitgang"
 
-#: app/views/design.html:300 app/views/menu.html:773
+#: app/views/design.html:294 app/views/menu.html:791
 msgid "Output label"
 msgstr ""
 
@@ -849,7 +874,7 @@ msgstr ""
 msgid "Output ports"
 msgstr "Uitgang"
 
-#: app/views/design.html:306 app/views/menu.html:778
+#: app/views/design.html:299 app/views/menu.html:796
 msgid "Paired labels"
 msgstr ""
 
@@ -857,40 +882,44 @@ msgstr ""
 msgid "Paste"
 msgstr "Plakken"
 
-#: app/scripts/controllers/menu.js:731 app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853 app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751 app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873 app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr "Pad {{file}} bestaat niet"
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr "Voer uit: {{cmd}}"
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr "Voorkeuren"
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr ""
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr "Projectinformatie"
 
-#: app/scripts/controllers/menu.js:935 app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955 app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr "Projectinformatie bijgewerkt"
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr "Project {{name}} geladen"
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr "Project {{name}} opgeslagen"
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
 msgstr ""
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
 msgstr ""
 
@@ -898,11 +927,7 @@ msgstr ""
 msgid "Quit"
 msgstr "Afsluiten"
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr "Alleen lezen"
-
-#: app/scripts/services/forms.js:391 app/views/design.html:116
+#: app/scripts/services/forms.js:391 app/views/design.html:115
 #, fuzzy
 msgid "Red"
 msgstr "Opnieuw"
@@ -915,27 +940,27 @@ msgstr "Opnieuw"
 msgid "Release History WIKI"
 msgstr ""
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr "Herladen"
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr "Externe host {{name}} niet verbonden"
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr "Externe hostnaam"
 
-#: app/views/menu.html:647 app/views/menu.html:722
+#: app/views/menu.html:665 app/views/menu.html:740
 msgid "Remove"
 msgstr "Verwijderen"
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr "Alles verwijderen"
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
 msgstr ""
 
@@ -943,11 +968,11 @@ msgstr ""
 msgid "Replace One"
 msgstr ""
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr "Reset SVG"
 
-#: app/scripts/services/forms.js:442 app/views/design.html:243
+#: app/scripts/services/forms.js:442 app/views/design.html:241
 msgid "Royal Blue"
 msgstr ""
 
@@ -959,7 +984,7 @@ msgstr ""
 msgid "Save"
 msgstr "Opslaan"
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr "SVG opslaan"
 
@@ -971,11 +996,11 @@ msgstr "Opslaan als"
 msgid "Save submodule"
 msgstr ""
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr "Selecteren"
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr "Alles selecteren"
 
@@ -993,11 +1018,11 @@ msgstr ""
 msgid "Slate Blue"
 msgstr ""
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr ""
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr "Broncode"
 
@@ -1009,31 +1034,31 @@ msgstr "Spaans"
 msgid "Spring Green"
 msgstr ""
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr "Maken starten"
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr "Upload starten"
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr "Verificatie starten"
 
-#: app/scripts/services/forms.js:436 app/views/design.html:229
+#: app/scripts/services/forms.js:436 app/views/design.html:227
 msgid "Steel Blue"
 msgstr ""
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr "Synchroniseer externe bestanden..."
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
 msgstr ""
 
@@ -1049,11 +1074,11 @@ msgstr "Testbank"
 msgid "Thank you very much!"
 msgstr ""
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr "Collectie {{name}} bestaat al."
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
@@ -1061,19 +1086,19 @@ msgstr ""
 "De huidige FPGA I/O configuratie zal verloren gaan. Doorgaan met bord "
 "{{name}}?"
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr "De toolchain wordt verwijderd. Doorgaan?"
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr ""
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr ""
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
@@ -1081,7 +1106,7 @@ msgstr ""
 "Voor deze importoperatie is een projectpad nodig. U moet het huidige project "
 "opslaan. Doorgaan?"
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr "Dit project is bedoeld voor het bord {{name}}"
 
@@ -1091,50 +1116,50 @@ msgid ""
 "              done by an emerging team from"
 msgstr ""
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 msgid ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
 "mode\", lock the keylock to do it."
 msgstr ""
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr ""
 
 #: app/scripts/controllers/menu.js:349
 msgid ""
-"To save your design you need to lock the keylock and               go to top "
+"To save your design you need to lock the padlock and               go to top "
 "level design.<br/><br/>If you want to export               this submodule to "
 "a file, execute \"Save as\" command to do it."
 msgstr ""
 
-#: app/views/menu.html:320
+#: app/views/menu.html:338
 #, fuzzy
 msgid "Toolbox"
 msgstr "Gereedschappen"
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr "Toolchain"
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr "Toolchain geïnstalleerd"
 
-#: app/scripts/services/drivers.js:594 app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191 app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625 app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300 app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr "Toolchain niet geïnstalleerd"
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr "Toolchain verwijderd"
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr "Toolchain versie komt niet overeen"
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr "Gereedschappen"
 
@@ -1142,11 +1167,11 @@ msgstr "Gereedschappen"
 msgid "Turkish"
 msgstr ""
 
-#: app/scripts/services/forms.js:433 app/views/design.html:222
+#: app/scripts/services/forms.js:433 app/views/design.html:220
 msgid "Turquoise"
 msgstr ""
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 msgid "UI theme"
 msgstr ""
 
@@ -1154,57 +1179,57 @@ msgstr ""
 msgid "Undo"
 msgstr "Ongedaan maken"
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr "Onbekend bord"
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr "Niet-ondersteund projectformaat {{version}}"
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr "Naamloos"
 
-#: app/views/menu.html:639
+#: app/views/menu.html:657
 #, fuzzy
 msgid "Update (Latest stable)"
 msgstr "Werk de bloknaam bij"
 
-#: app/scripts/controllers/menu.js:1354 app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371 app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr "Uploaden"
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr "Uploaden voltooid"
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr "Verificatie voltooid"
 
-#: app/views/design.html:510 app/views/menu.html:599
+#: app/views/design.html:498 app/views/menu.html:617
 msgid "Verify"
 msgstr "Verifiëren"
 
-#: app/scripts/services/utils.js:641 app/views/menu.html:832
+#: app/scripts/services/utils.js:636 app/views/menu.html:850
 msgid "Version"
 msgstr "Versie"
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr ""
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr "Bekijken"
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr "Bekijk licentie"
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr "Het ontwerp bevat waarschuwingen"
 
@@ -1223,55 +1248,62 @@ msgstr "Verkeerd blokformaat: {{type}}"
 msgid "Wrong block name {{name}}"
 msgstr "Verkeerde bloknaam {{name}}"
 
-#: app/scripts/controllers/menu.js:1907
+#: app/scripts/controllers/menu.js:1925
 #, fuzzy
 msgid "Wrong new name!"
 msgstr "Verkeerde poortnaam {{name}}"
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr "Verkeerd projectformaat: {{name}}"
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr "Verkeerde externe hostnaam {{name}}"
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
 msgstr ""
 
-#: app/scripts/services/forms.js:412 app/views/design.html:166
+#: app/scripts/services/forms.js:412 app/views/design.html:164
 msgid "Yellow"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:394
+#: app/scripts/controllers/menu.js:409
 msgid ""
-"You are editing a submodule, if you save it, you save only               the "
-"submodule (in this situation \"save as\" works like               \"export "
-"module\"), Do you like to continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 msgstr ""
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+msgstr ""
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr "U kunt het laden zoals het is of converteren voor het {{name}} bord."
 
-#: app/scripts/controllers/menu.js:1328
+#: app/scripts/controllers/menu.js:1347
 msgid ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1355
+#: app/scripts/controllers/menu.js:1372
 msgid ""
-"You can only upload  your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
 msgstr ""
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr "Uw wijzigingen gaan verloren als u ze niet opslaat"
 
@@ -1279,25 +1311,28 @@ msgstr "Uw wijzigingen gaan verloren als u ze niet opslaat"
 msgid "back"
 msgstr "terug"
 
-#: app/scripts/services/drivers.js:412 app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439 app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr "{{app}} is vereist."
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr "{{board}} datasheet niet gedefinieerd"
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr "{{board}} pinning niet gedefinieerd"
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr "{{board}} regels niet gedefinieerd"
 
-#: app/scripts/controllers/menu.js:483 app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499 app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr "{{name}} geëxporteerd"
+
+#~ msgid "Read only"
+#~ msgstr "Alleen lezen"
 
 #~ msgid "Duplicated block attributes"
 #~ msgstr "Dubbele blokattributen"

--- a/app/resources/locale/ru_RU/ru_RU.po
+++ b/app/resources/locale/ru_RU/ru_RU.po
@@ -13,15 +13,27 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
-#: app/views/design.html:20
-msgid ": '}} {{'Unlock to edit block !"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
 msgstr ""
 
-#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr "<b>Отсоедините</b> и <b>переподключите</b> плату"
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
 msgstr "О программе"
 
@@ -29,11 +41,11 @@ msgstr "О программе"
 msgid "Acknowledgment"
 msgstr ""
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr "Добавить"
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr "Добавить блок в начало"
 
@@ -45,24 +57,24 @@ msgstr "Добавить как блок"
 msgid "Address format"
 msgstr "Формат адреса"
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr "Все коллекции удалены"
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr "Все сохраненные коллеции будут удалены. Продолжить ?"
 
-#: app/scripts/services/tools.js:1389
+#: app/scripts/services/tools.js:1500
 #, fuzzy
 msgid "At least Python 3.7 is required"
 msgstr "Необходим Python 3.7 или новее"
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr "Автор"
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr "Базовый"
 
@@ -74,6 +86,10 @@ msgstr "Баскский"
 msgid "Binary"
 msgstr "Бинарный"
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr ""
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -83,7 +99,7 @@ msgstr "Бинарный"
 msgid "Block updated"
 msgstr "Блок обновлен"
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr "Block {{name}} импортирован"
 
@@ -91,56 +107,52 @@ msgstr "Block {{name}} импортирован"
 msgid "Blocks"
 msgstr "Блоки"
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr "Плата"
 
-#: app/views/menu.html:367 app/views/menu.html:458
+#: app/views/menu.html:385 app/views/menu.html:476
 msgid "Board rules"
 msgstr "Правила платы"
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr "Правила платы отключены"
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr "Правила платы включены"
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr "Плата {{name}} отключена"
 
-#: app/scripts/services/tools.js:607 app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718 app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr "Плата {{name}} недоступна"
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr "Board {{name}} не подключена"
 
-#: app/scripts/app.js:185 app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184 app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr "Выбрана плата {{name}}"
 
-#: app/scripts/services/tools.js:596 app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707 app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr "Загрузчик не активен"
 
-#: app/scripts/controllers/menu.js:1327 app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346 app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr "Собрать"
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr "Сборка закончена"
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr "ВНИМАНИЕ! : Изменения будут также применены ко всем скопированным"
-
-#: app/scripts/app.js:59 app/scripts/services/project.js:147
+#: app/scripts/app.js:58 app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr "Отменить"
 
@@ -148,16 +160,16 @@ msgstr "Отменить"
 msgid "Catalan"
 msgstr "Каталонский"
 
-#: app/views/design.html:264
+#: app/views/design.html:262
 #, fuzzy
 msgid "Change Color"
 msgstr "Выберите цвет"
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr "Проверка соединения с Интернетом..."
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr "Проверка Python..."
 
@@ -170,20 +182,20 @@ msgstr "Китайский"
 msgid "Choose a color:"
 msgstr "Выберите цвет:"
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr "Нажмите здесь <b>для загрузки новой версии</b> Icestudio"
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr "Нажмите здесь <b>для установки драйверов</b>"
 
-#: app/scripts/services/drivers.js:413 app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613 app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440 app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644 app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr "Нажмите для установки"
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr "Нажмите для просмотра"
 
@@ -195,63 +207,63 @@ msgstr "Сигнал тактирования не разрешен для ши�
 msgid "Clone"
 msgstr "Клонировать"
 
-#: app/scripts/controllers/menu.js:565 app/views/version.html:80
+#: app/scripts/controllers/menu.js:581 app/views/version.html:80
 msgid "Close"
 msgstr "Закрыть"
 
-#: app/views/design.html:324 app/views/menu.html:791
+#: app/views/design.html:314 app/views/menu.html:809
 msgid "Code"
 msgstr "Код"
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr "Коллекция"
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr "Информация о коллекции"
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr "Информация для {{collection}} не задана"
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr "Коллекция {{name}} добавлена"
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr "Коллекция {{name}} не замещена"
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr "Коллекция {{name}} удалена"
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr "Коллекция {{name}} замещена"
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr "Коллекция {{name}} выбрана"
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr "Коллекции"
 
-#: app/scripts/controllers/menu.js:1229 app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249 app/views/menu.html:489
 msgid "Command output"
 msgstr "Вывод команды"
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr "Форум сообщества"
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr "Конфигурация неполна"
 
-#: app/views/design.html:312 app/views/menu.html:783
+#: app/views/design.html:304 app/views/menu.html:801
 msgid "Constant"
 msgstr "Константа"
 
@@ -260,7 +272,7 @@ msgstr "Константа"
 msgid "Constant names"
 msgstr "Константа"
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr "Сконвертировать"
 
@@ -268,11 +280,11 @@ msgstr "Сконвертировать"
 msgid "Copy"
 msgstr "Копировать"
 
-#: app/scripts/services/forms.js:400 app/views/design.html:137
+#: app/scripts/services/forms.js:400 app/views/design.html:136
 msgid "Coral"
 msgstr "Коралловый"
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr "Создание virtualenv..."
 
@@ -299,15 +311,15 @@ msgstr "Тёмно-зелёный"
 msgid "Dark Orange"
 msgstr "Тёмно-оранжевый"
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr "Тёмно-зелёный"
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr "Тёмно-оранжевый"
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr "Даташит"
 
@@ -315,41 +327,45 @@ msgstr "Даташит"
 msgid "Decimal"
 msgstr "Десятичный"
 
-#: app/scripts/services/forms.js:394 app/views/design.html:123
+#: app/scripts/services/forms.js:394 app/views/design.html:122
 #, fuzzy
 msgid "Deep Pink"
 msgstr "Тёмно-розовый"
 
-#: app/scripts/services/forms.js:439 app/views/design.html:236
+#: app/scripts/services/forms.js:439 app/views/design.html:234
 #, fuzzy
 msgid "Deep Sky Blue"
 msgstr "Тёмно-лазурный"
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr "По умолчанию"
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr ""
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr "Описание"
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr "Отключить"
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr "Закрыть приложение ?"
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr "Удалить коллекцию {{name}} ?"
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr "Заменить ?"
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr "Документация"
 
@@ -357,21 +373,26 @@ msgstr "Документация"
 msgid "Don't display"
 msgstr "Не показывать"
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr "Драйвера"
 
 #: app/scripts/services/drivers.js:252 app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr "Драйвера отключены"
 
 #: app/scripts/services/drivers.js:230 app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr "Драйвера подключены"
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+#, fuzzy
+msgid "Duplicate"
+msgstr "Метка вывода:"
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr "Дублирование портов ввода/вывода платы"
 
@@ -388,11 +409,11 @@ msgstr "Немецкий"
 msgid "Edit"
 msgstr "Редактировать"
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr "Редактировать имя коллекции"
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr "Включить"
 
@@ -425,15 +446,15 @@ msgstr "Входные порты"
 msgid "Enter the python path"
 msgstr "Путь до сторонней коллекции"
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr "Удаленный хост в формате user@host"
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr "Ошибка: {{error}}"
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr "Найдены ошибки в схеме"
 
@@ -441,7 +462,7 @@ msgstr "Найдены ошибки в схеме"
 msgid "Examples"
 msgstr "Примеры"
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr "Выполняется удаленно {{label}} ..."
 
@@ -449,29 +470,29 @@ msgstr "Выполняется удаленно {{label}} ..."
 msgid "Export"
 msgstr "Экспорт"
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395 app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr "Экспорт субмодуля"
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr "Сторонняя коллекция"
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr "Сторонние коллекции обновлены"
 
-#: app/views/menu.html:383
+#: app/views/menu.html:401
 #, fuzzy
 msgid "External plugins"
 msgstr "Сторонняя коллекция"
 
-#: app/scripts/controllers/menu.js:780
+#: app/scripts/controllers/menu.js:800
 #, fuzzy
 msgid "External plugins updated"
 msgstr "Сторонние коллекции обновлены"
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr "Порты ввода/вывода платы не определены"
 
@@ -479,7 +500,7 @@ msgstr "Порты ввода/вывода платы не определены"
 msgid "FPGA pin"
 msgstr "Пин FPGA"
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr "Ресурсы FPGA"
 
@@ -495,16 +516,16 @@ msgstr ""
 msgid "File"
 msgstr "Файл"
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr "Файл {{file}} уже существует в папке проекта. Заменить его?"
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr "Файл {{file}} не существует"
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr "Файл {{file}} импортирован"
 
@@ -512,7 +533,7 @@ msgstr "Файл {{file}} импортирован"
 msgid "Find"
 msgstr "Найти"
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr "Подогнать размер схемы"
 
@@ -520,8 +541,8 @@ msgstr "Подогнать размер схемы"
 msgid "French"
 msgstr "Французский"
 
-#: app/scripts/services/forms.js:385 app/views/design.html:173
-#: app/views/design.html:98
+#: app/scripts/services/forms.js:385 app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr "Фуксия"
 
@@ -533,7 +554,7 @@ msgstr "Галлийский"
 msgid "German"
 msgstr "Немецкий"
 
-#: app/scripts/services/forms.js:409 app/views/design.html:158
+#: app/scripts/services/forms.js:409 app/views/design.html:157
 msgid "Gold"
 msgstr "Золотой"
 
@@ -546,11 +567,11 @@ msgstr "Греческий"
 msgid "Green Yellow"
 msgstr "Зелёно-жёлтый"
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr "Зелёно-жёлтый"
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr "Помощь"
 
@@ -563,34 +584,34 @@ msgstr "Шестнадцатеричный"
 msgid "Icestudio is part of"
 msgstr "Icestudio Inception"
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid ""
 "If you have blank IN/OUT pins, it's because there is no equivalent in this "
 "board"
 msgstr "Могли остаться пустые пины, потому что на этой плате нет эквивалента"
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr "Изображение"
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr "Изображение {{name}} сохранено"
 
-#: app/scripts/services/forms.js:388 app/views/design.html:109
+#: app/scripts/services/forms.js:388 app/views/design.html:108
 #, fuzzy
 msgid "Indian Red"
 msgstr "Ярко-красный"
 
-#: app/views/design.html:330 app/views/menu.html:795
+#: app/views/design.html:319 app/views/menu.html:813
 msgid "Information"
 msgstr "Информация"
 
-#: app/views/design.html:282 app/views/menu.html:760
+#: app/views/design.html:279 app/views/menu.html:778
 msgid "Input"
 msgstr "Ввод"
 
-#: app/views/design.html:294 app/views/menu.html:769
+#: app/views/design.html:289 app/views/menu.html:787
 msgid "Input label"
 msgstr "Метка ввода"
 
@@ -613,34 +634,35 @@ msgstr "Введите имя порта:"
 msgid "Input ports"
 msgstr "Входные порты"
 
-#: app/views/menu.html:635
+#: app/views/menu.html:653
 #, fuzzy
 msgid "Install (Stable)"
 msgstr "Установить (Стабильная версия)"
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
 msgstr "Установить (В разработке)"
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid ""
 "Install the <b>STABLE Toolchain</b>. This operation requires Internet "
 "connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
 "allow the toolchain installation</p> <p>Do you want to continue?</p>"
-msgstr "Установите <b>стабильный набор инструментов</b>. Требуется подключение к сети "
-"<br><p><b>ВАЖНО:</b> Отключите VPN-сервис (если он активен), чтобы "
+msgstr ""
+"Установите <b>стабильный набор инструментов</b>. Требуется подключение к "
+"сети <br><p><b>ВАЖНО:</b> Отключите VPN-сервис (если он активен), чтобы "
 "разрешить установку</p> <p>Продолжить ?</p>"
 
-#: app/scripts/services/tools.js:1144
+#: app/scripts/services/tools.js:1255
 #, fuzzy
 msgid ""
 "Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
 "requires Internet connection. Do you want to continue?"
 msgstr ""
-"Установить набор инструментов в разработке. Для этой операции потребуется соединение "
-"с Интернетом. Продолжить ?"
+"Установить набор инструментов в разработке. Для этой операции потребуется "
+"соединение с Интернетом. Продолжить ?"
 
-#: app/scripts/services/tools.js:1166
+#: app/scripts/services/tools.js:1277
 #, fuzzy
 msgid ""
 "Install the LATEST STABLE toolchain. It will be downloaded. This operation "
@@ -649,52 +671,52 @@ msgstr ""
 "Набор инструментов будет обновлен. Для этой операции потребуется соединение "
 "с Интернетом. Продолжить ?"
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr "Установка завершена"
 
-#: app/scripts/services/tools.js:1274
+#: app/scripts/services/tools.js:1385
 #, fuzzy
 msgid "Installing"
 msgstr "Установка"
 
-#: app/scripts/services/drivers.js:421 app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447 app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr "Необходимо соединение с Интернетом"
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr "Неверное <i>подтягивающее</i> соединение:<br>блок уже подсоединен"
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr ""
 "Неверное <i>подтягивающее</i> соединение:<br>только <i>входы</i> блоков "
 "разрешены"
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr ""
 "Неверное соединение блока:<br><i>подтягивающее соединение</i> уже осущствлено"
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr "Неправильная коллекция {{name}}"
 
-#: app/scripts/services/graph.js:254 app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262 app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr "Неверное соединение"
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr "Неверное соединение: {{a}} → {{b}}"
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr "Неправильные множественные соединения"
 
-#: app/scripts/services/project.js:499 app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510 app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr "Неправильный формат проекта"
 
@@ -711,7 +733,7 @@ msgstr "Испанский"
 msgid "Korean"
 msgstr "Корейский"
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
 msgstr "Поиск блока"
 
@@ -720,7 +742,7 @@ msgstr "Поиск блока"
 msgid "Label updated"
 msgstr "Блок обновлен"
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr "Язык"
 
@@ -728,17 +750,17 @@ msgstr "Язык"
 msgid "Light"
 msgstr "Светлый"
 
-#: app/scripts/services/forms.js:448 app/views/design.html:257
+#: app/scripts/services/forms.js:448 app/views/design.html:255
 #, fuzzy
 msgid "Light Gray"
 msgstr "Светлая морская волна"
 
-#: app/scripts/services/forms.js:430 app/views/design.html:215
+#: app/scripts/services/forms.js:430 app/views/design.html:213
 #, fuzzy
 msgid "Light Sea Green"
 msgstr "Светлая морская волна"
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr "Загрузить"
 
@@ -746,20 +768,20 @@ msgstr "Загрузить"
 msgid "Local parameter"
 msgstr "Локальный параметр"
 
-#: app/views/menu.html:404
+#: app/views/menu.html:422
 #, fuzzy
 msgid "Logging enabled"
 msgstr "Драйвера подключены"
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
 msgstr "Файл журнала"
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
 msgstr "Файл журнала обновлен"
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr "Максимальный размер шины: 96 бит"
 
@@ -768,11 +790,11 @@ msgstr "Максимальный размер шины: 96 бит"
 msgid "Medium Violet Red"
 msgstr "Умеренный красно-фиолетовый"
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr "Умеренный красно-фиолетовый"
 
-#: app/views/design.html:318 app/views/menu.html:787
+#: app/views/design.html:309 app/views/menu.html:805
 msgid "Memory"
 msgstr "Память"
 
@@ -781,7 +803,7 @@ msgstr "Память"
 msgid "Memory blocks"
 msgstr "Блоки памяти"
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr "Имя"
 
@@ -789,7 +811,7 @@ msgstr "Имя"
 msgid "Name of the paired labels"
 msgstr "Имя парных меток"
 
-#: app/scripts/services/forms.js:445 app/views/design.html:250
+#: app/scripts/services/forms.js:445 app/views/design.html:248
 msgid "Navy"
 msgstr "Тёмно-синий"
 
@@ -803,15 +825,19 @@ msgstr "Новый цвет:"
 
 #: app/views/design.html:80
 #, fuzzy
-msgid "New Name:"
+msgid "New Name"
 msgstr "Новое имя:"
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr ""
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr "Нет сохраненных коллекций"
 
-#: app/scripts/app.js:58 app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57 app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr "ОК"
 
@@ -820,7 +846,7 @@ msgstr "ОК"
 msgid "Olive Drab"
 msgstr "Тускло-коричневый"
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr "Тускло-коричневый"
 
@@ -828,7 +854,7 @@ msgstr "Тускло-коричневый"
 msgid "Open"
 msgstr "Открыть"
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr "Открыть SVG"
 
@@ -837,19 +863,19 @@ msgstr "Открыть SVG"
 msgid "Orange Red"
 msgstr "Оранжево-красный"
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr "Оранжево-красный"
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr "Оригинальный файл {{file}} не существует"
 
-#: app/views/design.html:288 app/views/menu.html:764
+#: app/views/design.html:284 app/views/menu.html:782
 msgid "Output"
 msgstr "Вывод"
 
-#: app/views/design.html:300 app/views/menu.html:773
+#: app/views/design.html:294 app/views/menu.html:791
 msgid "Output label"
 msgstr "Метка вывода"
 
@@ -868,7 +894,7 @@ msgstr "Метка вывода"
 msgid "Output ports"
 msgstr "Метка вывода"
 
-#: app/views/design.html:306 app/views/menu.html:778
+#: app/views/design.html:299 app/views/menu.html:796
 msgid "Paired labels"
 msgstr "Парные метки"
 
@@ -876,40 +902,44 @@ msgstr "Парные метки"
 msgid "Paste"
 msgstr "Вставить"
 
-#: app/scripts/controllers/menu.js:731 app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853 app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751 app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873 app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr "Путь {{path}} не существует"
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr "Выполните команду: {{cmd}}"
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr "Параметры"
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr ""
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr "Информация о проекте"
 
-#: app/scripts/controllers/menu.js:935 app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955 app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr "Информация о проекте обновлена"
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr "Проект {{name}} загружен"
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr "Проект {{name}} сохранен"
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
 msgstr "Среда Python обновлена"
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
 msgstr "Среда Python"
 
@@ -917,11 +947,7 @@ msgstr "Среда Python"
 msgid "Quit"
 msgstr "Закрыть Icestudio"
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr "Только для чтения"
-
-#: app/scripts/services/forms.js:391 app/views/design.html:116
+#: app/scripts/services/forms.js:391 app/views/design.html:115
 msgid "Red"
 msgstr "Красный"
 
@@ -933,27 +959,27 @@ msgstr "Повторить"
 msgid "Release History WIKI"
 msgstr ""
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr "Перезагрузить"
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr "Удаленный хост {{name}} не подключен"
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr "Удаленный хост"
 
-#: app/views/menu.html:647 app/views/menu.html:722
+#: app/views/menu.html:665 app/views/menu.html:740
 msgid "Remove"
 msgstr "Удалить"
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr "Удалить все"
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
 msgstr "Заменить ВСЕ"
 
@@ -961,11 +987,11 @@ msgstr "Заменить ВСЕ"
 msgid "Replace One"
 msgstr "Заменить один"
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr "Убрать SVG"
 
-#: app/scripts/services/forms.js:442 app/views/design.html:243
+#: app/scripts/services/forms.js:442 app/views/design.html:241
 #, fuzzy
 msgid "Royal Blue"
 msgstr "Королевский голубой"
@@ -978,7 +1004,7 @@ msgstr "Русский"
 msgid "Save"
 msgstr "Сохранить"
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr "Сохранить SVG"
 
@@ -990,11 +1016,11 @@ msgstr "Сохранить как"
 msgid "Save submodule"
 msgstr "Сохранить субмодуль"
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr "Выбрать"
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr "Выбрать все"
 
@@ -1011,11 +1037,11 @@ msgstr "Показать тактирование"
 msgid "Slate Blue"
 msgstr "Серовато-синий"
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr "Серовато-синий"
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr "Исходный код"
 
@@ -1028,32 +1054,32 @@ msgstr "Испанский"
 msgid "Spring Green"
 msgstr "Весенний зелёный"
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr "Весенний зелёный"
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr "Запуск сборки"
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr "Запуск загрузки в плату"
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr "Запуск проверки"
 
-#: app/scripts/services/forms.js:436 app/views/design.html:229
+#: app/scripts/services/forms.js:436 app/views/design.html:227
 #, fuzzy
 msgid "Steel Blue"
 msgstr "Голубая сталь"
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr "Синхронизация файлов..."
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
 msgstr "Информация о системе"
 
@@ -1069,11 +1095,11 @@ msgstr "Тестбенч"
 msgid "Thank you very much!"
 msgstr "Большое спасибо!"
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr "Коллекция {{name}} уже существует."
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
@@ -1081,19 +1107,19 @@ msgstr ""
 "Текущая конфигурация портов ввода/вывода FPGA будет потеряна. Сменить "
 "текущую плату на {{name}} ?"
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr "Набор инструментов будет удален. Продолжить ?"
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr "Доступна для установки ночная сборка"
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr "Доступна для установки стабильная сборка"
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
@@ -1101,7 +1127,7 @@ msgstr ""
 "Для операции импорта требуется указать путь к проекту. Вы должны сохранить "
 "текущий проект. Продолжить ?"
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr "Этот проект был разработан для платы {{name}}."
 
@@ -1111,7 +1137,7 @@ msgid ""
 "              done by an emerging team from"
 msgstr ""
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 #, fuzzy
 msgid ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
@@ -1120,7 +1146,7 @@ msgstr ""
 "Чтобы включить \"режим редактирования\" глубинного блока, вам следует "
 "завершить текущий \"режим редактирования\". Lock the keylock to do it."
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr ""
 "Для перемещения по схеме, вы должны сперва закрыть \"режим редактирования\"."
@@ -1128,7 +1154,7 @@ msgstr ""
 #: app/scripts/controllers/menu.js:349
 #, fuzzy
 msgid ""
-"To save your design you need to lock the keylock and               go to top "
+"To save your design you need to lock the padlock and               go to top "
 "level design.<br/><br/>If you want to export               this submodule to "
 "a file, execute \"Save as\" command to do it."
 msgstr ""
@@ -1136,33 +1162,33 @@ msgstr ""
 "<br/><br/>Если вы хотите экспортировать этот субмодуль в файл, используйте "
 "команду \"Сохранить как\"."
 
-#: app/views/menu.html:320
+#: app/views/menu.html:338
 #, fuzzy
 msgid "Toolbox"
 msgstr "Инструменты"
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr "Набор инструментов"
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr "Набор инструментов установлен"
 
-#: app/scripts/services/drivers.js:594 app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191 app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625 app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300 app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr "Набор инструментов установлен"
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr "Набор инструментов удален"
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr "Версии инструментов не совпадают"
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr "Инструменты"
 
@@ -1170,11 +1196,11 @@ msgstr "Инструменты"
 msgid "Turkish"
 msgstr "Турецкий"
 
-#: app/scripts/services/forms.js:433 app/views/design.html:222
+#: app/scripts/services/forms.js:433 app/views/design.html:220
 msgid "Turquoise"
 msgstr "Бирюзовый"
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 msgid "UI theme"
 msgstr "Тема интерфейса"
 
@@ -1182,57 +1208,57 @@ msgstr "Тема интерфейса"
 msgid "Undo"
 msgstr "Отменить"
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr "Неизвестная плата"
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr "Неподдерживаемый формат проекта {{version}}"
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr "Безымянный"
 
-#: app/views/menu.html:639
+#: app/views/menu.html:657
 #, fuzzy
 msgid "Update (Latest stable)"
 msgstr "Обновить имя блока (последняя стабильная версия)"
 
-#: app/scripts/controllers/menu.js:1354 app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371 app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr "Загрузка"
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr "Загрузка завершена"
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr "Проверка завершена"
 
-#: app/views/design.html:510 app/views/menu.html:599
+#: app/views/design.html:498 app/views/menu.html:617
 msgid "Verify"
 msgstr "Проверка"
 
-#: app/scripts/services/utils.js:641 app/views/menu.html:832
+#: app/scripts/services/utils.js:636 app/views/menu.html:850
 msgid "Version"
 msgstr "Версия"
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr "Комментарии к этой версии"
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr "Вид"
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr "Просмотр лицензии"
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr "Предупреждения в схеме"
 
@@ -1251,65 +1277,74 @@ msgstr "Неправильный формат блока: {{type}}"
 msgid "Wrong block name {{name}}"
 msgstr "Неправильное имя блока  {{name}}"
 
-#: app/scripts/controllers/menu.js:1907
+#: app/scripts/controllers/menu.js:1925
 #, fuzzy
 msgid "Wrong new name!"
 msgstr "Неправильное имя порта {{name}}"
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr "Неправильный формат проекта: {{name}}"
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr "Неправильный удаленный хост {{name}}"
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
 msgstr "Неправильное имя поиска!"
 
-#: app/scripts/services/forms.js:412 app/views/design.html:166
+#: app/scripts/services/forms.js:412 app/views/design.html:164
 msgid "Yellow"
 msgstr "Желтый"
 
-#: app/scripts/controllers/menu.js:394
+#: app/scripts/controllers/menu.js:409
 #, fuzzy
 msgid ""
-"You are editing a submodule, if you save it, you save only               the "
-"submodule (in this situation \"save as\" works like               \"export "
-"module\"), Do you like to continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 msgstr ""
 "Вы работаете с субмодулем. Если вы сохраните его, то будет сохранен только "
 "субмодуль (в таких случаях команда \"Сохранить как\" работает как \"Экспорт "
 "модуля\"). Вы хотите продолжить?"
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+msgstr ""
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr ""
 "Вы можете загрузить проект \"как есть\" или сконвертировать для платы "
 "{{name}}"
 
-#: app/scripts/controllers/menu.js:1328
+#: app/scripts/controllers/menu.js:1347
+#, fuzzy
 msgid ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 msgstr ""
 "Сборка возможна на верхнем уровне. В субмодулях доступна только "
 "<strong>Проверка</strong>"
 
-#: app/scripts/controllers/menu.js:1355
+#: app/scripts/controllers/menu.js:1372
+#, fuzzy
 msgid ""
-"You can only upload  your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
 msgstr ""
-"Выгрузка схем возможна на верхнем уровне. В субмодулях доступна только "
+"Сборка возможна на верхнем уровне. В субмодулях доступна только "
 "<strong>Проверка</strong>"
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
 msgstr "Вы можете прочитать примечания к выпуску"
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr "Ваши изменения могут быть потеряны, если вы их не сохраните"
 
@@ -1317,25 +1352,38 @@ msgstr "Ваши изменения могут быть потеряны, есл
 msgid "back"
 msgstr "назад"
 
-#: app/scripts/services/drivers.js:412 app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439 app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr "Требуется приложение {{app}}."
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr "Даташит для {{board}} не определен"
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr "Разводка платы {{board}} не определена"
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr "Правила для платы {{board}} не определены"
 
-#: app/scripts/controllers/menu.js:483 app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499 app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr "{{name}} экспортирован(о)"
+
+#~ msgid "CAUTION ! : Changes will also be applied in all the copied"
+#~ msgstr "ВНИМАНИЕ! : Изменения будут также применены ко всем скопированным"
+
+#~ msgid "Read only"
+#~ msgstr "Только для чтения"
+
+#~ msgid ""
+#~ "You can only upload  your design at top-level design. Inside submodules "
+#~ "you only can <strong>Verify</strong>"
+#~ msgstr ""
+#~ "Выгрузка схем возможна на верхнем уровне. В субмодулях доступна только "
+#~ "<strong>Проверка</strong>"
 
 #~ msgid "Choose a color"
 #~ msgstr "Выберите цвет"

--- a/app/resources/locale/template.pot
+++ b/app/resources/locale/template.pot
@@ -4,16 +4,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: \n"
 
-#: app/views/design.html:20
-msgid ": '}} {{'Unlock to edit block !"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
 msgstr ""
 
 #: app/scripts/services/drivers.js:353
-#: app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr ""
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
 msgstr ""
 
@@ -21,11 +33,11 @@ msgstr ""
 msgid "Acknowledgment"
 msgstr ""
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr ""
 
@@ -37,23 +49,23 @@ msgstr ""
 msgid "Address format"
 msgstr ""
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr ""
 
-#: app/scripts/services/tools.js:1389
+#: app/scripts/services/tools.js:1500
 msgid "At least Python 3.7 is required"
 msgstr ""
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr ""
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr ""
 
@@ -65,6 +77,10 @@ msgstr ""
 msgid "Binary"
 msgstr ""
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr ""
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -74,7 +90,7 @@ msgstr ""
 msgid "Block updated"
 msgstr ""
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr ""
 
@@ -82,62 +98,58 @@ msgstr ""
 msgid "Blocks"
 msgstr ""
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr ""
 
-#: app/views/menu.html:367
-#: app/views/menu.html:458
+#: app/views/menu.html:385
+#: app/views/menu.html:476
 msgid "Board rules"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr ""
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr ""
 
-#: app/scripts/services/tools.js:607
-#: app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718
+#: app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr ""
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr ""
 
-#: app/scripts/app.js:185
-#: app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184
+#: app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr ""
 
-#: app/scripts/services/tools.js:596
-#: app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707
+#: app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1327
-#: app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346
+#: app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr ""
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr ""
-
-#: app/scripts/app.js:59
-#: app/scripts/services/project.js:147
+#: app/scripts/app.js:58
+#: app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr ""
 
@@ -145,15 +157,15 @@ msgstr ""
 msgid "Catalan"
 msgstr ""
 
-#: app/views/design.html:264
+#: app/views/design.html:262
 msgid "Change Color"
 msgstr ""
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr ""
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr ""
 
@@ -165,22 +177,22 @@ msgstr ""
 msgid "Choose a color:"
 msgstr ""
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr ""
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr ""
 
-#: app/scripts/services/drivers.js:413
-#: app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440
+#: app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr ""
 
@@ -192,67 +204,67 @@ msgstr ""
 msgid "Clone"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:565
+#: app/scripts/controllers/menu.js:581
 #: app/views/version.html:80
 msgid "Close"
 msgstr ""
 
-#: app/views/design.html:324
-#: app/views/menu.html:791
+#: app/views/design.html:314
+#: app/views/menu.html:809
 msgid "Code"
 msgstr ""
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr ""
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr ""
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr ""
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr ""
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr ""
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr ""
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1229
-#: app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249
+#: app/views/menu.html:489
 msgid "Command output"
 msgstr ""
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr ""
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr ""
 
-#: app/views/design.html:312
-#: app/views/menu.html:783
+#: app/views/design.html:304
+#: app/views/menu.html:801
 msgid "Constant"
 msgstr ""
 
@@ -260,7 +272,7 @@ msgstr ""
 msgid "Constant names"
 msgstr ""
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr ""
 
@@ -269,11 +281,11 @@ msgid "Copy"
 msgstr ""
 
 #: app/scripts/services/forms.js:400
-#: app/views/design.html:137
+#: app/views/design.html:136
 msgid "Coral"
 msgstr ""
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr ""
 
@@ -297,15 +309,15 @@ msgstr ""
 msgid "Dark Orange"
 msgstr ""
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr ""
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr ""
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr ""
 
@@ -314,40 +326,44 @@ msgid "Decimal"
 msgstr ""
 
 #: app/scripts/services/forms.js:394
-#: app/views/design.html:123
+#: app/views/design.html:122
 msgid "Deep Pink"
 msgstr ""
 
 #: app/scripts/services/forms.js:439
-#: app/views/design.html:236
+#: app/views/design.html:234
 msgid "Deep Sky Blue"
 msgstr ""
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr ""
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr ""
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr ""
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr ""
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr ""
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr ""
 
@@ -355,23 +371,27 @@ msgstr ""
 msgid "Don't display"
 msgstr ""
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr ""
 
 #: app/scripts/services/drivers.js:252
 #: app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr ""
 
 #: app/scripts/services/drivers.js:230
 #: app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr ""
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+msgid "Duplicate"
+msgstr ""
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr ""
 
@@ -387,11 +407,11 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr ""
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr ""
 
@@ -419,15 +439,15 @@ msgstr ""
 msgid "Enter the python path"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr ""
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr ""
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr ""
 
@@ -435,7 +455,7 @@ msgstr ""
 msgid "Examples"
 msgstr ""
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr ""
 
@@ -443,27 +463,28 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395
+#: app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr ""
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr ""
 
-#: app/views/menu.html:383
+#: app/views/menu.html:401
 msgid "External plugins"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:780
+#: app/scripts/controllers/menu.js:800
 msgid "External plugins updated"
 msgstr ""
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr ""
 
@@ -471,7 +492,7 @@ msgstr ""
 msgid "FPGA pin"
 msgstr ""
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr ""
 
@@ -487,15 +508,15 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr ""
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr ""
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr ""
 
@@ -503,7 +524,7 @@ msgstr ""
 msgid "Find"
 msgstr ""
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr ""
 
@@ -512,8 +533,8 @@ msgid "French"
 msgstr ""
 
 #: app/scripts/services/forms.js:385
-#: app/views/design.html:173
-#: app/views/design.html:98
+#: app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr ""
 
@@ -526,7 +547,7 @@ msgid "German"
 msgstr ""
 
 #: app/scripts/services/forms.js:409
-#: app/views/design.html:158
+#: app/views/design.html:157
 msgid "Gold"
 msgstr ""
 
@@ -538,11 +559,11 @@ msgstr ""
 msgid "Green Yellow"
 msgstr ""
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr ""
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr ""
 
@@ -554,35 +575,35 @@ msgstr ""
 msgid "Icestudio is part of"
 msgstr ""
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid "If you have blank IN/OUT pins, it's because there is no equivalent in this board"
 msgstr ""
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr ""
 
 #: app/scripts/services/forms.js:388
-#: app/views/design.html:109
+#: app/views/design.html:108
 msgid "Indian Red"
 msgstr ""
 
-#: app/views/design.html:330
-#: app/views/menu.html:795
+#: app/views/design.html:319
+#: app/views/menu.html:813
 msgid "Information"
 msgstr ""
 
-#: app/views/design.html:282
-#: app/views/menu.html:760
+#: app/views/design.html:279
+#: app/views/menu.html:778
 msgid "Input"
 msgstr ""
 
-#: app/views/design.html:294
-#: app/views/menu.html:769
+#: app/views/design.html:289
+#: app/views/menu.html:787
 msgid "Input label"
 msgstr ""
 
@@ -602,71 +623,71 @@ msgstr ""
 msgid "Input ports"
 msgstr ""
 
-#: app/views/menu.html:635
+#: app/views/menu.html:653
 msgid "Install (Stable)"
 msgstr ""
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
 msgstr ""
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid "Install the <b>STABLE Toolchain</b>. This operation requires Internet connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to allow the toolchain installation</p> <p>Do you want to continue?</p>"
 msgstr ""
 
-#: app/scripts/services/tools.js:1144
+#: app/scripts/services/tools.js:1255
 msgid "Install the DEVELOPMENT toolchain. It will be downloaded. This operation requires Internet connection. Do you want to continue?"
 msgstr ""
 
-#: app/scripts/services/tools.js:1166
+#: app/scripts/services/tools.js:1277
 msgid "Install the LATEST STABLE toolchain. It will be downloaded. This operation requires Internet connection. Do you want to continue?"
 msgstr ""
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr ""
 
-#: app/scripts/services/tools.js:1274
+#: app/scripts/services/tools.js:1385
 msgid "Installing"
 msgstr ""
 
-#: app/scripts/services/drivers.js:421
-#: app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447
+#: app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr ""
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr ""
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr ""
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr ""
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr ""
 
-#: app/scripts/services/graph.js:254
-#: app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262
+#: app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr ""
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr ""
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr ""
 
-#: app/scripts/services/project.js:499
-#: app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510
+#: app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr ""
 
@@ -682,7 +703,7 @@ msgstr ""
 msgid "Korean"
 msgstr ""
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
 msgstr ""
 
@@ -690,7 +711,7 @@ msgstr ""
 msgid "Label updated"
 msgstr ""
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr ""
 
@@ -699,16 +720,16 @@ msgid "Light"
 msgstr ""
 
 #: app/scripts/services/forms.js:448
-#: app/views/design.html:257
+#: app/views/design.html:255
 msgid "Light Gray"
 msgstr ""
 
 #: app/scripts/services/forms.js:430
-#: app/views/design.html:215
+#: app/views/design.html:213
 msgid "Light Sea Green"
 msgstr ""
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr ""
 
@@ -717,19 +738,19 @@ msgstr ""
 msgid "Local parameter"
 msgstr ""
 
-#: app/views/menu.html:404
+#: app/views/menu.html:422
 msgid "Logging enabled"
 msgstr ""
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
 msgstr ""
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr ""
 
@@ -737,12 +758,12 @@ msgstr ""
 msgid "Medium Violet Red"
 msgstr ""
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr ""
 
-#: app/views/design.html:318
-#: app/views/menu.html:787
+#: app/views/design.html:309
+#: app/views/menu.html:805
 msgid "Memory"
 msgstr ""
 
@@ -750,7 +771,7 @@ msgstr ""
 msgid "Memory blocks"
 msgstr ""
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr ""
 
@@ -759,7 +780,7 @@ msgid "Name of the paired labels"
 msgstr ""
 
 #: app/scripts/services/forms.js:445
-#: app/views/design.html:250
+#: app/views/design.html:248
 msgid "Navy"
 msgstr ""
 
@@ -772,16 +793,20 @@ msgid "New Color:"
 msgstr ""
 
 #: app/views/design.html:80
-msgid "New Name:"
+msgid "New Name"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr ""
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr ""
 
-#: app/scripts/app.js:58
-#: app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57
+#: app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr ""
 
@@ -789,7 +814,7 @@ msgstr ""
 msgid "Olive Drab"
 msgstr ""
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr ""
 
@@ -797,7 +822,7 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr ""
 
@@ -805,21 +830,21 @@ msgstr ""
 msgid "Orange Red"
 msgstr ""
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr ""
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr ""
 
-#: app/views/design.html:288
-#: app/views/menu.html:764
+#: app/views/design.html:284
+#: app/views/menu.html:782
 msgid "Output"
 msgstr ""
 
-#: app/views/design.html:300
-#: app/views/menu.html:773
+#: app/views/design.html:294
+#: app/views/menu.html:791
 msgid "Output label"
 msgstr ""
 
@@ -835,8 +860,8 @@ msgstr ""
 msgid "Output ports"
 msgstr ""
 
-#: app/views/design.html:306
-#: app/views/menu.html:778
+#: app/views/design.html:299
+#: app/views/menu.html:796
 msgid "Paired labels"
 msgstr ""
 
@@ -844,43 +869,47 @@ msgstr ""
 msgid "Paste"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:731
-#: app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853
-#: app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751
+#: app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873
+#: app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr ""
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr ""
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr ""
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr ""
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:935
-#: app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955
+#: app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr ""
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr ""
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
 msgstr ""
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
 msgstr ""
 
@@ -888,12 +917,8 @@ msgstr ""
 msgid "Quit"
 msgstr ""
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr ""
-
 #: app/scripts/services/forms.js:391
-#: app/views/design.html:116
+#: app/views/design.html:115
 msgid "Red"
 msgstr ""
 
@@ -905,28 +930,28 @@ msgstr ""
 msgid "Release History WIKI"
 msgstr ""
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr ""
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr ""
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr ""
 
-#: app/views/menu.html:647
-#: app/views/menu.html:722
+#: app/views/menu.html:665
+#: app/views/menu.html:740
 msgid "Remove"
 msgstr ""
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr ""
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
 msgstr ""
 
@@ -934,12 +959,12 @@ msgstr ""
 msgid "Replace One"
 msgstr ""
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr ""
 
 #: app/scripts/services/forms.js:442
-#: app/views/design.html:243
+#: app/views/design.html:241
 msgid "Royal Blue"
 msgstr ""
 
@@ -951,7 +976,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr ""
 
@@ -963,11 +988,11 @@ msgstr ""
 msgid "Save submodule"
 msgstr ""
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr ""
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr ""
 
@@ -983,11 +1008,11 @@ msgstr ""
 msgid "Slate Blue"
 msgstr ""
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr ""
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr ""
 
@@ -999,32 +1024,32 @@ msgstr ""
 msgid "Spring Green"
 msgstr ""
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr ""
 
 #: app/scripts/services/forms.js:436
-#: app/views/design.html:229
+#: app/views/design.html:227
 msgid "Steel Blue"
 msgstr ""
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr ""
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
 msgstr ""
 
@@ -1040,31 +1065,31 @@ msgstr ""
 msgid "Thank you very much!"
 msgstr ""
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid "The current FPGA I/O configuration will be lost. Do you want to change to {{name}} board?"
 msgstr ""
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr ""
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr ""
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr ""
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid "This import operation requires a project path. You need to save the current project. Do you want to continue?"
 msgstr ""
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr ""
 
@@ -1074,46 +1099,46 @@ msgid ""
 "              done by an emerging team from"
 msgstr ""
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 msgid "To enter on \"edit mode\" of deeper block, you need to finish current \"edit mode\", lock the keylock to do it."
 msgstr ""
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr ""
 
 #: app/scripts/controllers/menu.js:349
-msgid "To save your design you need to lock the keylock and               go to top level design.<br/><br/>If you want to export               this submodule to a file, execute \"Save as\" command to do it."
+msgid "To save your design you need to lock the padlock and               go to top level design.<br/><br/>If you want to export               this submodule to a file, execute \"Save as\" command to do it."
 msgstr ""
 
-#: app/views/menu.html:320
+#: app/views/menu.html:338
 msgid "Toolbox"
 msgstr ""
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr ""
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr ""
 
-#: app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191
-#: app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300
+#: app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr ""
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr ""
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr ""
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr ""
 
@@ -1122,11 +1147,11 @@ msgid "Turkish"
 msgstr ""
 
 #: app/scripts/services/forms.js:433
-#: app/views/design.html:222
+#: app/views/design.html:220
 msgid "Turquoise"
 msgstr ""
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 msgid "UI theme"
 msgstr ""
 
@@ -1134,59 +1159,59 @@ msgstr ""
 msgid "Undo"
 msgstr ""
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr ""
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr ""
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr ""
 
-#: app/views/menu.html:639
+#: app/views/menu.html:657
 msgid "Update (Latest stable)"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1354
-#: app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371
+#: app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr ""
 
-#: app/views/design.html:510
-#: app/views/menu.html:599
+#: app/views/design.html:498
+#: app/views/menu.html:617
 msgid "Verify"
 msgstr ""
 
-#: app/scripts/services/utils.js:641
-#: app/views/menu.html:832
+#: app/scripts/services/utils.js:636
+#: app/views/menu.html:850
 msgid "Version"
 msgstr ""
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr ""
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr ""
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr ""
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr ""
 
@@ -1206,48 +1231,52 @@ msgstr ""
 msgid "Wrong block name {{name}}"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1907
+#: app/scripts/controllers/menu.js:1925
 msgid "Wrong new name!"
 msgstr ""
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr ""
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
 msgstr ""
 
 #: app/scripts/services/forms.js:412
-#: app/views/design.html:166
+#: app/views/design.html:164
 msgid "Yellow"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:394
-msgid "You are editing a submodule, if you save it, you save only               the submodule (in this situation \"save as\" works like               \"export module\"), Do you like to continue?"
+#: app/scripts/controllers/menu.js:409
+msgid "You are editing a submodule, if you save it, you'll save only               the submodule (in this situation \"save as\" works like               \"export module\"). Do you want to continue?"
 msgstr ""
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid "You are navigating into the design, if you want to save the entire design, you need to back                       to the top level. If you want to export this module as new file, unlock the module and \"save as\""
+msgstr ""
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1328
-msgid "You can only build at top-level design. Inside submodules you only can <strong>Verify</strong>"
+#: app/scripts/controllers/menu.js:1347
+msgid "You can only build at the top-level design. Inside submodules, you can only <strong>Verify</strong>"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1355
-msgid "You can only upload  your design at top-level design. Inside submodules you only can <strong>Verify</strong>"
+#: app/scripts/controllers/menu.js:1372
+msgid "You can only upload at the top-level design. Inside submodules, you can only <strong>Verify</strong>"
 msgstr ""
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr ""
 
@@ -1255,24 +1284,24 @@ msgstr ""
 msgid "back"
 msgstr ""
 
-#: app/scripts/services/drivers.js:412
-#: app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439
+#: app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:483
-#: app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499
+#: app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr ""

--- a/app/resources/locale/tr_TR/tr_TR.po
+++ b/app/resources/locale/tr_TR/tr_TR.po
@@ -13,15 +13,27 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: app/views/design.html:20
-msgid ": '}} {{'Unlock to edit block !"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
 msgstr ""
 
-#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr "<b>Panoda kartı çıkartın</b> ve <b>yeniden</b> bağlayın"
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
 msgstr "Icestudio Hakkında"
 
@@ -29,11 +41,11 @@ msgstr "Icestudio Hakkında"
 msgid "Acknowledgment"
 msgstr ""
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr "Ekle"
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr "Başlamak için bir blok ekleyin"
 
@@ -45,24 +57,24 @@ msgstr "Blok olarak ekle"
 msgid "Address format"
 msgstr "Adres biçimi"
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr "Tüm koleksiyonlar kaldırıldı"
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr "Saklanan tüm koleksiyonlar kaybolacaktır. Devam etmek istiyor musunuz?"
 
-#: app/scripts/services/tools.js:1389
+#: app/scripts/services/tools.js:1500
 #, fuzzy
 msgid "At least Python 3.7 is required"
 msgstr "Python 2.7 gerekli"
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr "Yazar"
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr "Temel"
 
@@ -74,6 +86,10 @@ msgstr "Baskça"
 msgid "Binary"
 msgstr "İkili"
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr ""
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -83,7 +99,7 @@ msgstr "İkili"
 msgid "Block updated"
 msgstr "Blok güncellendi"
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr "Blok {{name}} ithal"
 
@@ -91,56 +107,52 @@ msgstr "Blok {{name}} ithal"
 msgid "Blocks"
 msgstr "Bloklar"
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr "Pano"
 
-#: app/views/menu.html:367 app/views/menu.html:458
+#: app/views/menu.html:385 app/views/menu.html:476
 msgid "Board rules"
 msgstr "Pano ölçüm aleti"
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr "Pano ölçüm kuralları devre dışı"
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr "Pano ölçüm kuralları aktif"
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr "Pano {{name}} kopuk"
 
-#: app/scripts/services/tools.js:607 app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718 app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr "Pano {{name}} kullanılamıyor"
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr "Pano {{name}} bağlı değil"
 
-#: app/scripts/app.js:185 app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184 app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr "Pano {{name}} seç"
 
-#: app/scripts/services/tools.js:596 app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707 app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr "Önyükleyici etkin değil"
 
-#: app/scripts/controllers/menu.js:1327 app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346 app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr "Yapı"
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr "Yapı tamam"
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr ""
-
-#: app/scripts/app.js:59 app/scripts/services/project.js:147
+#: app/scripts/app.js:58 app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr "İptal"
 
@@ -148,16 +160,16 @@ msgstr "İptal"
 msgid "Catalan"
 msgstr "Katalanca"
 
-#: app/views/design.html:264
+#: app/views/design.html:262
 #, fuzzy
 msgid "Change Color"
 msgstr "Bir renk seçin"
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr "İnternet bağlantısını kontrol edin..."
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr "Python'u Kontrol Et..."
 
@@ -170,21 +182,21 @@ msgstr "Çince"
 msgid "Choose a color:"
 msgstr "Bir renk seçin"
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr ""
 "Icestudio'nun daha <b>yeni bir sürümünü indirmek için buraya</b> tıklayın"
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr "Sürücüleri kurmak için <b>buraya tıklayın</b>"
 
-#: app/scripts/services/drivers.js:413 app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613 app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440 app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644 app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr "Yüklemek için buraya tıklayın"
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr "Görmek için buraya tıklayın"
 
@@ -196,63 +208,63 @@ msgstr "Veri yolları için saat izin verilmiyor"
 msgid "Clone"
 msgstr "Klon"
 
-#: app/scripts/controllers/menu.js:565 app/views/version.html:80
+#: app/scripts/controllers/menu.js:581 app/views/version.html:80
 msgid "Close"
 msgstr "Kapat"
 
-#: app/views/design.html:324 app/views/menu.html:791
+#: app/views/design.html:314 app/views/menu.html:809
 msgid "Code"
 msgstr "Kod"
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr "Koleksiyon"
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr "Koleksiyon bilgisi"
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr "Koleksiyon {{collection}} bilgisi tanımsız"
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr "Koleksiyon {{name}} eklendi"
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr "Koleksiyon {{name}} değiştirilmedi"
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr "Koleksiyon {{name}} kaldırıldı"
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr "Koleksiyon {{name}} değiştirildi"
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr "Koleksiyon {{name}} seçili"
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr "Koleksiyonlar"
 
-#: app/scripts/controllers/menu.js:1229 app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249 app/views/menu.html:489
 msgid "Command output"
 msgstr "Komut çıkışı"
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr "Topluluk forumu"
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr "Yapılandırma tamamlanmadı"
 
-#: app/views/design.html:312 app/views/menu.html:783
+#: app/views/design.html:304 app/views/menu.html:801
 msgid "Constant"
 msgstr "Sürekli"
 
@@ -261,7 +273,7 @@ msgstr "Sürekli"
 msgid "Constant names"
 msgstr "Sürekli"
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr "Dönüştür"
 
@@ -269,11 +281,11 @@ msgstr "Dönüştür"
 msgid "Copy"
 msgstr "Kopyala"
 
-#: app/scripts/services/forms.js:400 app/views/design.html:137
+#: app/scripts/services/forms.js:400 app/views/design.html:136
 msgid "Coral"
 msgstr "Mercan"
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr "Sanalort oluşturun..."
 
@@ -300,15 +312,15 @@ msgstr "KoyuYeşil"
 msgid "Dark Orange"
 msgstr "KoyuTuruncu"
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr "KoyuYeşil"
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr "KoyuTuruncu"
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr "Verisayfası"
 
@@ -316,41 +328,45 @@ msgstr "Verisayfası"
 msgid "Decimal"
 msgstr "Ondalık"
 
-#: app/scripts/services/forms.js:394 app/views/design.html:123
+#: app/scripts/services/forms.js:394 app/views/design.html:122
 #, fuzzy
 msgid "Deep Pink"
 msgstr "DerinPembe"
 
-#: app/scripts/services/forms.js:439 app/views/design.html:236
+#: app/scripts/services/forms.js:439 app/views/design.html:234
 #, fuzzy
 msgid "Deep Sky Blue"
 msgstr "DerinGökMavisi"
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr "Varsayılan"
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr ""
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr "Tanım"
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr "Devre dışı"
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr "Uygulamayı kapatmak istiyor musunuz?"
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr "Koleksiyonu kaldırmak {{name}} istiyor musunuz?"
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr "Onu değiştirmek ister misin?"
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr "Dokümantasyon"
 
@@ -358,21 +374,26 @@ msgstr "Dokümantasyon"
 msgid "Don't display"
 msgstr "Gösterme"
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr "Sürücüler"
 
 #: app/scripts/services/drivers.js:252 app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr "Sürücüler devre dışı"
 
 #: app/scripts/services/drivers.js:230 app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr "Sürücüler aktif"
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+#, fuzzy
+msgid "Duplicate"
+msgstr "Çıktı etiketi"
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr "Çoğaltılmış FPGA I/O bağlantı noktalaı"
 
@@ -389,11 +410,11 @@ msgstr "Felemenkçe"
 msgid "Edit"
 msgstr "Düzenle"
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr "Koleksiyon adını düzenle"
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr "Aktif"
 
@@ -426,15 +447,15 @@ msgstr "Giriş bağlantı noktalarını girin"
 msgid "Enter the python path"
 msgstr "Garici koleksiyonlar yolunu girin"
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr "Uzaktan ev ana bilgisayar adını girin @anabilgisayar"
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr "Hata: {{error}}"
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr "Tasarımda tespit edilen hatalar"
 
@@ -442,7 +463,7 @@ msgstr "Tasarımda tespit edilen hatalar"
 msgid "Examples"
 msgstr "Örnekler"
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr "Uzaktan çalıştırma {{label}} ..."
 
@@ -450,29 +471,29 @@ msgstr "Uzaktan çalıştırma {{label}} ..."
 msgid "Export"
 msgstr "İhraç"
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395 app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr "İhraç alt modül"
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr "Harici koleksiyon"
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr "Harici koleksiyonu güncelle"
 
-#: app/views/menu.html:383
+#: app/views/menu.html:401
 #, fuzzy
 msgid "External plugins"
 msgstr "Harici koleksiyon"
 
-#: app/scripts/controllers/menu.js:780
+#: app/scripts/controllers/menu.js:800
 #, fuzzy
 msgid "External plugins updated"
 msgstr "Harici koleksiyonu güncelle"
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr "FPGA I/O bağlantı noktaları tanımlanmadı"
 
@@ -480,7 +501,7 @@ msgstr "FPGA I/O bağlantı noktaları tanımlanmadı"
 msgid "FPGA pin"
 msgstr "FPGA raptiye"
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr "FPGA kaynaklar"
 
@@ -496,17 +517,17 @@ msgstr ""
 msgid "File"
 msgstr "Dosya"
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr ""
 "Dosya {{file}} proje yolunda zaten var. Bunu değiştirmek ister misiniz?"
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr "Dosya {{file}} yok"
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr "Dosya {{file}} ithal"
 
@@ -514,7 +535,7 @@ msgstr "Dosya {{file}} ithal"
 msgid "Find"
 msgstr ""
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr "Uygun içerik"
 
@@ -522,8 +543,8 @@ msgstr "Uygun içerik"
 msgid "French"
 msgstr "Fransızca"
 
-#: app/scripts/services/forms.js:385 app/views/design.html:173
-#: app/views/design.html:98
+#: app/scripts/services/forms.js:385 app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr "Eflatun"
 
@@ -535,7 +556,7 @@ msgstr "Galiçyaca"
 msgid "German"
 msgstr "Almanca"
 
-#: app/scripts/services/forms.js:409 app/views/design.html:158
+#: app/scripts/services/forms.js:409 app/views/design.html:157
 msgid "Gold"
 msgstr "Altın"
 
@@ -548,11 +569,11 @@ msgstr "Yunanca"
 msgid "Green Yellow"
 msgstr "YeşilSarı"
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr "YeşilSarı"
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr "Yardım"
 
@@ -565,7 +586,7 @@ msgstr "Onaltılı"
 msgid "Icestudio is part of"
 msgstr "Icestudio Başlangıç"
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid ""
 "If you have blank IN/OUT pins, it's because there is no equivalent in this "
 "board"
@@ -573,28 +594,28 @@ msgstr ""
 "Boş GİRİŞ/ÇIKIŞ raptiyeleriniz varsa, bunun nedeni bu kartta eşdeğer "
 "olmamasıdır"
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr "Görsel"
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr "Görseli {{name}} kaydet"
 
-#: app/scripts/services/forms.js:388 app/views/design.html:109
+#: app/scripts/services/forms.js:388 app/views/design.html:108
 #, fuzzy
 msgid "Indian Red"
 msgstr "HintKırmızısı"
 
-#: app/views/design.html:330 app/views/menu.html:795
+#: app/views/design.html:319 app/views/menu.html:813
 msgid "Information"
 msgstr "Bİlgi"
 
-#: app/views/design.html:282 app/views/menu.html:760
+#: app/views/design.html:279 app/views/menu.html:778
 msgid "Input"
 msgstr "Giriş"
 
-#: app/views/design.html:294 app/views/menu.html:769
+#: app/views/design.html:289 app/views/menu.html:787
 msgid "Input label"
 msgstr "Giriş etiketi"
 
@@ -617,23 +638,23 @@ msgstr ""
 msgid "Input ports"
 msgstr "Giriş bağlantı noktalarını girin"
 
-#: app/views/menu.html:635
+#: app/views/menu.html:653
 #, fuzzy
 msgid "Install (Stable)"
 msgstr "Yükle"
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
 msgstr ""
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid ""
 "Install the <b>STABLE Toolchain</b>. This operation requires Internet "
 "connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
 "allow the toolchain installation</p> <p>Do you want to continue?</p>"
 msgstr ""
 
-#: app/scripts/services/tools.js:1144
+#: app/scripts/services/tools.js:1255
 #, fuzzy
 msgid ""
 "Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
@@ -642,7 +663,7 @@ msgstr ""
 "Araç zinciri güncellenecektir. Bu işlem İnternet bağlantısı gerektirir. "
 "Devam etmek istiyor musunuz?"
 
-#: app/scripts/services/tools.js:1166
+#: app/scripts/services/tools.js:1277
 #, fuzzy
 msgid ""
 "Install the LATEST STABLE toolchain. It will be downloaded. This operation "
@@ -651,51 +672,51 @@ msgstr ""
 "Araç zinciri güncellenecektir. Bu işlem İnternet bağlantısı gerektirir. "
 "Devam etmek istiyor musunuz?"
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr "Kurulumu tamamlanmış"
 
-#: app/scripts/services/tools.js:1274
+#: app/scripts/services/tools.js:1385
 #, fuzzy
 msgid "Installing"
 msgstr "Yükle"
 
-#: app/scripts/services/drivers.js:421 app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447 app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr "İnternet bağlantısı gerekli"
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr "Geçersiz <i>Yukarı çekme</i> Bağlantı:<br>blok zaten bağlı"
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr ""
 "Geçersiz <i>Yukarı çekin</i> Bağlantı:<br>Sadece <i>Giriş</i> bloklar izin "
 "verildi"
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr "Geçersiz blok bağlantısı:<br><i>Yukarı çekin</i> zaten bağlı"
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr "Geçersiz koleksiyon {{name}}"
 
-#: app/scripts/services/graph.js:254 app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262 app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr "Geçersiz koleksiyon"
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr "Geçersiz koleksiyon: {{a}} → {{b}}"
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr "Geçersiz çoklu giriş bağlantıları"
 
-#: app/scripts/services/project.js:499 app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510 app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr "Geçersiz proje biçimi"
 
@@ -712,7 +733,7 @@ msgstr "İspanyolca"
 msgid "Korean"
 msgstr ""
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
 msgstr ""
 
@@ -721,7 +742,7 @@ msgstr ""
 msgid "Label updated"
 msgstr "Blok güncellendi"
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr "Lisan"
 
@@ -729,17 +750,17 @@ msgstr "Lisan"
 msgid "Light"
 msgstr ""
 
-#: app/scripts/services/forms.js:448 app/views/design.html:257
+#: app/scripts/services/forms.js:448 app/views/design.html:255
 #, fuzzy
 msgid "Light Gray"
 msgstr "AçıkDenizYeşili"
 
-#: app/scripts/services/forms.js:430 app/views/design.html:215
+#: app/scripts/services/forms.js:430 app/views/design.html:213
 #, fuzzy
 msgid "Light Sea Green"
 msgstr "AçıkDenizYeşili"
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr "Yük"
 
@@ -747,20 +768,20 @@ msgstr "Yük"
 msgid "Local parameter"
 msgstr "Yerel parametre"
 
-#: app/views/menu.html:404
+#: app/views/menu.html:422
 #, fuzzy
 msgid "Logging enabled"
 msgstr "Sürücüler aktif"
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
 msgstr ""
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr "Azami veri yolu boyutu: 96 bit"
 
@@ -769,11 +790,11 @@ msgstr "Azami veri yolu boyutu: 96 bit"
 msgid "Medium Violet Red"
 msgstr "OrtaMorAl"
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr "OrtaMorAl"
 
-#: app/views/design.html:318 app/views/menu.html:787
+#: app/views/design.html:309 app/views/menu.html:805
 msgid "Memory"
 msgstr "Bellek"
 
@@ -782,7 +803,7 @@ msgstr "Bellek"
 msgid "Memory blocks"
 msgstr "Import block"
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr "Ad"
 
@@ -790,7 +811,7 @@ msgstr "Ad"
 msgid "Name of the paired labels"
 msgstr ""
 
-#: app/scripts/services/forms.js:445 app/views/design.html:250
+#: app/scripts/services/forms.js:445 app/views/design.html:248
 msgid "Navy"
 msgstr "Lacivert"
 
@@ -804,15 +825,19 @@ msgstr ""
 
 #: app/views/design.html:80
 #, fuzzy
-msgid "New Name:"
+msgid "New Name"
 msgstr "Ad"
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr ""
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr "Koleksiyonların kaydı yok"
 
-#: app/scripts/app.js:58 app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57 app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr "TAMAM"
 
@@ -821,7 +846,7 @@ msgstr "TAMAM"
 msgid "Olive Drab"
 msgstr "HakiYeşil"
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr "HakiYeşil"
 
@@ -829,7 +854,7 @@ msgstr "HakiYeşil"
 msgid "Open"
 msgstr "Aç"
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr "SVG Aç"
 
@@ -838,19 +863,19 @@ msgstr "SVG Aç"
 msgid "Orange Red"
 msgstr "PortakalKırmızısı"
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr "PortakalKırmızısı"
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr "Özgün dosya {{file}} yok"
 
-#: app/views/design.html:288 app/views/menu.html:764
+#: app/views/design.html:284 app/views/menu.html:782
 msgid "Output"
 msgstr "Çıktı"
 
-#: app/views/design.html:300 app/views/menu.html:773
+#: app/views/design.html:294 app/views/menu.html:791
 msgid "Output label"
 msgstr "Çıktı etiketi"
 
@@ -869,7 +894,7 @@ msgstr "Çıktı etiketi"
 msgid "Output ports"
 msgstr "Çıktı etiketi"
 
-#: app/views/design.html:306 app/views/menu.html:778
+#: app/views/design.html:299 app/views/menu.html:796
 msgid "Paired labels"
 msgstr ""
 
@@ -877,40 +902,44 @@ msgstr ""
 msgid "Paste"
 msgstr "Yapıştır"
 
-#: app/scripts/controllers/menu.js:731 app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853 app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751 app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873 app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr "Yol {{path}} yok"
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr "Lütfen çalıştır: {{cmd}}"
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr "Tercihler"
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr ""
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr "Proje bilgileri"
 
-#: app/scripts/controllers/menu.js:935 app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955 app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr "Proje bilgileri güncellendi"
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr "Proje {{name}} yüklü"
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr "Projeyi {{name}} kaydet"
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
 msgstr ""
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
 msgstr ""
 
@@ -918,11 +947,7 @@ msgstr ""
 msgid "Quit"
 msgstr "Çıkış"
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr "Salt okunur"
-
-#: app/scripts/services/forms.js:391 app/views/design.html:116
+#: app/scripts/services/forms.js:391 app/views/design.html:115
 msgid "Red"
 msgstr "Kırmızı"
 
@@ -934,27 +959,27 @@ msgstr "Yeniden"
 msgid "Release History WIKI"
 msgstr ""
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr "Yeniden yükle"
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr "Uzak ana makine {{name}} bağlı değil"
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr "Uzak anamakineadı"
 
-#: app/views/menu.html:647 app/views/menu.html:722
+#: app/views/menu.html:665 app/views/menu.html:740
 msgid "Remove"
 msgstr "Kaldır"
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr "Tümünü kaldır"
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
 msgstr ""
 
@@ -962,11 +987,11 @@ msgstr ""
 msgid "Replace One"
 msgstr ""
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr "SVG Sıfırla"
 
-#: app/scripts/services/forms.js:442 app/views/design.html:243
+#: app/scripts/services/forms.js:442 app/views/design.html:241
 #, fuzzy
 msgid "Royal Blue"
 msgstr "KraliyetMavisi"
@@ -979,7 +1004,7 @@ msgstr "Rusça"
 msgid "Save"
 msgstr "Kaydet"
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr "SVG Kaydet"
 
@@ -991,11 +1016,11 @@ msgstr "Farklı kaydet"
 msgid "Save submodule"
 msgstr "Alt modülü kaydet"
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr "Seçilen"
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr "Tümünü seç"
 
@@ -1012,11 +1037,11 @@ msgstr "Saati göster"
 msgid "Slate Blue"
 msgstr "KoyuArduvazMavisi"
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr "KoyuArduvazMavisi"
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr "Kaynak kodu"
 
@@ -1029,32 +1054,32 @@ msgstr "İspanyolca"
 msgid "Spring Green"
 msgstr "BaharYeşili"
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr "BaharYeşili"
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr "Oluşturmaya başla"
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr "Yüklemeyi başlat"
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr "Doğrulamayı başlat"
 
-#: app/scripts/services/forms.js:436 app/views/design.html:229
+#: app/scripts/services/forms.js:436 app/views/design.html:227
 #, fuzzy
 msgid "Steel Blue"
 msgstr "ÇelikMavisi"
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr "Uzak dosyaları eşleştirin ..."
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
 msgstr ""
 
@@ -1070,11 +1095,11 @@ msgstr "Testbankası"
 msgid "Thank you very much!"
 msgstr ""
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr "Koleksiyon {{name}} zaten var."
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
@@ -1082,19 +1107,19 @@ msgstr ""
 "Mevcut FPGA I/O yapılandırması kaybolacaktır. {{name}} Panosuna geçmek ister "
 "misiniz?"
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr "Araç zinciri kaldırılacak. Devam etmek istiyor musunuz?"
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr "Mevcut yeni bir gece sürümü var"
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr "Mevcut yeni bir kararlı sürümü var"
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
@@ -1102,7 +1127,7 @@ msgstr ""
 "Bu alma işlemi bir proje yolu gerektirir. Geçerli projeyi kaydetmeniz "
 "gerekir. Devam etmek istiyor musunuz?"
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr "Bu proje {{name}} panosu için tasarlanmıştır."
 
@@ -1112,7 +1137,7 @@ msgid ""
 "              done by an emerging team from"
 msgstr ""
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 msgid ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
 "mode\", lock the keylock to do it."
@@ -1120,14 +1145,14 @@ msgstr ""
 "Daha derin bloğun \"düzenleme modu\" na girmek için, mevcut \"düzenleme modu"
 "\" nu bitirmeniz, bunu yapmak için tuş kilidini kilitlemeniz gerekir."
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr "Tasarımda gezinmek için \"düzenleme modu\"nu kapatmanız gerekir."
 
 #: app/scripts/controllers/menu.js:349
 #, fuzzy
 msgid ""
-"To save your design you need to lock the keylock and               go to top "
+"To save your design you need to lock the padlock and               go to top "
 "level design.<br/><br/>If you want to export               this submodule to "
 "a file, execute \"Save as\" command to do it."
 msgstr ""
@@ -1135,33 +1160,33 @@ msgstr ""
 "gitmeniz gerekir.<br/><br/>Bu alt modülü bir dosyaya vermek istiyorsanız, "
 "bunu yapmak için \"Farklı Kaydet\" komutunu çalıştırın."
 
-#: app/views/menu.html:320
+#: app/views/menu.html:338
 #, fuzzy
 msgid "Toolbox"
 msgstr "Araçlar"
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr "Uyumluuygulama"
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr "Uyumluuygulama yüklü"
 
-#: app/scripts/services/drivers.js:594 app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191 app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625 app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300 app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr "Uyumluuygulama yüklü değil"
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr "Uyumluuygulamayı kaldır"
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr "Uyumluuygulama sürümü eşleşmiyor"
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr "Araçlar"
 
@@ -1169,11 +1194,11 @@ msgstr "Araçlar"
 msgid "Turkish"
 msgstr ""
 
-#: app/scripts/services/forms.js:433 app/views/design.html:222
+#: app/scripts/services/forms.js:433 app/views/design.html:220
 msgid "Turquoise"
 msgstr "Turkuaz"
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 msgid "UI theme"
 msgstr ""
 
@@ -1181,57 +1206,57 @@ msgstr ""
 msgid "Undo"
 msgstr "Geri al"
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr "Bilinmeyen pano"
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr "Desteklenmeyen proje biçimi {{version}}"
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr "İsimsiz"
 
-#: app/views/menu.html:639
+#: app/views/menu.html:657
 #, fuzzy
 msgid "Update (Latest stable)"
 msgstr "Blok adını güncelle"
 
-#: app/scripts/controllers/menu.js:1354 app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371 app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr "Yükle"
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr "Yükleme tamamlandı"
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr "Doğrulama yapıldı"
 
-#: app/views/design.html:510 app/views/menu.html:599
+#: app/views/design.html:498 app/views/menu.html:617
 msgid "Verify"
 msgstr "Doğrulama"
 
-#: app/scripts/services/utils.js:641 app/views/menu.html:832
+#: app/scripts/services/utils.js:636 app/views/menu.html:850
 msgid "Version"
 msgstr "Sürüm"
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr "Sürüm notları"
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr "Görüntüle"
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr "Lisansı görüntüle"
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr "Tasarımda tespit edilen uyarılar"
 
@@ -1250,64 +1275,73 @@ msgstr "Yanlış blok biçimi: {{type}}"
 msgid "Wrong block name {{name}}"
 msgstr "Yanlış blok adı {{name}}"
 
-#: app/scripts/controllers/menu.js:1907
+#: app/scripts/controllers/menu.js:1925
 #, fuzzy
 msgid "Wrong new name!"
 msgstr "Yanlış bağlantı noktası adı {{name}}"
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr "Yanlış proje biçimi: {{name}}"
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr "Yanlış uzak anamakineadı {{name}}"
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
 msgstr ""
 
-#: app/scripts/services/forms.js:412 app/views/design.html:166
+#: app/scripts/services/forms.js:412 app/views/design.html:164
 msgid "Yellow"
 msgstr "Sarı"
 
-#: app/scripts/controllers/menu.js:394
+#: app/scripts/controllers/menu.js:409
 #, fuzzy
 msgid ""
-"You are editing a submodule, if you save it, you save only               the "
-"submodule (in this situation \"save as\" works like               \"export "
-"module\"), Do you like to continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 msgstr ""
 "Bir alt modülü düzenliyorsunuz, eğer kaydederseniz, sadece alt modülü "
 "kaydedersiniz (bu durumda \"farklı kaydet\", \"dışa aktarma modülü\" gibi "
 "çalışır), devam etmek ister misiniz?"
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+msgstr ""
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr ""
 "Olduğu gibi yükleyebilir veya panoya için {{name}} dönüştürebilirsiniz."
 
-#: app/scripts/controllers/menu.js:1328
+#: app/scripts/controllers/menu.js:1347
+#, fuzzy
 msgid ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 msgstr ""
 "Sadece üst düzey bir tasarım inşa edebilirsiniz. Alt modüllerin içinde "
 "sadece <strong>doğrulayabilirsiniz</strong>"
 
-#: app/scripts/controllers/menu.js:1355
+#: app/scripts/controllers/menu.js:1372
+#, fuzzy
 msgid ""
-"You can only upload  your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
 msgstr ""
-"Tasarımınızı yalnızca üst düzey tasarıma yükleyebilirsiniz. Alt modüllerin "
-"içinde sadece <strong>doğrulayabilirsiniz</strong>"
+"Sadece üst düzey bir tasarım inşa edebilirsiniz. Alt modüllerin içinde "
+"sadece <strong>doğrulayabilirsiniz</strong>"
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr "Kaydemezseniz değişikler kaybolacak"
 
@@ -1315,25 +1349,35 @@ msgstr "Kaydemezseniz değişikler kaybolacak"
 msgid "back"
 msgstr "geri"
 
-#: app/scripts/services/drivers.js:412 app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439 app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr "{{app}} gerekli."
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr "{{board}} veri sayfası tanımlanmadı"
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr "{{board}} kablo işlev şeması tanımlanmadı"
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr "{{board}} kurallar tanımlanmadı"
 
-#: app/scripts/controllers/menu.js:483 app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499 app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr "{{name}} ihraç"
+
+#~ msgid "Read only"
+#~ msgstr "Salt okunur"
+
+#~ msgid ""
+#~ "You can only upload  your design at top-level design. Inside submodules "
+#~ "you only can <strong>Verify</strong>"
+#~ msgstr ""
+#~ "Tasarımınızı yalnızca üst düzey tasarıma yükleyebilirsiniz. Alt "
+#~ "modüllerin içinde sadece <strong>doğrulayabilirsiniz</strong>"
 
 #~ msgid "Choose a color"
 #~ msgstr "Bir renk seçin"

--- a/app/resources/locale/zh_CN/zh_CN.po
+++ b/app/resources/locale/zh_CN/zh_CN.po
@@ -12,15 +12,27 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: app/views/design.html:20
-msgid ": '}} {{'Unlock to edit block !"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
 msgstr ""
 
-#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr "<b>拔下</b>并<b>重新连接</b>开发板"
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
 msgstr "关于 Icestudio"
 
@@ -28,11 +40,11 @@ msgstr "关于 Icestudio"
 msgid "Acknowledgment"
 msgstr ""
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr "添加"
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr "添加图块并开始"
 
@@ -44,24 +56,24 @@ msgstr "添加为图块"
 msgid "Address format"
 msgstr "地址格式"
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr "所有集合已删除"
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr "所有存储的集合将会丢失。是否继续？"
 
-#: app/scripts/services/tools.js:1389
+#: app/scripts/services/tools.js:1500
 #, fuzzy
 msgid "At least Python 3.7 is required"
 msgstr "需要安装 Python 2.7"
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr "作者"
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr "基础"
 
@@ -73,6 +85,10 @@ msgstr "Basque"
 msgid "Binary"
 msgstr "二进制"
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr ""
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -82,7 +98,7 @@ msgstr "二进制"
 msgid "Block updated"
 msgstr "图块已更新"
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr "图块 {{name}} 已被导入"
 
@@ -90,56 +106,52 @@ msgstr "图块 {{name}} 已被导入"
 msgid "Blocks"
 msgstr "图块"
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr "开发板"
 
-#: app/views/menu.html:367 app/views/menu.html:458
+#: app/views/menu.html:385 app/views/menu.html:476
 msgid "Board rules"
 msgstr "开发板规则"
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr "开发板规则关闭"
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr "开发板规则开启"
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr "开发板 {{name}} 断开连接"
 
-#: app/scripts/services/tools.js:607 app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718 app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr "开发板 {{name}} 不可用"
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr "开发板 {{name}} 未连接"
 
-#: app/scripts/app.js:185 app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184 app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr "开发板 {{name}} 已选中"
 
-#: app/scripts/services/tools.js:596 app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707 app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr "Bootloader 失效"
 
-#: app/scripts/controllers/menu.js:1327 app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346 app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr "构建"
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr "构建成功"
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr ""
-
-#: app/scripts/app.js:59 app/scripts/services/project.js:147
+#: app/scripts/app.js:58 app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr "取消"
 
@@ -147,16 +159,16 @@ msgstr "取消"
 msgid "Catalan"
 msgstr "Catalan"
 
-#: app/views/design.html:264
+#: app/views/design.html:262
 #, fuzzy
 msgid "Change Color"
 msgstr "选择一个颜色"
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr "检测网络连接..."
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr "检测 Python..."
 
@@ -169,20 +181,20 @@ msgstr "中文"
 msgid "Choose a color:"
 msgstr "选择一个颜色"
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr "点击此处 <b>下载 Icestudio 的新版本</b>"
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr "点击此处 <b>安装驱动程序</b>"
 
-#: app/scripts/services/drivers.js:413 app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613 app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440 app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644 app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr "点击此处安装"
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr "点击此处浏览"
 
@@ -194,63 +206,63 @@ msgstr "数据总线上不可以使用时钟"
 msgid "Clone"
 msgstr "克隆"
 
-#: app/scripts/controllers/menu.js:565 app/views/version.html:80
+#: app/scripts/controllers/menu.js:581 app/views/version.html:80
 msgid "Close"
 msgstr "关闭"
 
-#: app/views/design.html:324 app/views/menu.html:791
+#: app/views/design.html:314 app/views/menu.html:809
 msgid "Code"
 msgstr "代码"
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr "集合"
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr "集合信息"
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr "集合 {{collection}} 的信息未定义"
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr "已添加集合 {{name}}"
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr "集合 {{name}} 未被替换"
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr "已移除集合 {{name}}"
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr "已替换集合 {{name}}"
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr "已选中集合 {{name}}"
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr "集合"
 
-#: app/scripts/controllers/menu.js:1229 app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249 app/views/menu.html:489
 msgid "Command output"
 msgstr "命令输出"
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr "社区论坛"
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr "配置未完成"
 
-#: app/views/design.html:312 app/views/menu.html:783
+#: app/views/design.html:304 app/views/menu.html:801
 msgid "Constant"
 msgstr "常量"
 
@@ -259,7 +271,7 @@ msgstr "常量"
 msgid "Constant names"
 msgstr "常量"
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr "转换"
 
@@ -267,11 +279,11 @@ msgstr "转换"
 msgid "Copy"
 msgstr "复制"
 
-#: app/scripts/services/forms.js:400 app/views/design.html:137
+#: app/scripts/services/forms.js:400 app/views/design.html:136
 msgid "Coral"
 msgstr "珊瑚红"
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr "编译 virtualenv..."
 
@@ -298,15 +310,15 @@ msgstr "深绿"
 msgid "Dark Orange"
 msgstr "深橙"
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr "深绿"
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr "深橙"
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr "数据表"
 
@@ -314,41 +326,45 @@ msgstr "数据表"
 msgid "Decimal"
 msgstr "十进制"
 
-#: app/scripts/services/forms.js:394 app/views/design.html:123
+#: app/scripts/services/forms.js:394 app/views/design.html:122
 #, fuzzy
 msgid "Deep Pink"
 msgstr "深粉"
 
-#: app/scripts/services/forms.js:439 app/views/design.html:236
+#: app/scripts/services/forms.js:439 app/views/design.html:234
 #, fuzzy
 msgid "Deep Sky Blue"
 msgstr "深蓝"
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr "默认"
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr ""
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr "描述"
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr "关闭"
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr "您是否要关闭应用程序？"
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr "您是否要移除集合 {{name}}？"
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr "您是否要替换？"
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr "文档"
 
@@ -356,21 +372,26 @@ msgstr "文档"
 msgid "Don't display"
 msgstr "不再显示"
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr "驱动"
 
 #: app/scripts/services/drivers.js:252 app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr "驱动关闭"
 
 #: app/scripts/services/drivers.js:230 app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr "驱动开启"
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+#, fuzzy
+msgid "Duplicate"
+msgstr "输出标签"
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr "重复的 FPGA I/O 接口"
 
@@ -387,11 +408,11 @@ msgstr "Dutch"
 msgid "Edit"
 msgstr "编辑"
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr "编辑集合名称"
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr "开启"
 
@@ -424,15 +445,15 @@ msgstr "输入输入端口名称"
 msgid "Enter the python path"
 msgstr "输入新集合路径"
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr "输入远程主机 用户名@主机名"
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr "错误: {{error}}"
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr "设计中检测到错误"
 
@@ -440,7 +461,7 @@ msgstr "设计中检测到错误"
 msgid "Examples"
 msgstr "示例"
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr "远程执行 {{label}} ..."
 
@@ -448,29 +469,29 @@ msgstr "远程执行 {{label}} ..."
 msgid "Export"
 msgstr "导出"
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395 app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr "导出子模块"
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr "外部集合"
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr "外部集合已更新"
 
-#: app/views/menu.html:383
+#: app/views/menu.html:401
 #, fuzzy
 msgid "External plugins"
 msgstr "外部集合"
 
-#: app/scripts/controllers/menu.js:780
+#: app/scripts/controllers/menu.js:800
 #, fuzzy
 msgid "External plugins updated"
 msgstr "外部集合已更新"
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr "FPGA I/O 接口未定义"
 
@@ -478,7 +499,7 @@ msgstr "FPGA I/O 接口未定义"
 msgid "FPGA pin"
 msgstr "FPGA 引脚"
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr "FPGA 资源"
 
@@ -494,16 +515,16 @@ msgstr ""
 msgid "File"
 msgstr "文件"
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr "文件 {{file}} 在项目路径中已存在。是否替换？"
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr "文件 {{file}} 不存在"
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr "已导入文件 {{file}}"
 
@@ -511,7 +532,7 @@ msgstr "已导入文件 {{file}}"
 msgid "Find"
 msgstr ""
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr "缩放以适应窗口"
 
@@ -519,8 +540,8 @@ msgstr "缩放以适应窗口"
 msgid "French"
 msgstr "French"
 
-#: app/scripts/services/forms.js:385 app/views/design.html:173
-#: app/views/design.html:98
+#: app/scripts/services/forms.js:385 app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr "紫红"
 
@@ -532,7 +553,7 @@ msgstr "Galician"
 msgid "German"
 msgstr "German"
 
-#: app/scripts/services/forms.js:409 app/views/design.html:158
+#: app/scripts/services/forms.js:409 app/views/design.html:157
 msgid "Gold"
 msgstr "金黄"
 
@@ -545,11 +566,11 @@ msgstr "Greek"
 msgid "Green Yellow"
 msgstr "黄绿"
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr "黄绿"
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr "帮助"
 
@@ -561,34 +582,34 @@ msgstr "十六进制"
 msgid "Icestudio is part of"
 msgstr ""
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid ""
 "If you have blank IN/OUT pins, it's because there is no equivalent in this "
 "board"
 msgstr "如果你有空白的 IN/OUT 引脚，那是因为这块开发板上没有这些引脚"
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr "镜像"
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr "镜像 {{name}} 已保存"
 
-#: app/scripts/services/forms.js:388 app/views/design.html:109
+#: app/scripts/services/forms.js:388 app/views/design.html:108
 #, fuzzy
 msgid "Indian Red"
 msgstr "印度红"
 
-#: app/views/design.html:330 app/views/menu.html:795
+#: app/views/design.html:319 app/views/menu.html:813
 msgid "Information"
 msgstr "信息"
 
-#: app/views/design.html:282 app/views/menu.html:760
+#: app/views/design.html:279 app/views/menu.html:778
 msgid "Input"
 msgstr "输入"
 
-#: app/views/design.html:294 app/views/menu.html:769
+#: app/views/design.html:289 app/views/menu.html:787
 msgid "Input label"
 msgstr "输入标签"
 
@@ -611,79 +632,79 @@ msgstr ""
 msgid "Input ports"
 msgstr "输入输入端口名称"
 
-#: app/views/menu.html:635
+#: app/views/menu.html:653
 #, fuzzy
 msgid "Install (Stable)"
 msgstr "安装"
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
 msgstr ""
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid ""
 "Install the <b>STABLE Toolchain</b>. This operation requires Internet "
 "connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
 "allow the toolchain installation</p> <p>Do you want to continue?</p>"
 msgstr ""
 
-#: app/scripts/services/tools.js:1144
+#: app/scripts/services/tools.js:1255
 #, fuzzy
 msgid ""
 "Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
 "requires Internet connection. Do you want to continue?"
 msgstr "工具链将被更新，这个操作需要Internet连接，是否继续？"
 
-#: app/scripts/services/tools.js:1166
+#: app/scripts/services/tools.js:1277
 #, fuzzy
 msgid ""
 "Install the LATEST STABLE toolchain. It will be downloaded. This operation "
 "requires Internet connection. Do you want to continue?"
 msgstr "工具链将被更新，这个操作需要Internet连接，是否继续？"
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr "安装成功"
 
-#: app/scripts/services/tools.js:1274
+#: app/scripts/services/tools.js:1385
 #, fuzzy
 msgid "Installing"
 msgstr "安装"
 
-#: app/scripts/services/drivers.js:421 app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447 app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr "需要网络连接"
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr "无效的 <i>上拉</i> 连接：<br>图块已被连接"
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr "无效的 <i>上拉</i> 连接：<br>只有 <i>输入</i> 图块才能被上拉"
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr "无效的图块连接：<br><i>上拉</i> 已经使用"
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr "无效的集合 {{name}}"
 
-#: app/scripts/services/graph.js:254 app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262 app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr "无效的连接"
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr "无效的连接 {{a}} → {{b}}"
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr "无效的多输入连接"
 
-#: app/scripts/services/project.js:499 app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510 app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr "无效的项目格式"
 
@@ -700,7 +721,7 @@ msgstr "Spanish"
 msgid "Korean"
 msgstr ""
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
 msgstr ""
 
@@ -709,7 +730,7 @@ msgstr ""
 msgid "Label updated"
 msgstr "图块已更新"
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr "语言"
 
@@ -717,17 +738,17 @@ msgstr "语言"
 msgid "Light"
 msgstr ""
 
-#: app/scripts/services/forms.js:448 app/views/design.html:257
+#: app/scripts/services/forms.js:448 app/views/design.html:255
 #, fuzzy
 msgid "Light Gray"
 msgstr "亮海绿"
 
-#: app/scripts/services/forms.js:430 app/views/design.html:215
+#: app/scripts/services/forms.js:430 app/views/design.html:213
 #, fuzzy
 msgid "Light Sea Green"
 msgstr "亮海绿"
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr "载入"
 
@@ -735,20 +756,20 @@ msgstr "载入"
 msgid "Local parameter"
 msgstr "本地参数"
 
-#: app/views/menu.html:404
+#: app/views/menu.html:422
 #, fuzzy
 msgid "Logging enabled"
 msgstr "驱动开启"
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
 msgstr ""
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr "最大总线宽度：96 bits"
 
@@ -757,11 +778,11 @@ msgstr "最大总线宽度：96 bits"
 msgid "Medium Violet Red"
 msgstr "紫红"
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr "紫红"
 
-#: app/views/design.html:318 app/views/menu.html:787
+#: app/views/design.html:309 app/views/menu.html:805
 msgid "Memory"
 msgstr "内存"
 
@@ -770,7 +791,7 @@ msgstr "内存"
 msgid "Memory blocks"
 msgstr "输入内存图块名称"
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr "名称"
 
@@ -778,7 +799,7 @@ msgstr "名称"
 msgid "Name of the paired labels"
 msgstr ""
 
-#: app/scripts/services/forms.js:445 app/views/design.html:250
+#: app/scripts/services/forms.js:445 app/views/design.html:248
 msgid "Navy"
 msgstr "海军蓝"
 
@@ -792,15 +813,19 @@ msgstr ""
 
 #: app/views/design.html:80
 #, fuzzy
-msgid "New Name:"
+msgid "New Name"
 msgstr "名称"
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr ""
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr "没有存储的集合"
 
-#: app/scripts/app.js:58 app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57 app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr "确定"
 
@@ -809,7 +834,7 @@ msgstr "确定"
 msgid "Olive Drab"
 msgstr "橄榄绿"
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr "橄榄绿"
 
@@ -817,7 +842,7 @@ msgstr "橄榄绿"
 msgid "Open"
 msgstr "打开"
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr "打开 SVG"
 
@@ -826,19 +851,19 @@ msgstr "打开 SVG"
 msgid "Orange Red"
 msgstr "橙红"
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr "橙红"
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr "原始文件 {{file}} 不存在"
 
-#: app/views/design.html:288 app/views/menu.html:764
+#: app/views/design.html:284 app/views/menu.html:782
 msgid "Output"
 msgstr "输出"
 
-#: app/views/design.html:300 app/views/menu.html:773
+#: app/views/design.html:294 app/views/menu.html:791
 msgid "Output label"
 msgstr "输出标签"
 
@@ -857,7 +882,7 @@ msgstr "输出标签"
 msgid "Output ports"
 msgstr "输出标签"
 
-#: app/views/design.html:306 app/views/menu.html:778
+#: app/views/design.html:299 app/views/menu.html:796
 msgid "Paired labels"
 msgstr ""
 
@@ -865,40 +890,44 @@ msgstr ""
 msgid "Paste"
 msgstr "粘贴"
 
-#: app/scripts/controllers/menu.js:731 app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853 app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751 app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873 app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr "路径 {{path}} 不存在"
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr "请运行： {{cmd}}"
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr "个性化"
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr ""
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr "项目信息"
 
-#: app/scripts/controllers/menu.js:935 app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955 app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr "项目信息已更新"
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr "项目 {{name}} 已载入"
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr "项目 {{name}} 已保存"
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
 msgstr ""
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
 msgstr ""
 
@@ -906,11 +935,7 @@ msgstr ""
 msgid "Quit"
 msgstr "退出"
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr "只读"
-
-#: app/scripts/services/forms.js:391 app/views/design.html:116
+#: app/scripts/services/forms.js:391 app/views/design.html:115
 msgid "Red"
 msgstr "红"
 
@@ -922,27 +947,27 @@ msgstr "重做"
 msgid "Release History WIKI"
 msgstr ""
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr "重载"
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr "远程主机 {{name}} 未连接"
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr "远程主机名"
 
-#: app/views/menu.html:647 app/views/menu.html:722
+#: app/views/menu.html:665 app/views/menu.html:740
 msgid "Remove"
 msgstr "移除"
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr "移除全部"
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
 msgstr ""
 
@@ -950,11 +975,11 @@ msgstr ""
 msgid "Replace One"
 msgstr ""
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr "重载 SVG"
 
-#: app/scripts/services/forms.js:442 app/views/design.html:243
+#: app/scripts/services/forms.js:442 app/views/design.html:241
 #, fuzzy
 msgid "Royal Blue"
 msgstr "宝石蓝"
@@ -967,7 +992,7 @@ msgstr "Russian"
 msgid "Save"
 msgstr "保存"
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr "保存 SVG"
 
@@ -979,11 +1004,11 @@ msgstr "另存为"
 msgid "Save submodule"
 msgstr "保存子模块"
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr "选择"
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr "全选"
 
@@ -1000,11 +1025,11 @@ msgstr "显示时钟"
 msgid "Slate Blue"
 msgstr "板岩蓝"
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr "板岩蓝"
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr "源代码"
 
@@ -1017,32 +1042,32 @@ msgstr "Spanish"
 msgid "Spring Green"
 msgstr "春绿"
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr "春绿"
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr "开始编译"
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr "开始上传"
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr "开始验证"
 
-#: app/scripts/services/forms.js:436 app/views/design.html:229
+#: app/scripts/services/forms.js:436 app/views/design.html:227
 #, fuzzy
 msgid "Steel Blue"
 msgstr "钢蓝"
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr "远程文件同步..."
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
 msgstr ""
 
@@ -1058,35 +1083,35 @@ msgstr "测试平台"
 msgid "Thank you very much!"
 msgstr ""
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr "集合 {{name}} 已存在。"
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
 msgstr "目前FPGA的I/O配置将会丢失，您是否确定换用 {{name}} 开发板？"
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr "工具链将被移除，是否继续？"
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr "有新的每日构建版本"
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr "有新的稳定版本"
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
 msgstr "本次导入操作需要项目路径，您必须保存当前项目，是否继续？"
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr "该项目为开发板 {{name}} 设计使用。"
 
@@ -1096,7 +1121,7 @@ msgid ""
 "              done by an emerging team from"
 msgstr ""
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 msgid ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
 "mode\", lock the keylock to do it."
@@ -1104,47 +1129,47 @@ msgstr ""
 "要为更深层次的图块使用 \"编辑模式\"，您需要完成当前的\"编辑模式\"，然后锁定键"
 "锁即可。"
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr "要浏览设计，您需要退出 \"编辑模式\"。"
 
 #: app/scripts/controllers/menu.js:349
 #, fuzzy
 msgid ""
-"To save your design you need to lock the keylock and               go to top "
+"To save your design you need to lock the padlock and               go to top "
 "level design.<br/><br/>If you want to export               this submodule to "
 "a file, execute \"Save as\" command to do it."
 msgstr ""
 "要保存您的设计，您需要锁定键锁并且切换到顶层设计<br/><br/>如果您想将子模块导"
 "出到文件，请点击\"另存为\"。"
 
-#: app/views/menu.html:320
+#: app/views/menu.html:338
 #, fuzzy
 msgid "Toolbox"
 msgstr "工具"
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr "工具链"
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr "工具链已安装"
 
-#: app/scripts/services/drivers.js:594 app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191 app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625 app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300 app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr "工具链未安装"
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr "工具链已移除"
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr "工具链版本不匹配"
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr "工具"
 
@@ -1152,11 +1177,11 @@ msgstr "工具"
 msgid "Turkish"
 msgstr ""
 
-#: app/scripts/services/forms.js:433 app/views/design.html:222
+#: app/scripts/services/forms.js:433 app/views/design.html:220
 msgid "Turquoise"
 msgstr "松石绿"
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 msgid "UI theme"
 msgstr ""
 
@@ -1164,57 +1189,57 @@ msgstr ""
 msgid "Undo"
 msgstr "撤销"
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr "未知的开发板"
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr "不支持的项目格式 {{version}}"
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr "未命名"
 
-#: app/views/menu.html:639
+#: app/views/menu.html:657
 #, fuzzy
 msgid "Update (Latest stable)"
 msgstr "更新图块名称"
 
-#: app/scripts/controllers/menu.js:1354 app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371 app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr "上传"
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr "上传成功"
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr "验证成功"
 
-#: app/views/design.html:510 app/views/menu.html:599
+#: app/views/design.html:498 app/views/menu.html:617
 msgid "Verify"
 msgstr "验证"
 
-#: app/scripts/services/utils.js:641 app/views/menu.html:832
+#: app/scripts/services/utils.js:636 app/views/menu.html:850
 msgid "Version"
 msgstr "版本"
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr "版本说明"
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr "查看"
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr "查看许可"
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr "设计中发现警告"
 
@@ -1233,58 +1258,67 @@ msgstr "图块格式错误： {{type}}"
 msgid "Wrong block name {{name}}"
 msgstr "图块名称错误 {{name}}"
 
-#: app/scripts/controllers/menu.js:1907
+#: app/scripts/controllers/menu.js:1925
 #, fuzzy
 msgid "Wrong new name!"
 msgstr "端口名称错误 {{name}}"
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr "项目格式错误： {{name}}"
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr "远程主机名错误 {{name}}"
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
 msgstr ""
 
-#: app/scripts/services/forms.js:412 app/views/design.html:166
+#: app/scripts/services/forms.js:412 app/views/design.html:164
 msgid "Yellow"
 msgstr "橙黄"
 
-#: app/scripts/controllers/menu.js:394
+#: app/scripts/controllers/menu.js:409
 #, fuzzy
 msgid ""
-"You are editing a submodule, if you save it, you save only               the "
-"submodule (in this situation \"save as\" works like               \"export "
-"module\"), Do you like to continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 msgstr ""
 "您正在编辑一个子模块。如果您保存，您将只会保存子模块 (在此情况下 \"另存为\" "
 "和 \"导出子模块\" 效果相同)，是否继续？"
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+msgstr ""
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr "您可以载入原始项目，或转换以适应开发板 {{name}}。"
 
-#: app/scripts/controllers/menu.js:1328
+#: app/scripts/controllers/menu.js:1347
+#, fuzzy
 msgid ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 msgstr "您只能在顶层设计中编译。在子模块中您将只能 <strong>验证</strong>"
 
-#: app/scripts/controllers/menu.js:1355
+#: app/scripts/controllers/menu.js:1372
+#, fuzzy
 msgid ""
-"You can only upload  your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
-msgstr "您只能在顶层设计中上传。在子模块中您将只能 <strong>验证</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
+msgstr "您只能在顶层设计中编译。在子模块中您将只能 <strong>验证</strong>"
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr "如果不保存，您的更改将会丢失"
 
@@ -1292,25 +1326,33 @@ msgstr "如果不保存，您的更改将会丢失"
 msgid "back"
 msgstr "后退"
 
-#: app/scripts/services/drivers.js:412 app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439 app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr "需要 {{app}} 。"
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr "{{board}} 数据表未定义"
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr "{{board}} 引脚未定义"
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr "{{board}} 规则未定义"
 
-#: app/scripts/controllers/menu.js:483 app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499 app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr "{{name}} 已导出"
+
+#~ msgid "Read only"
+#~ msgstr "只读"
+
+#~ msgid ""
+#~ "You can only upload  your design at top-level design. Inside submodules "
+#~ "you only can <strong>Verify</strong>"
+#~ msgstr "您只能在顶层设计中上传。在子模块中您将只能 <strong>验证</strong>"
 
 #~ msgid "Choose a color"
 #~ msgstr "选择一个颜色"

--- a/app/resources/locale/zh_TW/zh_TW.po
+++ b/app/resources/locale/zh_TW/zh_TW.po
@@ -12,15 +12,27 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: app/views/design.html:20
-msgid ": '}} {{'Unlock to edit block !"
+#: app/views/design.html:18
+msgid ""
+"<b>Read only</b><br>\n"
+"            Unlock to edit the block!"
 msgstr ""
 
-#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:602
+#: app/scripts/services/drivers.js:353 app/scripts/services/drivers.js:633
 msgid "<b>Unplug</b> and <b>reconnect</b> the board"
 msgstr "<b>拔出</b>並<b>重新連接</b>開發板"
 
-#: app/views/menu.html:873
+#: app/views/design.html:34
+msgid ""
+"<b>WARNING!</b><br>\n"
+"        The changes made here, will also be applied to all the\n"
+"        [<b>{{ information.name }}</b>] blocks in the current design. If\n"
+"        you DO NOT want them to propagate, create a cloned block instead\n"
+"        using<br>\n"
+"        <b>Edit → Clone</b>."
+msgstr ""
+
+#: app/views/menu.html:891
 msgid "About Icestudio"
 msgstr "關於 Icestudio"
 
@@ -28,11 +40,11 @@ msgstr "關於 Icestudio"
 msgid "Acknowledgment"
 msgstr "致謝"
 
-#: app/views/menu.html:708
+#: app/views/menu.html:726
 msgid "Add"
 msgstr "新增"
 
-#: app/scripts/controllers/menu.js:1385
+#: app/scripts/controllers/menu.js:1402
 msgid "Add a block to start"
 msgstr "新增區塊並開始"
 
@@ -44,24 +56,24 @@ msgstr "新增為區塊"
 msgid "Address format"
 msgstr "地址格式"
 
-#: app/scripts/services/tools.js:1807
+#: app/scripts/services/tools.js:1918
 msgid "All collections removed"
 msgstr "已刪除全部選集"
 
-#: app/scripts/controllers/menu.js:1425
+#: app/scripts/controllers/menu.js:1442
 msgid "All stored collections will be lost. Do you want to continue?"
 msgstr "儲存的選集會全部消失，是否要繼續?"
 
-#: app/scripts/services/tools.js:1389
+#: app/scripts/services/tools.js:1500
 #, fuzzy
 msgid "At least Python 3.7 is required"
 msgstr "至少需要 Python3.5版"
 
-#: app/scripts/services/utils.js:643
+#: app/scripts/services/utils.js:638
 msgid "Author"
 msgstr "作者"
 
-#: app/views/menu.html:753
+#: app/views/menu.html:771
 msgid "Basic"
 msgstr "基本區塊"
 
@@ -73,6 +85,10 @@ msgstr "Basque"
 msgid "Binary"
 msgstr "Binary"
 
+#: app/scripts/services/tools.js:159
+msgid "Bitstream not found, build first your project"
+msgstr ""
+
 #: app/scripts/services/blockforms.js:1082
 #: app/scripts/services/blockforms.js:1206
 #: app/scripts/services/blockforms.js:1249
@@ -82,7 +98,7 @@ msgstr "Binary"
 msgid "Block updated"
 msgstr "區塊已更新"
 
-#: app/scripts/services/project.js:494
+#: app/scripts/services/project.js:505
 msgid "Block {{name}} imported"
 msgstr "區塊 {{name}}已導入"
 
@@ -90,56 +106,52 @@ msgstr "區塊 {{name}}已導入"
 msgid "Blocks"
 msgstr "區塊"
 
-#: app/views/menu.html:508
+#: app/views/menu.html:526
 msgid "Board"
 msgstr "開發板"
 
-#: app/views/menu.html:367 app/views/menu.html:458
+#: app/views/menu.html:385 app/views/menu.html:476
 msgid "Board rules"
 msgstr "開發板規則"
 
-#: app/scripts/controllers/menu.js:997
+#: app/scripts/controllers/menu.js:1017
 msgid "Board rules disabled"
 msgstr "開發板規則停用"
 
-#: app/scripts/controllers/menu.js:995
+#: app/scripts/controllers/menu.js:1015
 msgid "Board rules enabled"
 msgstr "開發板規則啟用"
 
-#: app/scripts/services/tools.js:648
+#: app/scripts/services/tools.js:759
 msgid "Board {{name}} disconnected"
 msgstr "開發板 {{name}}斷線"
 
-#: app/scripts/services/tools.js:607 app/scripts/services/tools.js:633
+#: app/scripts/services/tools.js:718 app/scripts/services/tools.js:744
 msgid "Board {{name}} not available"
 msgstr "開發板 {{name}}無法使用"
 
-#: app/scripts/services/tools.js:585
+#: app/scripts/services/tools.js:696
 msgid "Board {{name}} not connected"
 msgstr "開發板 {{name}} 未連線"
 
-#: app/scripts/app.js:185 app/scripts/controllers/menu.js:1304
+#: app/scripts/app.js:184 app/scripts/controllers/menu.js:1324
 msgid "Board {{name}} selected"
 msgstr "開發板{{name}} 已選中"
 
-#: app/scripts/services/tools.js:596 app/scripts/services/tools.js:626
+#: app/scripts/services/tools.js:707 app/scripts/services/tools.js:737
 msgid "Bootloader not active"
 msgstr "Bootloader 未啟動"
 
-#: app/scripts/controllers/menu.js:1327 app/views/design.html:518
-#: app/views/menu.html:607
+#: app/scripts/controllers/menu.js:1346 app/views/design.html:506
+#: app/views/menu.html:625
 msgid "Build"
 msgstr "建構"
 
-#: app/scripts/controllers/menu.js:1337
+#: app/scripts/controllers/menu.js:1356
 msgid "Build done"
 msgstr "建構完成"
 
-#: app/views/design.html:35
-msgid "CAUTION ! : Changes will also be applied in all the copied"
-msgstr ""
-
-#: app/scripts/app.js:59 app/scripts/services/project.js:147
+#: app/scripts/app.js:58 app/scripts/services/project.js:158
 msgid "Cancel"
 msgstr "取消"
 
@@ -147,16 +159,16 @@ msgstr "取消"
 msgid "Catalan"
 msgstr "Catalan"
 
-#: app/views/design.html:264
+#: app/views/design.html:262
 #, fuzzy
 msgid "Change Color"
 msgstr "選擇顏色"
 
-#: app/scripts/services/tools.js:1344
+#: app/scripts/services/tools.js:1455
 msgid "Check Internet connection..."
 msgstr "檢查網路連接..."
 
-#: app/scripts/services/tools.js:1378
+#: app/scripts/services/tools.js:1489
 msgid "Check Python..."
 msgstr "檢查Python..."
 
@@ -169,20 +181,20 @@ msgstr "中文(簡)"
 msgid "Choose a color:"
 msgstr "選擇顏色"
 
-#: app/scripts/services/project.js:171
+#: app/scripts/services/project.js:182
 msgid "Click here to <b>download a newer version</b> of Icestudio"
 msgstr "點按這裡<b>下載新版本</b> 的 Icestudio"
 
-#: app/scripts/services/tools.js:1518
+#: app/scripts/services/tools.js:1629
 msgid "Click here to <b>setup the drivers</b>"
 msgstr "點按這裡 <b>安裝驅動程式</b>"
 
-#: app/scripts/services/drivers.js:413 app/scripts/services/drivers.js:594
-#: app/scripts/services/drivers.js:613 app/scripts/services/tools.js:430
+#: app/scripts/services/drivers.js:440 app/scripts/services/drivers.js:625
+#: app/scripts/services/drivers.js:644 app/scripts/services/tools.js:539
 msgid "Click here to install it"
 msgstr "點按這裡安裝"
 
-#: app/scripts/controllers/menu.js:937
+#: app/scripts/controllers/menu.js:957
 msgid "Click here to view"
 msgstr "點按這裡瀏覽"
 
@@ -194,63 +206,63 @@ msgstr "時脈不合於資料匯流排線"
 msgid "Clone"
 msgstr "Clone"
 
-#: app/scripts/controllers/menu.js:565 app/views/version.html:80
+#: app/scripts/controllers/menu.js:581 app/views/version.html:80
 msgid "Close"
 msgstr "關閉"
 
-#: app/views/design.html:324 app/views/menu.html:791
+#: app/views/design.html:314 app/views/menu.html:809
 msgid "Code"
 msgstr "程式碼區塊"
 
-#: app/views/menu.html:541
+#: app/views/menu.html:559
 msgid "Collection"
 msgstr "選集"
 
-#: app/views/menu.html:465
+#: app/views/menu.html:483
 msgid "Collection info"
 msgstr "選集資訊"
 
-#: app/scripts/controllers/menu.js:1213
+#: app/scripts/controllers/menu.js:1233
 msgid "Collection {{collection}} info not defined"
 msgstr "選集 {{collection}} 資訊未定義"
 
-#: app/scripts/services/tools.js:1660
+#: app/scripts/services/tools.js:1771
 msgid "Collection {{name}} added"
 msgstr "已新增 {{name}} 選集"
 
-#: app/scripts/services/tools.js:1647
+#: app/scripts/services/tools.js:1758
 msgid "Collection {{name}} not replaced"
 msgstr "沒替換 {{name}} 選集"
 
-#: app/scripts/services/tools.js:1798
+#: app/scripts/services/tools.js:1909
 msgid "Collection {{name}} removed"
 msgstr "已移除 {{name}} 選集"
 
-#: app/scripts/services/tools.js:1636
+#: app/scripts/services/tools.js:1747
 msgid "Collection {{name}} replaced"
 msgstr "已替換 {{name}} 選集"
 
-#: app/scripts/controllers/menu.js:1259
+#: app/scripts/controllers/menu.js:1279
 msgid "Collection {{name}} selected"
 msgstr "選中 {{name}} 選集"
 
-#: app/views/menu.html:700
+#: app/views/menu.html:718
 msgid "Collections"
 msgstr "範例選集組"
 
-#: app/scripts/controllers/menu.js:1229 app/views/menu.html:471
+#: app/scripts/controllers/menu.js:1249 app/views/menu.html:489
 msgid "Command output"
 msgstr "查看執行結果"
 
-#: app/views/menu.html:864
+#: app/views/menu.html:882
 msgid "Community forum"
 msgstr "社群論壇"
 
-#: app/scripts/services/tools.js:676
+#: app/scripts/services/tools.js:787
 msgid "Configuration not completed"
 msgstr "設定未完成"
 
-#: app/views/design.html:312 app/views/menu.html:783
+#: app/views/design.html:304 app/views/menu.html:801
 msgid "Constant"
 msgstr "常數"
 
@@ -259,7 +271,7 @@ msgstr "常數"
 msgid "Constant names"
 msgstr "常數"
 
-#: app/scripts/services/project.js:93
+#: app/scripts/services/project.js:99
 msgid "Convert"
 msgstr "轉換"
 
@@ -267,11 +279,11 @@ msgstr "轉換"
 msgid "Copy"
 msgstr "複製"
 
-#: app/scripts/services/forms.js:400 app/views/design.html:137
+#: app/scripts/services/forms.js:400 app/views/design.html:136
 msgid "Coral"
 msgstr "珊瑚色"
 
-#: app/scripts/services/tools.js:1408
+#: app/scripts/services/tools.js:1519
 msgid "Create virtualenv..."
 msgstr "編譯 virtualenv..."
 
@@ -297,15 +309,15 @@ msgstr "深綠色"
 msgid "Dark Orange"
 msgstr "深橘色"
 
-#: app/views/design.html:201
+#: app/views/design.html:199
 msgid "DarkGreen"
 msgstr "深綠色"
 
-#: app/views/design.html:151
+#: app/views/design.html:150
 msgid "DarkOrange"
 msgstr "深橘色"
 
-#: app/views/menu.html:452
+#: app/views/menu.html:470
 msgid "Datasheet"
 msgstr "規格書"
 
@@ -313,41 +325,45 @@ msgstr "規格書"
 msgid "Decimal"
 msgstr "十進位"
 
-#: app/scripts/services/forms.js:394 app/views/design.html:123
+#: app/scripts/services/forms.js:394 app/views/design.html:122
 #, fuzzy
 msgid "Deep Pink"
 msgstr "暗粉紅色"
 
-#: app/scripts/services/forms.js:439 app/views/design.html:236
+#: app/scripts/services/forms.js:439 app/views/design.html:234
 #, fuzzy
 msgid "Deep Sky Blue"
 msgstr "深天空藍色"
 
-#: app/views/menu.html:550
+#: app/views/menu.html:568
 msgid "Default"
 msgstr "預設"
 
-#: app/scripts/services/utils.js:642
+#: app/views/menu.html:296
+msgid "Delete"
+msgstr ""
+
+#: app/scripts/services/utils.js:637
 msgid "Description"
 msgstr "說明"
 
-#: app/views/menu.html:688
+#: app/views/menu.html:706
 msgid "Disable"
 msgstr "取消"
 
-#: app/scripts/controllers/menu.js:570
+#: app/scripts/controllers/menu.js:586
 msgid "Do you want to close the application?"
 msgstr "您是否關閉應用程式?"
 
-#: app/scripts/controllers/menu.js:1408
+#: app/scripts/controllers/menu.js:1425
 msgid "Do you want to remove the {{name}} collection?"
 msgstr "您是是否要移除這 {{name}} 選集?"
 
-#: app/scripts/services/tools.js:1629
+#: app/scripts/services/tools.js:1740
 msgid "Do you want to replace it?"
 msgstr "您是否要替換?"
 
-#: app/views/menu.html:845
+#: app/views/menu.html:863
 msgid "Documentation"
 msgstr "說明文件"
 
@@ -355,21 +371,26 @@ msgstr "說明文件"
 msgid "Don't display"
 msgstr "不再顯示"
 
-#: app/views/menu.html:675
+#: app/views/menu.html:693
 msgid "Drivers"
 msgstr "驅動程式"
 
 #: app/scripts/services/drivers.js:252 app/scripts/services/drivers.js:307
-#: app/scripts/services/drivers.js:447
+#: app/scripts/services/drivers.js:478
 msgid "Drivers disabled"
 msgstr "停用驅動程式"
 
 #: app/scripts/services/drivers.js:230 app/scripts/services/drivers.js:287
-#: app/scripts/services/drivers.js:431
+#: app/scripts/services/drivers.js:455
 msgid "Drivers enabled"
 msgstr "啟用驅動程式"
 
-#: app/scripts/services/tools.js:694
+#: app/views/menu.html:287
+#, fuzzy
+msgid "Duplicate"
+msgstr "輸出標籤"
+
+#: app/scripts/services/tools.js:805
 msgid "Duplicated FPGA I/O ports"
 msgstr "重複的 FPGA I/O 接腳"
 
@@ -386,11 +407,11 @@ msgstr "Dutch"
 msgid "Edit"
 msgstr "編輯"
 
-#: app/scripts/services/tools.js:1608
+#: app/scripts/services/tools.js:1719
 msgid "Edit the collection name"
 msgstr "編輯選集名稱"
 
-#: app/views/menu.html:681
+#: app/views/menu.html:699
 msgid "Enable"
 msgstr "開啟"
 
@@ -422,15 +443,15 @@ msgstr "填寫輸入埠名稱"
 msgid "Enter the python path"
 msgstr "輸入 python 版本 > 3.8 的路徑"
 
-#: app/scripts/controllers/menu.js:984
+#: app/scripts/controllers/menu.js:1004
 msgid "Enter the remote hostname user@host"
 msgstr "輸入遠端主機 用戶名@主機名"
 
-#: app/scripts/services/utils.js:846
+#: app/scripts/services/utils.js:841
 msgid "Error: {{error}}"
 msgstr "錯誤: {{error}}"
 
-#: app/scripts/services/tools.js:800
+#: app/scripts/services/tools.js:911
 msgid "Errors detected in the design"
 msgstr "設計中檢測到錯誤"
 
@@ -438,7 +459,7 @@ msgstr "設計中檢測到錯誤"
 msgid "Examples"
 msgstr "範例"
 
-#: app/scripts/services/tools.js:468
+#: app/scripts/services/tools.js:577
 msgid "Execute remote {{label}} ..."
 msgstr "遠端執行 {{label}} ..."
 
@@ -446,27 +467,27 @@ msgstr "遠端執行 {{label}} ..."
 msgid "Export"
 msgstr "導出"
 
-#: app/scripts/controllers/menu.js:393
+#: app/scripts/controllers/menu.js:395 app/scripts/controllers/menu.js:408
 msgid "Export submodule"
 msgstr "輸出子模組"
 
-#: app/views/menu.html:377
+#: app/views/menu.html:395
 msgid "External collections"
 msgstr "外部選集"
 
-#: app/scripts/controllers/menu.js:909
+#: app/scripts/controllers/menu.js:929
 msgid "External collections updated"
 msgstr "外部選集已更新"
 
-#: app/views/menu.html:383
+#: app/views/menu.html:401
 msgid "External plugins"
 msgstr "外部外掛"
 
-#: app/scripts/controllers/menu.js:780
+#: app/scripts/controllers/menu.js:800
 msgid "External plugins updated"
 msgstr "外部外掛已更新"
 
-#: app/scripts/services/tools.js:687
+#: app/scripts/services/tools.js:798
 msgid "FPGA I/O ports not defined"
 msgstr "FPGA I/O 埠未定義"
 
@@ -474,7 +495,7 @@ msgstr "FPGA I/O 埠未定義"
 msgid "FPGA pin"
 msgstr "FPGA 接腳"
 
-#: app/views/menu.html:486
+#: app/views/menu.html:504
 msgid "FPGA resources"
 msgstr "FPGA 資源"
 
@@ -490,16 +511,16 @@ msgstr ""
 msgid "File"
 msgstr "檔案"
 
-#: app/scripts/services/project.js:508
+#: app/scripts/services/project.js:519
 msgid ""
 "File {{file}} already exists in the project path. Do you want to replace it?"
 msgstr "檔案 {{file}} 在目錄中已存在. 是否要覆寫?"
 
-#: app/scripts/services/tools.js:324
+#: app/scripts/services/tools.js:433
 msgid "File {{file}} does not exist"
 msgstr "檔案 {{file}} 不存在"
 
-#: app/scripts/services/project.js:541
+#: app/scripts/services/project.js:552
 msgid "File {{file}} imported"
 msgstr "檔案 {{file}} 導入了"
 
@@ -507,7 +528,7 @@ msgstr "檔案 {{file}} 導入了"
 msgid "Find"
 msgstr ""
 
-#: app/views/menu.html:300
+#: app/views/menu.html:318
 msgid "Fit content"
 msgstr "縮放以適應視窗"
 
@@ -515,8 +536,8 @@ msgstr "縮放以適應視窗"
 msgid "French"
 msgstr "French"
 
-#: app/scripts/services/forms.js:385 app/views/design.html:173
-#: app/views/design.html:98
+#: app/scripts/services/forms.js:385 app/views/design.html:171
+#: app/views/design.html:97
 msgid "Fuchsia"
 msgstr "洋紅色"
 
@@ -528,7 +549,7 @@ msgstr "Galician"
 msgid "German"
 msgstr "German"
 
-#: app/scripts/services/forms.js:409 app/views/design.html:158
+#: app/scripts/services/forms.js:409 app/views/design.html:157
 msgid "Gold"
 msgstr "金色"
 
@@ -541,11 +562,11 @@ msgstr "Greek"
 msgid "Green Yellow"
 msgstr "黃綠色"
 
-#: app/views/design.html:187
+#: app/views/design.html:185
 msgid "GreenYellow"
 msgstr "黃綠色"
 
-#: app/views/menu.html:809
+#: app/views/menu.html:827
 msgid "Help"
 msgstr "輔助說明"
 
@@ -557,34 +578,34 @@ msgstr "十六進位"
 msgid "Icestudio is part of"
 msgstr ""
 
-#: app/scripts/services/graph.js:1619
+#: app/scripts/services/graph.js:1659
 msgid ""
 "If you have blank IN/OUT pins, it's because there is no equivalent in this "
 "board"
 msgstr "若您看到空的輸入輸出接腳，這是因為這塊開發板上沒有對應的腳位"
 
-#: app/scripts/services/utils.js:656
+#: app/scripts/services/utils.js:651
 msgid "Image"
 msgstr "圖像"
 
-#: app/scripts/controllers/menu.js:2108
+#: app/scripts/controllers/menu.js:2126
 msgid "Image {{name}} saved"
 msgstr "圖像 {{name}} 已儲存"
 
-#: app/scripts/services/forms.js:388 app/views/design.html:109
+#: app/scripts/services/forms.js:388 app/views/design.html:108
 #, fuzzy
 msgid "Indian Red"
 msgstr "印地安紅色"
 
-#: app/views/design.html:330 app/views/menu.html:795
+#: app/views/design.html:319 app/views/menu.html:813
 msgid "Information"
 msgstr "資訊"
 
-#: app/views/design.html:282 app/views/menu.html:760
+#: app/views/design.html:279 app/views/menu.html:778
 msgid "Input"
 msgstr "輸入"
 
-#: app/views/design.html:294 app/views/menu.html:769
+#: app/views/design.html:289 app/views/menu.html:787
 msgid "Input label"
 msgstr "輸入標籤"
 
@@ -607,79 +628,79 @@ msgstr ""
 msgid "Input ports"
 msgstr "填寫輸入埠名稱"
 
-#: app/views/menu.html:635
+#: app/views/menu.html:653
 #, fuzzy
 msgid "Install (Stable)"
 msgstr "安裝"
 
-#: app/views/menu.html:656
+#: app/views/menu.html:674
 msgid "Install Development version"
 msgstr ""
 
-#: app/scripts/services/tools.js:1118
+#: app/scripts/services/tools.js:1229
 msgid ""
 "Install the <b>STABLE Toolchain</b>. This operation requires Internet "
 "connection <br><p><b>NOTE:</b> You need to disconnect your VPN (if any) to "
 "allow the toolchain installation</p> <p>Do you want to continue?</p>"
 msgstr ""
 
-#: app/scripts/services/tools.js:1144
+#: app/scripts/services/tools.js:1255
 #, fuzzy
 msgid ""
 "Install the DEVELOPMENT toolchain. It will be downloaded. This operation "
 "requires Internet connection. Do you want to continue?"
 msgstr "工具鏈將被更新，這需要連上 Internet , 是否繼續?"
 
-#: app/scripts/services/tools.js:1166
+#: app/scripts/services/tools.js:1277
 #, fuzzy
 msgid ""
 "Install the LATEST STABLE toolchain. It will be downloaded. This operation "
 "requires Internet connection. Do you want to continue?"
 msgstr "工具鏈將被更新，這需要連上 Internet , 是否繼續?"
 
-#: app/scripts/services/tools.js:1496
+#: app/scripts/services/tools.js:1607
 msgid "Installation completed"
 msgstr "安裝完成"
 
-#: app/scripts/services/tools.js:1274
+#: app/scripts/services/tools.js:1385
 #, fuzzy
 msgid "Installing"
 msgstr "安裝"
 
-#: app/scripts/services/drivers.js:421 app/scripts/services/tools.js:1362
+#: app/scripts/services/drivers.js:447 app/scripts/services/tools.js:1473
 msgid "Internet connection required"
 msgstr "需要連接 Internet"
 
-#: app/scripts/services/graph.js:290
+#: app/scripts/services/graph.js:298
 msgid "Invalid <i>Pull up</i> connection:<br>block already connected"
 msgstr "無效的 <i>上拉</i> 連接:<br>區塊已連接"
 
-#: app/scripts/services/graph.js:304
+#: app/scripts/services/graph.js:312
 msgid "Invalid <i>Pull up</i> connection:<br>only <i>Input</i> blocks allowed"
 msgstr "無效的 <i>上拉</i> 連接:<br>只有 <i>輸入</i> 區塊才能被上拉"
 
-#: app/scripts/services/graph.js:296
+#: app/scripts/services/graph.js:304
 msgid "Invalid block connection:<br><i>Pull up</i> already connected"
 msgstr "無效的區塊連接:<br><i>上拉</i> 已經使用"
 
-#: app/scripts/services/tools.js:1673
+#: app/scripts/services/tools.js:1784
 msgid "Invalid collection {{name}}"
 msgstr "無效的選集 {{name}}"
 
-#: app/scripts/services/graph.js:254 app/scripts/services/graph.js:261
-#: app/scripts/services/graph.js:268
+#: app/scripts/services/graph.js:262 app/scripts/services/graph.js:269
+#: app/scripts/services/graph.js:276
 msgid "Invalid connection"
 msgstr "無效的連接"
 
-#: app/scripts/services/graph.js:324
+#: app/scripts/services/graph.js:332
 msgid "Invalid connection: {{a}} → {{b}}"
 msgstr "無效的連接: {{a}} → {{b}}"
 
-#: app/scripts/services/graph.js:284
+#: app/scripts/services/graph.js:292
 msgid "Invalid multiple input connections"
 msgstr "無效的多輸入連接"
 
-#: app/scripts/services/project.js:499 app/scripts/services/project.js:78
+#: app/scripts/services/project.js:510 app/scripts/services/project.js:85
 msgid "Invalid project format"
 msgstr "無效的專案格式"
 
@@ -696,7 +717,7 @@ msgstr "Spanish"
 msgid "Korean"
 msgstr "Korean"
 
-#: app/views/menu.html:310
+#: app/views/menu.html:328
 msgid "Label Finder"
 msgstr ""
 
@@ -705,7 +726,7 @@ msgstr ""
 msgid "Label updated"
 msgstr "區塊已更新"
 
-#: app/views/menu.html:341
+#: app/views/menu.html:359
 msgid "Language"
 msgstr "語言"
 
@@ -713,17 +734,17 @@ msgstr "語言"
 msgid "Light"
 msgstr "淺色模式"
 
-#: app/scripts/services/forms.js:448 app/views/design.html:257
+#: app/scripts/services/forms.js:448 app/views/design.html:255
 #, fuzzy
 msgid "Light Gray"
 msgstr "淺色模式"
 
-#: app/scripts/services/forms.js:430 app/views/design.html:215
+#: app/scripts/services/forms.js:430 app/views/design.html:213
 #, fuzzy
 msgid "Light Sea Green"
 msgstr "淺海藍色"
 
-#: app/scripts/services/project.js:92
+#: app/scripts/services/project.js:98
 msgid "Load"
 msgstr "載入"
 
@@ -731,20 +752,20 @@ msgstr "載入"
 msgid "Local parameter"
 msgstr "本地參數"
 
-#: app/views/menu.html:404
+#: app/views/menu.html:422
 #, fuzzy
 msgid "Logging enabled"
 msgstr "啟用驅動程式"
 
-#: app/views/menu.html:413
+#: app/views/menu.html:431
 msgid "Logging file"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:722
+#: app/scripts/controllers/menu.js:742
 msgid "Logging file updated"
 msgstr ""
 
-#: app/scripts/services/utils.js:960
+#: app/scripts/services/utils.js:955
 msgid "Maximum bus size: 96 bits"
 msgstr "最大的匯流排大小：96位元"
 
@@ -753,11 +774,11 @@ msgstr "最大的匯流排大小：96位元"
 msgid "Medium Violet Red"
 msgstr "中度紫紅色"
 
-#: app/views/design.html:130
+#: app/views/design.html:129
 msgid "MediumVioletRed"
 msgstr "中度紫紅色"
 
-#: app/views/design.html:318 app/views/menu.html:787
+#: app/views/design.html:309 app/views/menu.html:805
 msgid "Memory"
 msgstr "記憶體"
 
@@ -766,7 +787,7 @@ msgstr "記憶體"
 msgid "Memory blocks"
 msgstr "輸入記憶體區塊"
 
-#: app/scripts/services/utils.js:640
+#: app/scripts/services/utils.js:635
 msgid "Name"
 msgstr "名稱"
 
@@ -774,7 +795,7 @@ msgstr "名稱"
 msgid "Name of the paired labels"
 msgstr ""
 
-#: app/scripts/services/forms.js:445 app/views/design.html:250
+#: app/scripts/services/forms.js:445 app/views/design.html:248
 msgid "Navy"
 msgstr "海軍藍色"
 
@@ -788,15 +809,19 @@ msgstr ""
 
 #: app/views/design.html:80
 #, fuzzy
-msgid "New Name:"
+msgid "New Name"
 msgstr "名稱"
 
-#: app/scripts/controllers/menu.js:1436
+#: app/views/design.html:71
+msgid "Next"
+msgstr ""
+
+#: app/scripts/controllers/menu.js:1453
 msgid "No collections stored"
 msgstr "沒有儲存的選集"
 
-#: app/scripts/app.js:58 app/scripts/controllers/menu.js:585
-#: app/scripts/services/project.js:146
+#: app/scripts/app.js:57 app/scripts/controllers/menu.js:601
+#: app/scripts/services/project.js:157
 msgid "OK"
 msgstr "確定"
 
@@ -805,7 +830,7 @@ msgstr "確定"
 msgid "Olive Drab"
 msgstr "橄欖綠色"
 
-#: app/views/design.html:208
+#: app/views/design.html:206
 msgid "OliveDrab"
 msgstr "橄欖綠色"
 
@@ -813,7 +838,7 @@ msgstr "橄欖綠色"
 msgid "Open"
 msgstr "開啟"
 
-#: app/scripts/services/utils.js:697
+#: app/scripts/services/utils.js:692
 msgid "Open SVG"
 msgstr "開啟 SVG"
 
@@ -822,19 +847,19 @@ msgstr "開啟 SVG"
 msgid "Orange Red"
 msgstr "橘紅色"
 
-#: app/views/design.html:144
+#: app/views/design.html:143
 msgid "OrangeRed"
 msgstr "橘紅色"
 
-#: app/scripts/services/project.js:544
+#: app/scripts/services/project.js:555
 msgid "Original file {{file}} does not exist"
 msgstr "原始檔案 {{file}} 不存在"
 
-#: app/views/design.html:288 app/views/menu.html:764
+#: app/views/design.html:284 app/views/menu.html:782
 msgid "Output"
 msgstr "輸出"
 
-#: app/views/design.html:300 app/views/menu.html:773
+#: app/views/design.html:294 app/views/menu.html:791
 msgid "Output label"
 msgstr "輸出標籤"
 
@@ -853,7 +878,7 @@ msgstr "輸出標籤"
 msgid "Output ports"
 msgstr "輸出標籤"
 
-#: app/views/design.html:306 app/views/menu.html:778
+#: app/views/design.html:299 app/views/menu.html:796
 msgid "Paired labels"
 msgstr ""
 
@@ -861,40 +886,44 @@ msgstr ""
 msgid "Paste"
 msgstr "貼上"
 
-#: app/scripts/controllers/menu.js:731 app/scripts/controllers/menu.js:788
-#: app/scripts/controllers/menu.js:853 app/scripts/controllers/menu.js:917
+#: app/scripts/controllers/menu.js:751 app/scripts/controllers/menu.js:808
+#: app/scripts/controllers/menu.js:873 app/scripts/controllers/menu.js:937
 msgid "Path {{path}} does not exist"
 msgstr "路徑 {{path}} 不存在"
 
-#: app/scripts/services/utils.js:1142
+#: app/scripts/services/utils.js:1137
 msgid "Please run: {{cmd}}"
 msgstr "請執行: {{cmd}}"
 
-#: app/views/menu.html:334
+#: app/views/menu.html:352
 msgid "Preferences"
 msgstr "偏好設定"
 
-#: app/views/menu.html:422
+#: app/views/design.html:68
+msgid "Prev."
+msgstr ""
+
+#: app/views/menu.html:440
 msgid "Project information"
 msgstr "專案資訊"
 
-#: app/scripts/controllers/menu.js:935 app/scripts/controllers/menu.js:961
+#: app/scripts/controllers/menu.js:955 app/scripts/controllers/menu.js:981
 msgid "Project information updated"
 msgstr "專案資訊已更新"
 
-#: app/scripts/services/project.js:132
+#: app/scripts/services/project.js:143
 msgid "Project {{name}} loaded"
 msgstr "專案 {{name}} 已載入"
 
-#: app/scripts/services/project.js:405
+#: app/scripts/services/project.js:416
 msgid "Project {{name}} saved"
 msgstr "專案 {{name}} 已儲存"
 
-#: app/scripts/controllers/menu.js:845
+#: app/scripts/controllers/menu.js:865
 msgid "Python Environment updated"
 msgstr "Python 環境已更新"
 
-#: app/views/menu.html:389
+#: app/views/menu.html:407
 msgid "Python environment"
 msgstr "Python 環境"
 
@@ -902,11 +931,7 @@ msgstr "Python 環境"
 msgid "Quit"
 msgstr "結束程式"
 
-#: app/views/design.html:19
-msgid "Read only"
-msgstr "唯讀"
-
-#: app/scripts/services/forms.js:391 app/views/design.html:116
+#: app/scripts/services/forms.js:391 app/views/design.html:115
 msgid "Red"
 msgstr "紅色"
 
@@ -918,27 +943,27 @@ msgstr "重做"
 msgid "Release History WIKI"
 msgstr ""
 
-#: app/views/menu.html:715
+#: app/views/menu.html:733
 msgid "Reload"
 msgstr "重載"
 
-#: app/scripts/services/tools.js:869
+#: app/scripts/services/tools.js:980
 msgid "Remote host {{name}} not connected"
 msgstr "遠端主機 {{name}} 未連接"
 
-#: app/views/menu.html:395
+#: app/views/menu.html:413
 msgid "Remote hostname"
 msgstr "遠端主機名"
 
-#: app/views/menu.html:647 app/views/menu.html:722
+#: app/views/menu.html:665 app/views/menu.html:740
 msgid "Remove"
 msgstr "移除"
 
-#: app/views/menu.html:738
+#: app/views/menu.html:756
 msgid "Remove all"
 msgstr "全部移除"
 
-#: app/views/design.html:267
+#: app/views/design.html:265
 msgid "Replace All"
 msgstr ""
 
@@ -946,11 +971,11 @@ msgstr ""
 msgid "Replace One"
 msgstr ""
 
-#: app/scripts/services/utils.js:699
+#: app/scripts/services/utils.js:694
 msgid "Reset SVG"
 msgstr "重載SVG"
 
-#: app/scripts/services/forms.js:442 app/views/design.html:243
+#: app/scripts/services/forms.js:442 app/views/design.html:241
 #, fuzzy
 msgid "Royal Blue"
 msgstr "皇家藍色"
@@ -963,7 +988,7 @@ msgstr "Russian"
 msgid "Save"
 msgstr "儲存"
 
-#: app/scripts/services/utils.js:698
+#: app/scripts/services/utils.js:693
 msgid "Save SVG"
 msgstr "儲存SVG"
 
@@ -975,11 +1000,11 @@ msgstr "另存為"
 msgid "Save submodule"
 msgstr "儲存子模組"
 
-#: app/views/menu.html:502
+#: app/views/menu.html:520
 msgid "Select"
 msgstr "選擇"
 
-#: app/views/menu.html:287
+#: app/views/menu.html:305
 msgid "Select all"
 msgstr "全選"
 
@@ -996,11 +1021,11 @@ msgstr "顯示時脈"
 msgid "Slate Blue"
 msgstr "板藍色"
 
-#: app/views/design.html:180
+#: app/views/design.html:178
 msgid "SlateBlue"
 msgstr "板藍色"
 
-#: app/views/menu.html:853
+#: app/views/menu.html:871
 msgid "Source code"
 msgstr "原始程式"
 
@@ -1013,32 +1038,32 @@ msgstr "Spanish"
 msgid "Spring Green"
 msgstr "春天綠色"
 
-#: app/views/design.html:194
+#: app/views/design.html:192
 msgid "SpringGreen"
 msgstr "春天綠色"
 
-#: app/scripts/controllers/menu.js:1336
+#: app/scripts/controllers/menu.js:1355
 msgid "Start build"
 msgstr "開始編譯"
 
-#: app/scripts/controllers/menu.js:1364
+#: app/scripts/controllers/menu.js:1381
 msgid "Start upload"
 msgstr "開始上傳"
 
-#: app/scripts/controllers/menu.js:1312
+#: app/scripts/controllers/menu.js:1332
 msgid "Start verification"
 msgstr "開始驗證"
 
-#: app/scripts/services/forms.js:436 app/views/design.html:229
+#: app/scripts/services/forms.js:436 app/views/design.html:227
 #, fuzzy
 msgid "Steel Blue"
 msgstr "鋼鐵藍色"
 
-#: app/scripts/services/tools.js:445
+#: app/scripts/services/tools.js:554
 msgid "Synchronize remote files ..."
 msgstr "遠端檔案同步..."
 
-#: app/views/menu.html:477
+#: app/views/menu.html:495
 msgid "System Info"
 msgstr ""
 
@@ -1055,35 +1080,35 @@ msgstr "測試平台"
 msgid "Thank you very much!"
 msgstr ". 非常感謝"
 
-#: app/scripts/services/tools.js:1622
+#: app/scripts/services/tools.js:1733
 msgid "The collection {{name}} already exists."
 msgstr "選集 {{name}} 已存在."
 
-#: app/scripts/controllers/menu.js:1284
+#: app/scripts/controllers/menu.js:1304
 msgid ""
 "The current FPGA I/O configuration will be lost. Do you want to change to "
 "{{name}} board?"
 msgstr "目前 FPGA 的 I/O 設定將丟失. 您是否確定換用 {{name}} 開發板?"
 
-#: app/scripts/services/tools.js:1184
+#: app/scripts/services/tools.js:1295
 msgid "The toolchain will be removed. Do you want to continue?"
 msgstr "工具鏈將會移除，是否繼續?"
 
-#: app/scripts/services/tools.js:1842
+#: app/scripts/services/tools.js:1953
 msgid "There is a new nightly version available"
 msgstr "有新的測試版了"
 
-#: app/scripts/services/tools.js:1834
+#: app/scripts/services/tools.js:1945
 msgid "There is a new stable version available"
 msgstr "有新的穩定版本了"
 
-#: app/scripts/services/project.js:468
+#: app/scripts/services/project.js:479
 msgid ""
 "This import operation requires a project path. You need to save the current "
 "project. Do you want to continue?"
 msgstr "這導入操作需要專案路徑，您必須保存目前專案，是否繼續?"
 
-#: app/scripts/services/project.js:96
+#: app/scripts/services/project.js:102
 msgid "This project is designed for the {{name}} board."
 msgstr "此專案為開發板 {{name}} 所設計."
 
@@ -1093,53 +1118,53 @@ msgid ""
 "              done by an emerging team from"
 msgstr ""
 
-#: app/scripts/services/graph.js:521
+#: app/scripts/services/graph.js:532
 msgid ""
 "To enter on \"edit mode\" of deeper block, you need to finish current \"edit "
 "mode\", lock the keylock to do it."
 msgstr "要進入深層區塊的編輯模式，您必須先結束現在的編輯模式，鎖住鎖頭即可。"
 
-#: app/scripts/controllers/design.js:51
+#: app/scripts/controllers/design.js:50
 msgid "To navigate through design, you need to close \"edit mode\"."
 msgstr "要在設計中遊走瀏覽，您需要先關閉編輯模式。"
 
 #: app/scripts/controllers/menu.js:349
 #, fuzzy
 msgid ""
-"To save your design you need to lock the keylock and               go to top "
+"To save your design you need to lock the padlock and               go to top "
 "level design.<br/><br/>If you want to export               this submodule to "
 "a file, execute \"Save as\" command to do it."
 msgstr ""
 "要鎖住並回到最上層才能儲存您的設計。<br/><br/>若您要輸出子模組到檔案，請用"
 "Save as另存為功能。"
 
-#: app/views/menu.html:320
+#: app/views/menu.html:338
 #, fuzzy
 msgid "Toolbox"
 msgstr "工具"
 
-#: app/views/menu.html:627
+#: app/views/menu.html:645
 msgid "Toolchain"
 msgstr "工具鏈"
 
-#: app/scripts/services/tools.js:1506
+#: app/scripts/services/tools.js:1617
 msgid "Toolchain installed"
 msgstr "工具鏈已安裝"
 
-#: app/scripts/services/drivers.js:594 app/scripts/services/drivers.js:613
-#: app/scripts/services/tools.js:191 app/scripts/services/tools.js:371
+#: app/scripts/services/drivers.js:625 app/scripts/services/drivers.js:644
+#: app/scripts/services/tools.js:300 app/scripts/services/tools.js:480
 msgid "Toolchain not installed"
 msgstr "工具鏈未安裝"
 
-#: app/scripts/services/tools.js:1202
+#: app/scripts/services/tools.js:1313
 msgid "Toolchain removed"
 msgstr "工具鏈移除了"
 
-#: app/scripts/services/tools.js:414
+#: app/scripts/services/tools.js:523
 msgid "Toolchain version does not match"
 msgstr "工具鏈版本不符合"
 
-#: app/views/menu.html:592
+#: app/views/menu.html:610
 msgid "Tools"
 msgstr "工具"
 
@@ -1147,11 +1172,11 @@ msgstr "工具"
 msgid "Turkish"
 msgstr ""
 
-#: app/scripts/services/forms.js:433 app/views/design.html:222
+#: app/scripts/services/forms.js:433 app/views/design.html:220
 msgid "Turquoise"
 msgstr "綠松色"
 
-#: app/views/menu.html:354
+#: app/views/menu.html:372
 msgid "UI theme"
 msgstr "介面主題風格"
 
@@ -1159,57 +1184,57 @@ msgstr "介面主題風格"
 msgid "Undo"
 msgstr "還原"
 
-#: app/scripts/services/tools.js:615
+#: app/scripts/services/tools.js:726
 msgid "Unknown board"
 msgstr "未知的開發板"
 
-#: app/scripts/services/project.js:170
+#: app/scripts/services/project.js:181
 msgid "Unsupported project format {{version}}"
 msgstr "不支援的專案格式  {{version}}"
 
-#: app/scripts/app.js:207
+#: app/scripts/app.js:209
 msgid "Untitled"
 msgstr "未命名"
 
-#: app/views/menu.html:639
+#: app/views/menu.html:657
 #, fuzzy
 msgid "Update (Latest stable)"
 msgstr "更新區塊名稱"
 
-#: app/scripts/controllers/menu.js:1354 app/views/design.html:526
-#: app/views/menu.html:615
+#: app/scripts/controllers/menu.js:1371 app/views/design.html:514
+#: app/views/menu.html:633
 msgid "Upload"
 msgstr "上傳"
 
-#: app/scripts/controllers/menu.js:1365
+#: app/scripts/controllers/menu.js:1382
 msgid "Upload done"
 msgstr "上傳完成"
 
-#: app/scripts/controllers/menu.js:1313
+#: app/scripts/controllers/menu.js:1333
 msgid "Verification done"
 msgstr "驗證完成"
 
-#: app/views/design.html:510 app/views/menu.html:599
+#: app/views/design.html:498 app/views/menu.html:617
 msgid "Verify"
 msgstr "驗證"
 
-#: app/scripts/services/utils.js:641 app/views/menu.html:832
+#: app/scripts/services/utils.js:636 app/views/menu.html:850
 msgid "Version"
 msgstr "版本"
 
-#: app/views/menu.html:826
+#: app/views/menu.html:844
 msgid "Version notes"
 msgstr "版本通知"
 
-#: app/views/menu.html:434
+#: app/views/menu.html:452
 msgid "View"
 msgstr "查看"
 
-#: app/views/menu.html:819
+#: app/views/menu.html:837
 msgid "View license"
 msgstr "查看版權說明"
 
-#: app/scripts/services/tools.js:806
+#: app/scripts/services/tools.js:917
 msgid "Warnings detected in the design"
 msgstr "設計中發現警告"
 
@@ -1228,58 +1253,67 @@ msgstr "區塊格式錯誤: {{type}}"
 msgid "Wrong block name {{name}}"
 msgstr "區塊名稱錯誤 {{name}}"
 
-#: app/scripts/controllers/menu.js:1907
+#: app/scripts/controllers/menu.js:1925
 #, fuzzy
 msgid "Wrong new name!"
 msgstr "埠名稱錯誤 {{name}}"
 
-#: app/scripts/services/project.js:143
+#: app/scripts/services/project.js:154
 msgid "Wrong project format: {{name}}"
 msgstr "專案格式錯誤: {{name}}"
 
-#: app/scripts/services/tools.js:862
+#: app/scripts/services/tools.js:973
 msgid "Wrong remote hostname {{name}}"
 msgstr "遠端主機名稱錯誤 {{name}}"
 
-#: app/scripts/controllers/menu.js:1811
+#: app/scripts/controllers/menu.js:1829
 msgid "Wrong search name!"
 msgstr ""
 
-#: app/scripts/services/forms.js:412 app/views/design.html:166
+#: app/scripts/services/forms.js:412 app/views/design.html:164
 msgid "Yellow"
 msgstr "黃色"
 
-#: app/scripts/controllers/menu.js:394
+#: app/scripts/controllers/menu.js:409
 #, fuzzy
 msgid ""
-"You are editing a submodule, if you save it, you save only               the "
-"submodule (in this situation \"save as\" works like               \"export "
-"module\"), Do you like to continue?"
+"You are editing a submodule, if you save it, you'll save only               "
+"the submodule (in this situation \"save as\" works like               "
+"\"export module\"). Do you want to continue?"
 msgstr ""
 "您正在編輯子模組，如果您儲存它，只有子模組會儲存，用「另存為」可以導出模組，"
 "請問還要繼續嗎？"
 
-#: app/scripts/services/project.js:97
+#: app/scripts/controllers/menu.js:396
+msgid ""
+"You are navigating into the design, if you want to save the entire design, "
+"you need to back                       to the top level. If you want to "
+"export this module as new file, unlock the module and \"save as\""
+msgstr ""
+
+#: app/scripts/services/project.js:103
 msgid "You can load it as it is or convert it for the {{name}} board."
 msgstr "您可以載入原始專案，或轉換成適合開發板 {{name}} ."
 
-#: app/scripts/controllers/menu.js:1328
+#: app/scripts/controllers/menu.js:1347
+#, fuzzy
 msgid ""
-"You can only build at top-level design. Inside submodules you only can "
+"You can only build at the top-level design. Inside submodules, you can only "
 "<strong>Verify</strong>"
 msgstr "您可以只建構最上層的設計，子模組內只要 <strong>驗證。</strong>"
 
-#: app/scripts/controllers/menu.js:1355
+#: app/scripts/controllers/menu.js:1372
+#, fuzzy
 msgid ""
-"You can only upload  your design at top-level design. Inside submodules you "
-"only can <strong>Verify</strong>"
-msgstr "您可以只要上傳最上層的設計，子模組內只要 <strong>驗證。</strong>"
+"You can only upload at the top-level design. Inside submodules, you can only "
+"<strong>Verify</strong>"
+msgstr "您可以只建構最上層的設計，子模組內只要 <strong>驗證。</strong>"
 
 #: app/views/version.html:23
 msgid "You can read the release notes on the"
 msgstr ""
 
-#: app/scripts/controllers/menu.js:574
+#: app/scripts/controllers/menu.js:590
 msgid "Your changes will be lost if you don’t save them"
 msgstr "如果不儲存，更改內容將消失"
 
@@ -1287,25 +1321,33 @@ msgstr "如果不儲存，更改內容將消失"
 msgid "back"
 msgstr "後退"
 
-#: app/scripts/services/drivers.js:412 app/scripts/services/utils.js:1122
+#: app/scripts/services/drivers.js:439 app/scripts/services/utils.js:1117
 msgid "{{app}} is required."
 msgstr "需要{{app}}"
 
-#: app/scripts/controllers/menu.js:1099
+#: app/scripts/controllers/menu.js:1119
 msgid "{{board}} datasheet not defined"
 msgstr "{{board}} 數據表未定義"
 
-#: app/scripts/controllers/menu.js:1085
+#: app/scripts/controllers/menu.js:1105
 msgid "{{board}} pinout not defined"
 msgstr "{{board}} 接腳未定義"
 
-#: app/scripts/controllers/menu.js:1125
+#: app/scripts/controllers/menu.js:1145
 msgid "{{board}} rules not defined"
 msgstr "{{board}} 規則未定義"
 
-#: app/scripts/controllers/menu.js:483 app/scripts/controllers/menu.js:516
+#: app/scripts/controllers/menu.js:499 app/scripts/controllers/menu.js:532
 msgid "{{name}} exported"
 msgstr "{{name}} 已導出"
+
+#~ msgid "Read only"
+#~ msgstr "唯讀"
+
+#~ msgid ""
+#~ "You can only upload  your design at top-level design. Inside submodules "
+#~ "you only can <strong>Verify</strong>"
+#~ msgstr "您可以只要上傳最上層的設計，子模組內只要 <strong>驗證。</strong>"
 
 #~ msgid "Choose a color"
 #~ msgstr "選擇顏色"

--- a/app/views/design.html
+++ b/app/views/design.html
@@ -9,35 +9,35 @@
 
     <div class="info">
       &nbsp;{{ information.name }}&nbsp;
-      {{ information.version ? '-&nbsp;v' + information.version + '&nbsp;' 
+      {{ information.version ? '-&nbsp;v' + information.version + '&nbsp;'
                              : '' }}
     </div>
 
     <div class="read-only">
         <div class="leftColumn"></div>
-        <div class="rightColumn">
-            <b>{{'Read only' | translate }}</b> 
-            {{': '}} {{'Unlock to edit block !' | translate }}
-        </div>   
+        <div class="rightColumn" translate>
+            <b>Read only</b><br>
+            Unlock to edit the block!
+        </div>
     </div>
 
     <a class="back-button" ng-click="breadcrumbsBack()">
-       &larr;&nbsp;{{'back' | translate }}&nbsp;
+       &larr;&nbsp;{{'back' | translate}}&nbsp;
     </a>
   </div>
-  
+
   <div class="banner-submodule hidden">
     <a class="edit-button" ng-click="editModeToggle($event)">
-      <img src="resources/images/lock.png" 
-            data-lock="resources/images/lock.png" 
+      <img src="resources/images/lock.png"
+            data-lock="resources/images/lock.png"
             data-unlock="resources/images/unlock.png">
-      <span class="tooltiptext">
-          {{'CAUTION ! : Changes will also be applied in all the copied'
-            | translate }}
-        <b>{{ information.name }}</b>
-            {{'blocks of the current .ice design. If you do not want ' + 
-              'a propagation of a change, make it inside a cloned block ' + 
-              '(instead of copied one)' | translate }} &nbsp;
+      <span class="tooltiptext" translate>
+        <b>WARNING!</b><br>
+        The changes made here, will also be applied to all the
+        [<b>{{ information.name }}</b>] blocks in the current design. If
+        you DO NOT want them to propagate, create a cloned block instead
+        using<br>
+        <b>Edit → Clone</b>.
       </span>
     </a>
   </div>
@@ -62,209 +62,207 @@
     </input>
 
     <!-- Find button -->
-    <div class="lFinder-find">{{'Find'| translate}}</div>
+    <div class="lFinder-find" translate>Find</div>
 
     <!-- Previous button -->
-    <div class="lFinder-prev">Prev</div>
+    <div class="lFinder-prev" translate>Prev.</div>
 
     <!-- Next button -->
-    <div class="lFinder-next">Next</div>
-    
+    <div class="lFinder-next" translate>Next</div>
+
     <!-- Close button -->
     <div class="lFinder-close"></div>
-    
+
     <!-- Advanced menu -->
     <div class="lFinder-advanced">
 
       <!-- New name text entry -->
-      <span class="lFinder-name">{{'New Name:'| translate}}</span>
+      <span class="lFinder-name" translate>New Name</span>
       <input class="lFinder-name--field"></input>
 
       <!-- Replace one button -->
-      <div class="lFinder-replace--name">{{'Replace One'| translate}}</div>
+      <div class="lFinder-replace--name" translate>Replace One</div>
 
       <!-- New color Selector -->
-      <span class="lFinder-color">{{'New Color:'| translate}}</span>
+      <span class="lFinder-color" translate>New Color:</span>
 
       <!-- Color selector menu -->
       <div class="lFinder-color--dropdown">
 
         <!-- Default color option -->
         <div class="lf-dropdown-title">
-          <span class="lf-selected-color color-fuchsia" 
-                data-color="fuchsia" 
-                data-name="Fuchsia">
-          </span>
-          {{'Fuchsia' | translate }}
+          <span class="lf-selected-color color-fuchsia"
+            data-color="fuchsia"
+            data-name="Fuchsia"></span>
+          {{'Fuchsia' | translate}}
           <span class="lf-dropdown-icon"></span>
         </div>
 
         <!-- Available colors -->
         <div class="lf-dropdown-menu">
 
-          <div class="lf-dropdown-option" 
-            data-color="indianred" 
+          <div class="lf-dropdown-option"
+            data-color="indianred"
             data-name="Indian Red">
             <span class="lf-option-color color-indianred"></span>
-            {{'Indian Red' | translate }}
+            {{'Indian Red' | translate}}
           </div>
 
-          <div class="lf-dropdown-option" 
-            data-color="red" 
+          <div class="lf-dropdown-option"
+            data-color="red"
             data-name="Red">
             <span class="lf-option-color color-red"></span>
-            {{'Red' | translate }} 
+            {{'Red' | translate}}
           </div>
 
-          <div class="lf-dropdown-option" 
-            data-color="deeppink" 
+          <div class="lf-dropdown-option"
+            data-color="deeppink"
             data-name="Deep Pink">
             <span class="lf-option-color color-deeppink"></span>
-            {{'Deep Pink' | translate }} 
+            {{'Deep Pink' | translate}}
           </div>
 
-          <div class="lf-dropdown-option" 
+          <div class="lf-dropdown-option"
             data-color="mediumvioletred"
             data-name="MediumVioletRed">
             <span class="lf-option-color color-mediumvioletred"></span>
             {{'MediumVioletRed' | translate}}
           </div>
 
-          <div class="lf-dropdown-option" 
+          <div class="lf-dropdown-option"
             data-color="coral"
             data-name="Coral">
             <span class="lf-option-color color-coral"></span>
-            {{'Coral' | translate }}
-          </div>
-
-          <div class="lf-dropdown-option" 
-            data-color="orangered"
-            data-name="OrangeRed">
-            <span class="lf-option-color color-orangered"></span>
-            {{'OrangeRed' | translate }}
-          </div>
-
-          <div class="lf-dropdown-option" 
-            data-color="darkorange"
-            data-name="DarkOrange">
-            <span class="lf-option-color color-darkorange"></span>
-            {{'DarkOrange' | translate }}
-          </div>
-
-          <div class="lf-dropdown-option" 
-               data-color="gold"
-               data-name="Gold">
-               <span class="lf-option-color color-gold"></span>
-               {{'Gold' | translate }}
-          </div>
-
-          <div class="lf-dropdown-option" 
-               data-color="yellow"
-               data-name="Yellow">
-               <span class="lf-option-color color-yellow">
-               </span>
-               {{ 'Yellow' | translate }}
-          </div>
-
-          <div class="lf-dropdown-option" 
-               data-color="fuchsia"
-               data-name="Fuchsia">
-               <span class="lf-option-color color-fuchsia"></span>
-               {{'Fuchsia' | translate }}
-          </div>
-
-          <div class="lf-dropdown-option" 
-               data-color="slateblue"
-               data-name="SlateBlue">
-               <span class="lf-option-color color-slateblue"></span>
-               {{'SlateBlue' | translate }}
-          </div>
-
-          <div class="lf-dropdown-option" 
-               data-color="greenyellow"
-               data-name="GreenYellow">
-               <span class="lf-option-color color-greenyellow"></span>
-               {{ 'GreenYellow' | translate }}
+            {{'Coral' | translate}}
           </div>
 
           <div class="lf-dropdown-option"
-               data-color="springgreen"
-               data-name="SpringGreen">
-               <span class="lf-option-color color-springgreen"></span>
-               {{ 'SpringGreen' | translate }}
+            data-color="orangered"
+            data-name="OrangeRed">
+            <span class="lf-option-color color-orangered"></span>
+            {{'OrangeRed' | translate}}
           </div>
 
-          <div class="lf-dropdown-option" 
-               data-color="darkgreen"
-               data-name="DarkGreen">
-               <span class="lf-option-color color-darkgreen"></span>
-               {{'DarkGreen' | translate }}
+          <div class="lf-dropdown-option"
+            data-color="darkorange"
+            data-name="DarkOrange">
+            <span class="lf-option-color color-darkorange"></span>
+            {{'DarkOrange' | translate}}
           </div>
 
-          <div class="lf-dropdown-option" 
-               data-color="olivedrab"
-               data-name="OliveDrab">
-               <span class="lf-option-color color-olivedrab"></span>
-               {{'OliveDrab' | translate }}
+          <div class="lf-dropdown-option"
+            data-color="gold"
+            data-name="Gold">
+            <span class="lf-option-color color-gold"></span>
+            {{'Gold' | translate}}
           </div>
 
-          <div class="lf-dropdown-option" 
-               data-color="lightseagreen"
-               data-name="LightSeaGreen">
-               <span class="lf-option-color color-lightseagreen"></span>
-               {{'Light Sea Green' | translate }}
+          <div class="lf-dropdown-option"
+            data-color="yellow"
+            data-name="Yellow">
+            <span class="lf-option-color color-yellow"></span>
+            {{'Yellow' | translate}}
           </div>
 
-          <div class="lf-dropdown-option" 
-               data-color="turquoise"
-               data-name="Turquoise">
-               <span class="lf-option-color color-turquoise"></span>
-               {{ 'Turquoise' | translate }}
+          <div class="lf-dropdown-option"
+            data-color="fuchsia"
+            data-name="Fuchsia">
+            <span class="lf-option-color color-fuchsia"></span>
+            {{'Fuchsia' | translate}}
           </div>
 
-          <div class="lf-dropdown-option" 
-               data-color="steelblue"
-               data-name="SteelBlue">
-               <span class="lf-option-color color-steelblue"></span>
-               {{ 'Steel Blue' | translate }}
+          <div class="lf-dropdown-option"
+            data-color="slateblue"
+            data-name="SlateBlue">
+            <span class="lf-option-color color-slateblue"></span>
+            {{'SlateBlue' | translate}}
           </div>
 
-          <div class="lf-dropdown-option" 
-               data-color="deepskyblue"
-               data-name="DeepSkyBlue">
-               <span class="lf-option-color color-deepskyblue"></span>
-               {{ 'Deep Sky Blue' | translate }}
+          <div class="lf-dropdown-option"
+            data-color="greenyellow"
+            data-name="GreenYellow">
+            <span class="lf-option-color color-greenyellow"></span>
+            {{'GreenYellow' | translate}}
           </div>
 
-          <div class="lf-dropdown-option" 
-               data-color="royalblue"
-               data-name="RoyalBlue">
-               <span class="lf-option-color color-royalblue"></span>
-               {{ 'Royal Blue' | translate }}
+          <div class="lf-dropdown-option"
+            data-color="springgreen"
+            data-name="SpringGreen">
+            <span class="lf-option-color color-springgreen"></span>
+            {{'SpringGreen' | translate}}
           </div>
 
-          <div class="lf-dropdown-option" 
-               data-color="navy"
-              data-name="Navy">
-              <span class="lf-option-color color-navy"></span>
-              {{ 'Navy' | translate }}
+          <div class="lf-dropdown-option"
+            data-color="darkgreen"
+            data-name="DarkGreen">
+            <span class="lf-option-color color-darkgreen"></span>
+            {{'DarkGreen' | translate}}
           </div>
 
-          <div class="lf-dropdown-option" 
-               data-color="lightgray"
-               data-name="LightGray">
-               <span class="lf-option-color color-lightgray"></span>
-               {{ 'Light Gray' | translate }}
+          <div class="lf-dropdown-option"
+            data-color="olivedrab"
+            data-name="OliveDrab">
+            <span class="lf-option-color color-olivedrab"></span>
+            {{'OliveDrab' | translate}}
+          </div>
+
+          <div class="lf-dropdown-option"
+            data-color="lightseagreen"
+            data-name="LightSeaGreen">
+            <span class="lf-option-color color-lightseagreen"></span>
+            {{'Light Sea Green' | translate}}
+          </div>
+
+          <div class="lf-dropdown-option"
+            data-color="turquoise"
+            data-name="Turquoise">
+            <span class="lf-option-color color-turquoise"></span>
+            {{ 'Turquoise' | translate}}
+          </div>
+
+          <div class="lf-dropdown-option"
+            data-color="steelblue"
+            data-name="SteelBlue">
+            <span class="lf-option-color color-steelblue"></span>
+            {{'Steel Blue' | translate}}
+          </div>
+
+          <div class="lf-dropdown-option"
+            data-color="deepskyblue"
+            data-name="DeepSkyBlue">
+            <span class="lf-option-color color-deepskyblue"></span>
+            {{'Deep Sky Blue' | translate}}
+          </div>
+
+          <div class="lf-dropdown-option"
+            data-color="royalblue"
+            data-name="RoyalBlue">
+            <span class="lf-option-color color-royalblue"></span>
+            {{'Royal Blue' | translate}}
+          </div>
+
+          <div class="lf-dropdown-option"
+            data-color="navy"
+            data-name="Navy">
+            <span class="lf-option-color color-navy"></span>
+            {{'Navy' | translate}}
+          </div>
+
+          <div class="lf-dropdown-option"
+            data-color="lightgray"
+            data-name="LightGray">
+            <span class="lf-option-color color-lightgray"></span>
+            {{'Light Gray' | translate}}
           </div>
 
         </div>
       </div>
 
       <!-- Color change button -->
-      <div class="lFinder-change--color">{{'Change Color'| translate}}</div>
+      <div class="lFinder-change--color" translate>Change Color</div>
 
       <!-- Replace all button -->
-      <div class="lFinder-replace--all">{{'Replace All'| translate}}</div>
+      <div class="lFinder-replace--all" translate>Replace All</div>
     </div>
   </div>
 
@@ -276,58 +274,49 @@
     <div class="title-bar">Basic Toolbox</div>
     <div class="closeToolbox-button"></div>
       <li>
-        <a href="" class="iceToolbox--item js-shortcut--action" 
-           data-item="input">
-           <div class="marker marker-blue"></div>
-           {{ 'Input' | translate }}
+        <a href="" class="iceToolbox--item js-shortcut--action" data-item="input">
+          <div class="marker marker-blue"></div>
+          {{'Input' | translate}}
         </a>
 
-        <a href="" class="iceToolbox--item js-shortcut--action" 
-           data-item="output">
-           <div class="marker marker-blue"></div>
-           {{ 'Output' | translate }}
+        <a href="" class="iceToolbox--item js-shortcut--action" data-item="output">
+          <div class="marker marker-blue"></div>
+          {{'Output' | translate}}
         </a>
 
-        <a href="" class="iceToolbox--item js-shortcut--action" 
-           data-item="labelInput">
-           <div class="marker marker-fuchsia"></div>
-           {{ 'Input label' | translate }}
+        <a href="" class="iceToolbox--item js-shortcut--action" data-item="labelInput">
+          <div class="marker marker-fuchsia"></div>
+          {{'Input label' | translate}}
         </a>
 
-        <a href="" class="iceToolbox--item js-shortcut--action" 
-           data-item="labelOutput">
-           <div class="marker marker-fuchsia"></div>
-           {{ 'Output label' | translate }}
+        <a href="" class="iceToolbox--item js-shortcut--action" data-item="labelOutput">
+          <div class="marker marker-fuchsia"></div>
+          {{'Output label' | translate}}
         </a>
 
-        <a href="" class="iceToolbox--item js-shortcut--action" 
-           data-item="labelPaired">
-           <div class="marker marker-fuchsia"></div>
-           {{ 'Paired labels' | translate }}
+        <a href="" class="iceToolbox--item js-shortcut--action" data-item="labelPaired">
+          <div class="marker marker-fuchsia"></div>
+          {{'Paired labels' | translate}}
         </a>
 
-        <a href="" class="iceToolbox--item js-shortcut--action" 
-           data-item="constant">
-           <div class="marker marker-orange"></div>
-           {{ 'Constant' | translate }}
+        <a href="" class="iceToolbox--item js-shortcut--action" data-item="constant">
+          <div class="marker marker-orange"></div>
+           {{'Constant' | translate}}
         </a>
 
-        <a href="" class="iceToolbox--item js-shortcut--action" 
-           data-item="memory">
-           <div class="marker marker-orange"></div>
-           {{ 'Memory' | translate }}
+        <a href="" class="iceToolbox--item js-shortcut--action" data-item="memory">
+          <div class="marker marker-orange"></div>
+          {{'Memory' | translate}}
         </a
         >
-        <a href="" class="iceToolbox--item js-shortcut--action" 
-           data-item="code">
-           <div class="marker marker-blue"></div>
-           {{ 'Code' | translate }}
+        <a href="" class="iceToolbox--item js-shortcut--action" data-item="code">
+          <div class="marker marker-blue"></div>
+          {{'Code' | translate}}
         </a>
 
-        <a href="" class="iceToolbox--item js-shortcut--action"
-           data-item="information">
-           <div class="marker marker-gray"></div>
-           {{ 'Information' | translate }}
+        <a href="" class="iceToolbox--item js-shortcut--action" data-item="information">
+          <div class="marker marker-gray"></div>
+          {{'Information' | translate}}
         </a>
       </li>
     </ul>
@@ -348,13 +337,12 @@
 
       <!-- Show the design name and the path to the current sub-block -->
       <ol class="breadcrumb">
-        <li ng-repeat="item in graph.breadcrumbs" 
-            ng-class="{active: $last}" 
+        <li ng-repeat="item in graph.breadcrumbs"
+            ng-class="{active: $last}"
             ng-switch="$last">
-            <span ng-switch-when="true">{{ item.name }}</span>
-            <a href ng-click="breadcrumbsNavitate(item)" 
-                    ng-switch-default>{{ item.name }}
-            </a>
+          <span ng-switch-when="true">{{ item.name }}</span>
+          <a href ng-click="breadcrumbsNavitate(item)"
+                    ng-switch-default>{{ item.name }}</a>
         </li>
       </ol>
     </div>
@@ -363,139 +351,139 @@
     <div class="board-container">
 
       <!-- FPGA resources Information -->
-      <div class="fpga-resources" 
-           ng-show="common.selectedBoard && 
+      <div class="fpga-resources"
+           ng-show="common.selectedBoard &&
                     topModule && profile.data.showFPGAResources">
         <div>
-          <!-- 3 next fields with percentage precision higher than 
+          <!-- 3 next fields with percentage precision higher than
                the nextpnr one -->
           <span>
             {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr)
-               ? ('-') 
-               : (common.FPGAResources.nextpnr.Field0.name + ' : ' + 
+               ? ('-')
+               : (common.FPGAResources.nextpnr.Field0.name + ' : ' +
                   common.FPGAResources.nextpnr.Field0.used + ' / ' +
-                  common.FPGAResources.nextpnr.Field0.total +' ( ' + 
+                  common.FPGAResources.nextpnr.Field0.total +' ( ' +
                   (common.FPGAResources.nextpnr.Field0.used /
                    common.FPGAResources.nextpnr.Field0.total*100).toFixed(1) +
-                   '%)') 
+                   '%)')
             }}
           </span>
-        
+
           <span>
             {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr)
-              ? ('-') 
+              ? ('-')
               : (common.FPGAResources.nextpnr.Field1.name + ' : ' +
                   common.FPGAResources.nextpnr.Field1.used + ' / ' +
                   common.FPGAResources.nextpnr.Field1.total + ' ( ' +
                   (common.FPGAResources.nextpnr.Field1.used /
                   common.FPGAResources.nextpnr.Field1.total*100).toFixed(1) +
-                  '%)') 
-            }}
-          </span>
-        
-          <span>
-            {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr) 
-              ? ('-') 
-              : (common.FPGAResources.nextpnr.Field2.name + 
-                  '&nbsp;:&nbsp;&nbsp;' + 
-                  common.FPGAResources.nextpnr.Field2.used + 
-                  '&nbsp;/' + 
-                  common.FPGAResources.nextpnr.Field2.total + 
-                  '&nbsp;&nbsp;(&nbsp;' + 
-                  (common.FPGAResources.nextpnr.Field2.used /
-                  common.FPGAResources.nextpnr.Field2.total*100).toFixed(1) + 
                   '%)')
             }}
           </span>
-        
+
+          <span>
+            {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr)
+              ? ('-')
+              : (common.FPGAResources.nextpnr.Field2.name +
+                  '&nbsp;:&nbsp;&nbsp;' +
+                  common.FPGAResources.nextpnr.Field2.used +
+                  '&nbsp;/' +
+                  common.FPGAResources.nextpnr.Field2.total +
+                  '&nbsp;&nbsp;(&nbsp;' +
+                  (common.FPGAResources.nextpnr.Field2.used /
+                  common.FPGAResources.nextpnr.Field2.total*100).toFixed(1) +
+                  '%)')
+            }}
+          </span>
+
           <!-- 3 next fields with percentage precision from nextpnr -->
           <span>
-            {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr) 
-              ? ('-') 
-              : (common.FPGAResources.nextpnr.Field3.name + 
-                  '&nbsp;:&nbsp;&nbsp;' + 
-                  common.FPGAResources.nextpnr.Field3.used + 
-                  '&nbsp;/' + 
-                  common.FPGAResources.nextpnr.Field3.total + 
-                  '&nbsp;&nbsp;(&nbsp;' + 
-                  common.FPGAResources.nextpnr.Field3.percentage + 
-                  '%)') 
+            {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr)
+              ? ('-')
+              : (common.FPGAResources.nextpnr.Field3.name +
+                  '&nbsp;:&nbsp;&nbsp;' +
+                  common.FPGAResources.nextpnr.Field3.used +
+                  '&nbsp;/' +
+                  common.FPGAResources.nextpnr.Field3.total +
+                  '&nbsp;&nbsp;(&nbsp;' +
+                  common.FPGAResources.nextpnr.Field3.percentage +
+                  '%)')
             }}
           </span>
 
         </div>
-        
-        <div>         
+
+        <div>
           <span>
-            {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr) 
-              ? ('-') 
-              : (common.FPGAResources.nextpnr.Field10.name + 
-              ' : ' + 
-              common.FPGAResources.nextpnr.Field10.used + 
-              ' / ' + 
-              common.FPGAResources.nextpnr.Field10.total + 
-              ' ( ' + 
-              common.FPGAResources.nextpnr.Field10.percentage 
-              +'%)') 
+            {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr)
+              ? ('-')
+              : (common.FPGAResources.nextpnr.Field10.name +
+              ' : ' +
+              common.FPGAResources.nextpnr.Field10.used +
+              ' / ' +
+              common.FPGAResources.nextpnr.Field10.total +
+              ' ( ' +
+              common.FPGAResources.nextpnr.Field10.percentage
+              +'%)')
             }}
           </span>
-        
+
           <span>
-            {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr) 
-              ? ('-') 
-              : (common.FPGAResources.nextpnr.Field11.name + 
-                ' : ' + 
-                common.FPGAResources.nextpnr.Field11.used + 
-                ' / ' + 
-                common.FPGAResources.nextpnr.Field11.total + 
-                ' ( ' + 
-                common.FPGAResources.nextpnr.Field11.percentage + 
-                '%)') 
+            {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr)
+              ? ('-')
+              : (common.FPGAResources.nextpnr.Field11.name +
+                ' : ' +
+                common.FPGAResources.nextpnr.Field11.used +
+                ' / ' +
+                common.FPGAResources.nextpnr.Field11.total +
+                ' ( ' +
+                common.FPGAResources.nextpnr.Field11.percentage +
+                '%)')
             }}
           </span>
-        
+
           <!-- 2 next fields with no percentage -->
-        
+
           <span>
-            {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr) 
-              ? ('-') 
-              : (common.FPGAResources.nextpnr.Field12.name + 
-                 ' : ' + 
-                 common.FPGAResources.nextpnr.Field12.used + 
-                 ' / ' + 
-                 common.FPGAResources.nextpnr.Field12.total) 
+            {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr)
+              ? ('-')
+              : (common.FPGAResources.nextpnr.Field12.name +
+                 ' : ' +
+                 common.FPGAResources.nextpnr.Field12.used +
+                 ' / ' +
+                 common.FPGAResources.nextpnr.Field12.total)
             }}
           </span>
-        
+
           <span>
-            {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr) 
-              ? ('-') 
+            {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr)
+              ? ('-')
               : (common.FPGAResources.nextpnr.Field13.name +
-                 '&nbsp;:&nbsp;&nbsp;' + 
+                 '&nbsp;:&nbsp;&nbsp;' +
                  common.FPGAResources.nextpnr.Field13.used&nbsp;&nbsp; +
                  '/' + &nbsp;&nbsp;common.FPGAResources.nextpnr.Field13.total)
             }}
           </span>
-        
-        
+
+
           <span>
             MaxFreq.:&nbsp;&nbsp;
-            {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr) 
-               ? '-' 
-               : (common.FPGAResources.nextpnr.MF.value+'&nbsp;MHz') 
+            {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr)
+               ? '-'
+               : (common.FPGAResources.nextpnr.MF.value+'&nbsp;MHz')
             }}
           </span>
-        
+
           <span>
             BuildTime&nbsp;:&nbsp;&nbsp;
-            {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr) 
-              ? '-' 
-              : (common.FPGAResources.nextpnr.BUILDT.value + 
-                 '&nbsp;' + 
-                 common.FPGAResources.nextpnr.BUILDT.unit ) 
+            {{ (common.hasChangesSinceBuild || !common.FPGAResources.nextpnr)
+              ? '-'
+              : (common.FPGAResources.nextpnr.BUILDT.value +
+                 '&nbsp;' +
+                 common.FPGAResources.nextpnr.BUILDT.unit )
             }}
           </span>
-        
+
         </div>
       </div>
 
@@ -506,28 +494,28 @@
       <div class="shortcut-toolbox">
 
         <!-- Verify button -->
-        <a href="" class="shortcut-toolbox--item js-shortcut--action" 
-           uib-tooltip="{{ 'Verify' | translate }}" 
-           tooltip-append-to-body="true" 
+        <a href="" class="shortcut-toolbox--item js-shortcut--action"
+           uib-tooltip="{{'Verify' | translate}}"
+           tooltip-append-to-body="true"
            data-item="verify" >
-           <i class="icon--verify"></i>
+          <i class="icon--verify"></i>
         </a>
 
         <!-- Build button -->
-        <a href="" class="shortcut-toolbox--item js-shortcut--action" 
-           uib-tooltip="{{ 'Build' | translate }}" 
-           tooltip-append-to-body="true" 
+        <a href="" class="shortcut-toolbox--item js-shortcut--action"
+           uib-tooltip="{{'Build' | translate}}"
+           tooltip-append-to-body="true"
            data-item="build">
-           <i class="icon--build"></i>
+          <i class="icon--build"></i>
         </a>
 
         <!-- Upload button -->
-        <a href="" class="shortcut-toolbox--item js-shortcut--action" 
-           uib-tooltip="{{ 'Upload' | translate }}" 
-           tooltip-append-to-body="true" 
+        <a href="" class="shortcut-toolbox--item js-shortcut--action"
+           uib-tooltip="{{'Upload' | translate}}"
+           tooltip-append-to-body="true"
            data-item="upload">
-           <i class="icon--upload"></i>
-        </a>  
+          <i class="icon--upload"></i>
+        </a>
 
       </div>
     </div>

--- a/scripts/table_translations.sh
+++ b/scripts/table_translations.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#############################################
+#   Generate README translation %'s table   #
+#############################################
+
+#-- File for the Statistics
+TABLE_FILE="readme_table.txt"
+
+#-- lookup table
+declare "languages_en=English"
+declare "languages_es_ES=Spanish"
+declare "languages_ja_JP=Japanese"
+declare "languages_fr_FR=French"
+declare "languages_it_IT=Italian"
+declare "languages_zh_TW=Taiwanese"
+declare "languages_zh_CN=Chinese"
+declare "languages_eu_ES=Basque"
+declare "languages_de_DE=German"
+declare "languages_ko_KR=Korean"
+declare "languages_cs_CZ=Czech"
+declare "languages_tr_TR=Turkish"
+declare "languages_ru_RU=Russian"
+declare "languages_ca_ES=Catalonian"
+declare "languages_el_GR=Greek"
+declare "languages_nl_NL=Dutch"
+declare "languages_gl_ES=Galician"
+
+
+#-- Examine the .po file of all the locale folders
+cd app/resources/locale
+
+
+#-- Calculate results: percentage per LOCALE
+
+TOTAL_LINES=$(msgfmt --statistics template.pot 2>&1 |cut -d " " -f 4)
+RESULTS=()
+
+#-- d is the locale directory
+for d in */ ; do
+    LOCALE=${d%/}  # folder without trailing slash
+    TRANSLATED_LINES=$(msgfmt --statistics $LOCALE/$LOCALE.po 2>&1 |cut -d " " -f 1)
+    PERCENT=$((TRANSLATED_LINES * 100 / TOTAL_LINES))
+    RESULTS[${#RESULTS[@]}]="$PERCENT:$LOCALE" # add to the end of the array
+done
+
+#-- sort the results
+IFS=$'\n'; SORTED=($(sort -nr <<<"${RESULTS[*]}")); unset IFS
+
+
+#-- Output results
+echo "|  Language  | Translated strings |" > $TABLE_FILE
+echo "|:----------:|:------------------:|" >> $TABLE_FILE
+
+for LINE in ${SORTED[*]}
+do
+    PARTS=(${LINE//:/ })
+    LANGUAGE="languages_${PARTS[1]}"
+    #echo "${!LANGUAGE}" "${PARTS[0]}"
+    echo "| ${!LANGUAGE} (${PARTS[1]}) | ![Progress](http://progress-bar.dev/${PARTS[0]}) |" >> $TABLE_FILE
+done


### PR DESCRIPTION
The initial goal was to translate into Spanish the new additions from my previous commits, but I discovered some problems and tried to solve them:

- Some translation blocks weren't working correctly: they were lost when extracting the labels. After some digging and reading the [documentation](https://angular-gettext.rocketeer.be/dev-guide/annotate/) I managed to solve the issue simplifying how the translation annotations were being made (and correcting them), mainly in the `design.html` file.
- Many language files where outdated: after the template is updated, the *.po files should also be updated. There is now a complete English and Spanish translation.
- The translation percentage table in the README.md wasn't updated: there is now a tool to automate/simplify the process (and is now up to date).
- Some typos and LOTS of trailing white-spaces and non-uniform indentations. 

Please, review this PR carefully and let me know if any change is required.