### PR TITLE
utils: Remove hardcoded paths to let the system find programs with PATH

### DIFF
--- a/app/scripts/services/utils.js
+++ b/app/scripts/services/utils.js
@@ -59,39 +59,24 @@ angular.module('icestudio')
           possibleExecutables.push('py.exe -3');
           possibleExecutables.push('python.exe');
 
-          possibleExecutables.push('C:\\Python315\\python.exe');
-          possibleExecutables.push('C:\\Python314\\python.exe');
-          possibleExecutables.push('C:\\Python313\\python.exe');
-          possibleExecutables.push('C:\\Python312\\python.exe');
-          possibleExecutables.push('C:\\Python311\\python.exe');
-          possibleExecutables.push('C:\\Python39\\python.exe');
-          possibleExecutables.push('C:\\Python38\\python.exe');
-          possibleExecutables.push('C:\\Python37\\python.exe');
         } //-- Python executables in Linux/Mac
         else {
-          let paths = ['/usr/bin/', '/usr/local/bin/', '/opt/homebrew/bin/', ''];
-          paths.forEach((base) => {
-
-            for (let i = 16; i >= 7; i--) {
-              possibleExecutables.push(`${base}python3.${i}`);
-            }
-            possibleExecutables.push(`${base}python3`);
-            possibleExecutables.push(`${base}python`);
-          });
-          possibleExecutables.push('/usr/local/Cellar/python/3.8.2/bin/python3');
-          possibleExecutables.push('/usr/local/Cellar/python/3.7.7/bin/python3');
-
-
+          possibleExecutables.push('python3');
+          possibleExecutables.push('python');
         }
 
-        console.log('Possible Python', possibleExecutables);
         //-- Move through all the possible executables
         //-- checking if they are executable
         for (let executable of possibleExecutables) {
-
+          iceConsole.log("Trying executable: " + executable);
           if (isPython3(executable)) {
             _pythonExecutableCached = executable;
-            console.log("Executable: " + executable);
+            const pythonExecutablePath = getExecutablePath(executable);
+            if (pythonExecutablePath) {
+              iceConsole.log(`Using Python 3 executable: ${pythonExecutablePath}`);
+            } else {
+              iceConsole.log(`Using Python 3 executable: ${executable}`);
+            }
             break;
           }
         }
@@ -124,6 +109,27 @@ angular.module('icestudio')
         console.error(e);
       }
       return false;
+    }
+
+    //---------------------------------------------------------
+    //-- Get the path of an executable using the `which` utility
+    //--
+    //-- INPUTS:
+    //--   -executable: string for an executable
+    //-- OUTPUTS:
+    //--   string: the path to the executable
+    //--   null: `which` is unavailable or execution error
+    function getExecutablePath(executable) {
+      const command = `which ${executable}`;
+      try {
+        const result = nodeChildProcess.execSync(command);
+        if (result !== false && result !== null) {
+          return result.toString();
+        }
+      } catch (e) {
+          console.error(e);
+      }
+      return null;
     }
 
 


### PR DESCRIPTION
During the [sponsored packaging process of Icestudio for Nix and NixOS](https://nlnet.nl/thema/NGI0Entrust.html), we came across some inconsistencies that prevented successful installation of the APIO toolchain.

The culprit appears to be a hardcoded list of paths that are checked to see if they contain a Python 3 executable. While this feature might have been useful in some corner cases, it can be considered an antipattern. Windows has had PATH environment variable support for a long time, is a native feature in Linux and macOS supports it too.

This PR gets rid of these hardcoded paths, letting the system, or power users, manage how a Python installation might be found. As a minor feature, I'm also adding a call to `which` to get the path for the found Python 3 executable (in a future commit I'll use shelljs and add a dependency on it to do that portably).

This PR has been tested successfully on Linux, and Windows, which has Python 3 installations from the Python website, Windows Store, and the standalone indygreg versions.
