### PR TITLE
package.json: Add `sh` call in postinstall and replace bash -> sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "jshint": "grunt jshint",
     "clean": "grunt clean",
     "getcollection": "grunt getcollection",
-    "postinstall": "scripts/postInstall.sh && grunt getcollection && npmpd && cd app && npm install"
+    "postinstall": "sh scripts/postInstall.sh && grunt getcollection && npmpd && cd app && npm install"
   },
   "devDependencies": {
     "grunt": "^1.4.1",

--- a/scripts/postInstall.sh
+++ b/scripts/postInstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 sed -i  's/options\.srcDir/\/\/options.srcDir/g' node_modules/grunt-nw-builder/tasks/nw.js
 sed -i'' -e 's/options\.srcDir/\/\/options.srcDir/g' node_modules/grunt-nw-builder/tasks/nw.js


### PR DESCRIPTION
This avoids Windows not knowing how to execute the file. `sh` is aliased to `bash` when you install Git in Windows, for instance. This also changes bash to sh, as for now that script doesn't seem to require bash.