### PR TITLE
utils: Add missing semicolon

### DIFF
--- a/app/scripts/services/utils.js
+++ b/app/scripts/services/utils.js
@@ -122,8 +122,8 @@ angular.module('icestudio')
     //--   null: executable not found
     function getExecutablePath(executable) {
       // split executable at first space to account for e.g. `python.exe -3`
-      executable = executable.split(" ")[0]
-      return shelljs.which(executable)
+      executable = executable.split(" ")[0];
+      return shelljs.which(executable);
     }
 
 


### PR DESCRIPTION
There were a couple missing semicolons that triggered jshint errors during CI builds. This PR solves that. Sorry for the oversight in the commit :yum: I'll make sure to run jshint before any further commit. 