### PR TITLE
ci: remove ref in the checkout action so that checkout fetches $GITHUB_SHA instead

### DIFF
--- a/.github/workflows/main-aarch64.yml
+++ b/.github/workflows/main-aarch64.yml
@@ -23,8 +23,6 @@ jobs:
      
       # Checkout the develop branch
       - uses: actions/checkout@v3
-        with:
-          ref: develop
     
       - name: Setup por arm64
         run:  ./scripts/preInstallArm64.sh

--- a/.github/workflows/main-osx-arm64.yml
+++ b/.github/workflows/main-osx-arm64.yml
@@ -24,8 +24,6 @@ jobs:
     
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
-        with:
-          ref: develop 
       
       - name: Setup Nodejs version
         uses: actions/setup-node@v3

--- a/.github/workflows/main-windows.yml
+++ b/.github/workflows/main-windows.yml
@@ -23,8 +23,6 @@ jobs:
      
       # Checkout the develop branch
       - uses: actions/checkout@v3
-        with:
-          ref: develop
       
       - name: Setup Nodejs version
         uses: actions/setup-node@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,6 @@ jobs:
      
       # Checkout the develop branch
       - uses: actions/checkout@v3
-        with:
-          ref: develop
       
       - name: Setup Nodejs version
         uses: actions/setup-node@v3


### PR DESCRIPTION
During my PRs this afternoon I found out that the CI fetched `develop` on PRs, so the actions would run against `develop` without merging the PRs commits.

For instance, I introduced commit 6bae3b1 with [linting errors](https://github.com/kiike/icestudio/commit/6bae3b129157fd002aa191c42f1827f17bbdc429#diff-31dbaaf6bb8f759673dfc7db710b6a60785bd84047cc58bbb9a5cde3bad8d9e4R125-R126) that [didn't trigger a linting failure](https://github.com/FPGAwars/icestudio/actions/runs/9872306761/job/27262143321#step:5:1).

In that log, [we see that `develop` is being checked out](https://github.com/FPGAwars/icestudio/actions/runs/9872306761/job/27262143321#step:2:470), instead of checking out the PR commits on top of develop. In that case, we should see a mention of the commit 6bae3b1 and the PR ref instead.

By removing these two lines in the action files we can fix that. The action will fetch the commit that triggered the event. I think that is what is expected, so that CI catches errors before merging them.