### PR TITLE
gruntfile: clean collection after unzipping

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -693,9 +693,9 @@ module.exports = function (grunt) {
   //-- This task is called in the npm postinstallation
   //-- (after npm install is executed)
   grunt.registerTask("getcollection", [
-    "clean:collection",  //-- Remove previous collection downloaded
     "wget:collection",   //-- Download the collection
-    "unzip"              //-- Unzip the collection (install it)
+    "unzip",             //-- Unzip the collection (install it)
+    "clean:collection"   //-- Remove previously downloaded collection
   ]);
 
   //-- grunt server


### PR DESCRIPTION
During the packaging work for Nix, we noticed that the `wget` task would always try downloading the collections file, even though we downloaded it to the cache location. After some digging, it looks like cleaning the downloaded file before the download will just do that.

If we run the `clean:collection` task after unzipping, we allow downloading the file manually into the cache directory so that the unzip task doesn't try downloading it again. That is especially beneficial on NixOS, as the dependencies should be cached before running the build.