### PR TITLE
gruntfile: clean collection after unzipping

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -693,9 +693,10 @@ module.exports = function (grunt) {
   //-- This task is called in the npm postinstallation
   //-- (after npm install is executed)
   grunt.registerTask("getcollection", [
-    "clean:collection",  //-- Remove previous collection downloaded
+    "clean:collection",  //-- Remove previously installed collection
     "wget:collection",   //-- Download the collection
-    "unzip"              //-- Unzip the collection (install it)
+    "unzip",             //-- Unzip the collection (install it)
+    "clean:collectionFile" //-- Remove cached collection file
   ]);
 
   //-- grunt server
@@ -733,7 +734,11 @@ module.exports = function (grunt) {
 
       //-- Remove the default collection (which is installed when 
       //-- npm install is executed initially
-      collection: [DEFAULT_COLLECTION_FOLDER, CACHE_DEFAULT_COLLECTION_FILE],
+      collection: [DEFAULT_COLLECTION_FOLDER],
+
+      //-- Remove the downloaded collection file
+      //-- that is fetched with wget:collection
+      collectionFile: [CACHE_DEFAULT_COLLECTION_FILE],
     },
 
     //-- Get the English texts from the .js and .html files


### PR DESCRIPTION
This PR splits the `clean:collection` task into `clean:collectionFile` and `clean:collection`:

- `clean:collection` removes the previously installed collection as the comment indicated.
- `clean:collectionFile` downloads the file in the cache that was downloaded with `wget:collection.`

Then, when we run `getcollection`:

1. the installed collection is cleaned (`clean:collection`)
2. the collection is downloaded if not cached (`wget:collection`)
3. the collection is unzipped (`unzip:using-router`)
4. the cached file is cleaned (`clean:collectionFile`)