### PR TITLE
gruntfile: Add flag to skip building nwjs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -474,7 +474,10 @@ module.exports = function (grunt) {
     "nggettext_compile",  //-- Extract English texts to the template file
     "copy:dist",    //-- Copy the files to be included in the build package
     "json-minify",  //-- Minify JSON files
-    "nwjs",         //-- Build the executable package
+
+    //-- Build the executable package with nwjs by default, and skip this task
+    //-- when the flag --dont-build-nwjs is passed
+    ... grunt.option('dont-build-nwjs') ? [] : ["nwjs"],
 
     //-- The clean:tmp task is also a common task, but it is
     //-- executed after the specific platform task


### PR DESCRIPTION
This PR adds a flag to allow skipping building the executable with nwjs. When this flag is passed, we skip the `nwjs` task, which is beneficial in NixOS so that we don't download any extra binaries; the system already has an `nwjs` package. Let me know if you think this flag is fine or if you prefer another style `--skip-build-nwjs` or `--skip-nwjs`, for instance.