### PR TITLE
gruntfile: Allow skipping cleaning of tmp

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -726,7 +726,12 @@ module.exports = function (grunt) {
     //-- https://github.com/gruntjs/grunt-contrib-clean
     clean: {
       //-- Remove temporary folder
-      tmp: [".tmp", DIST_TMP],
+      tmp: {
+        src: [".tmp", DIST_TMP],
+        options: {
+          'no-write': grunt.option('dont-clean-tmp')
+        }
+      },
 
       //-- Remove folder with generated executable packages
       dist: [DIST],


### PR DESCRIPTION
This PR adds a flag to skip cleaning the tmp folder. That might be a good idea, for instance, when packaging for Nix, as we work on the dist/tmp folder. As #762, please tell me if that's something you'd like having in the Gruntfile and also the style of the flag. Thanks!