### PR TITLE
gruntfile: Allow a `none` `platform` to skip platform-specific tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -525,7 +525,11 @@ module.exports = function (grunt) {
       "copy:aarch64",      //-- Copy the Linux build dir to ARM build dir
       "shell:mergeAarch64",
       "compress:Aarch64"
-    ]
+    ],
+
+    //-- NO TARGET
+    //-- Use this to skip running platform-specific tasks
+    "none": []
   };
 
   //---------------------------------------------------------------


### PR DESCRIPTION
A change in `distPlatformTasks` allows passing `--platform=none` so that no platform-specific tasks are executed. With this, we avoid running tasks that would not be necessary if, for instance, we are not going to use the zipfile or the AppImage, like the actions we carry out in the Nix package.

Without the` --platform=none` flag on `linux64`:

```
┌─────────┬─────────────────────────┐
│ (index) │ Values                  │
├─────────┼─────────────────────────┤
│ 0       │ 'jshint'                │
│ 1       │ 'clean:dist'            │
│ 2       │ 'nggettext_compile'     │
│ 3       │ 'copy:dist'             │
│ 4       │ 'json-minify'           │
│ 5       │ 'nwjs'                  │
│ 6       │ 'compress:linux64'      │
│ 7       │ 'shell:appImageLinux64' │
│ 8       │ 'clean:tmp'             │
└─────────┴─────────────────────────┘
```

With the `--platform=none` flag:

```
┌─────────┬─────────────────────┐
│ (index) │ Values              │
├─────────┼─────────────────────┤
│ 0       │ 'jshint'            │
│ 1       │ 'clean:dist'        │
│ 2       │ 'nggettext_compile' │
│ 3       │ 'copy:dist'         │
│ 4       │ 'json-minify'       │
│ 5       │ 'nwjs'              │
│ 6       │ 'clean:tmp'         │
└─────────┴─────────────────────┘
```