### PR TITLE
Add support for PULLMODE=NONE to lpf generation

### DIFF
--- a/app/scripts/services/compiler.js
+++ b/app/scripts/services/compiler.js
@@ -956,9 +956,7 @@ angular.module('icestudio')
 
               //-- Get the pullmode property of the physical pin (its id is pin.value)
               let pullmode = common.selectedBoard.pinout.find(x => x.value === value).pullmode;
-              pullmode = (typeof pullmode === 'undefined') ? 'NONE' : pullmode;
-
-              if (pullmode === 'UP' || pullmode === 'DOWN') {
+              if (pullmode === 'UP' || pullmode === 'DOWN'  || pullmode === 'NONE') {
                 code += 'PULLMODE=' + pullmode;
               }
               code += ' ;\n\n';
@@ -978,9 +976,7 @@ angular.module('icestudio')
 
             //-- Get the pullmode property of the physical pin (its id is pin.value)
             let pullmode = common.selectedBoard.pinout.find(x => x.value === value).pullmode;
-            pullmode = (typeof pullmode === 'undefined') ? 'NONE' : pullmode;
-
-            if (pullmode === 'UP' || pullmode === 'DOWN') {
+            if (pullmode === 'UP' || pullmode === 'DOWN' || pullmode === 'NONE') {
               code += 'PULLMODE=' + pullmode;
             }
             code += ' ;\n\n';


### PR DESCRIPTION
At present the compiler only supports the generation of lpf files containing pin attributes of: `PULLMODE=UP` and `PULLMODE=DOWN`. 

This PR cleans up the code for generating pull modes as well as adding support for generating `PULLMODE=NONE` from a `pinout.json` file such as:

```json
{"type": "input",  "name": "button_user", "value": "M14", "pullmode" : "NONE"},
```

The original implemenation also had a bug whereby pins without a `pullmode` property would be assigned a pullmode of `NONE`:

```js
pullmode = (typeof pullmode === 'undefined') ? 'NONE' : pullmode;
```

This is incorrect as the default pull mode for a lpf file with no pull mode attribute is `DOWN`. 

However this did not cause any problems in practice due to the conditional below it which would only generate a `PULLMODE` attribute for `UP` and `DOWN`:

```js
if (pullmode === 'UP' || pullmode === 'DOWN') {
  code += 'PULLMODE=' + pullmode;
}
```


