### PR TITLE
Change upload shortcut from Ctrl+U to Ctrl+Shift+U

### DIFF
--- a/app/scripts/services/shortcuts.js
+++ b/app/scripts/services/shortcuts.js
@@ -156,8 +156,8 @@ angular.module('icestudio')
         mac: { label: '⌘+B', meta: true, key: 66 }
       },
       uploadCode: {
-        linux: { label: 'Ctrl+U', ctrl: true, key: 85 },
-        mac: { label: '⌘+U', meta: true, key: 85 }
+        linux: { label: 'Ctrl+Shift+U', ctrl: true, shift: true, key: 85 },
+        mac: { label: '⌘+⇧+U', meta: true, shift: true, key: 85 }
       },
       stepUp: {
         linux: { label: 'Arrow up', key: 38 },


### PR DESCRIPTION
This PR fixes issue #767. The limitation has been confirmed through documentation from [Chrome](https://support.google.com/surveys/answer/6172725?hl=en) and [Firefox](https://firefox-source-docs.mozilla.org/devtools-user/view_source/index.html).