### PR TITLE
allow setting ICESTUDIO_DIR and LOGFILE using environment variables

### DIFF
--- a/app/scripts/services/common.js
+++ b/app/scripts/services/common.js
@@ -115,8 +115,8 @@ angular.module('icestudio').service(
     this.ICESTUDIO_HOME =
       this.WIN32 && process.arch === 'ia32' ? 'icestudio_home' : '.icestudio';
     this.BASE_DIR = process.env.HOME || process.env.USERPROFILE;
-    this.LOGFILE = nodePath.join(this.BASE_DIR, 'icestudio.log');
-    this.ICESTUDIO_DIR = nodePath.join(this.BASE_DIR, this.ICESTUDIO_HOME);
+    this.LOGFILE = process.env.ICESTUDIO_LOGFILE || nodePath.join(this.BASE_DIR, 'icestudio.log');
+    this.ICESTUDIO_DIR = process.env.ICESTUDIO_DIR || nodePath.join(this.BASE_DIR, this.ICESTUDIO_HOME);
 
     this.INTERNAL_COLLECTIONS_DIR = nodePath.join(
       this.ICESTUDIO_DIR,


### PR DESCRIPTION
(I've tested this to the extent that I can, but I'm having some windows build problems at the moment.)

> Please provide enough information so that others can review your pull request:

This is a pretty simple change. I wanted to be able to set the location of ICESTUDIO_DIR via environment variables so I can move it to a COW (copy on write) disk image I use. Also wanted to be able to set the LOGFILE location.

> Explain the **details** for making this change. What existing problem does the pull request solve?

This is good for when you don't want the `.icestudio` directory in HOME or don't want it hidden, etc.

> Screenshots/GIFs

n/a