### PR TITLE
Sync and Extend I/O Ports Table Behavior

### DIFF
--- a/app/resources/uiThemes/dark/dark.css
+++ b/app/resources/uiThemes/dark/dark.css
@@ -980,3 +980,16 @@
   border-color: #666;
   color: white;
 }
+
+.jexcel_container .highlight {
+  border: none !important;
+  border-radius: 0 !important;
+  width: auto !important;
+  height: auto !important;
+  position: static !important;
+  top: auto !important;
+  left: auto !important;
+  padding-top: 0 !important;
+
+  background-color: rgba(0, 0, 0, 0.05) !important;
+}

--- a/app/resources/uiThemes/light/light.css
+++ b/app/resources/uiThemes/light/light.css
@@ -990,3 +990,16 @@ li.active {
   border-color: #e7e7e7;
   color: #333;
 }
+
+.jexcel_container .highlight {
+  border: none !important;
+  border-radius: 0 !important;
+  width: auto !important;
+  height: auto !important;
+  position: static !important;
+  top: auto !important;
+  left: auto !important;
+  padding-top: 0 !important;
+
+  background-color: rgba(0, 0, 0, 0.05) !important;
+}

--- a/app/scripts/services/forms.js
+++ b/app/scripts/services/forms.js
@@ -2015,6 +2015,7 @@ angular
           const data = [['', 'IN', 1, false, false, true]];
 
           let field7 = new GridField(7, 'ports-table', columns, data);
+          field7.onEnter = onEnterIOPortsTable;
           this.addField(field7, modulePortsLabel);
 
           field0.onChange((value) => {
@@ -2878,6 +2879,35 @@ angular
       //------------------------------------------------------------------------
       //-- Private functions
       //------------------------------------------------------------------------
+      function onEnterIOPortsTable() {
+        const [col, row] = this.table.selectedCell || [];
+        const data = this.table.getData();
+        const rowData = this.table.getRowData(row);
+        const name = rowData[0];
+        const totalRows = data.length;
+
+        const isEmpty = !name;
+        const defaultRow = ['', 'IN', 1, false, false, true];
+
+        if (isEmpty) {
+          const otherEmptyRowExists = data.some((r, i) => !r[0] && i !== row);
+
+          if (otherEmptyRowExists || totalRows > 1) {
+            this.table.deleteRow(row);
+
+            const stillHasEmptyRow = this.table.getData().some((r) => !r[0]);
+            if (!stillHasEmptyRow) {
+              this.table.insertRow([...defaultRow]);
+            }
+          }
+        } else {
+          const hasEmptyRow = data.some((r) => !r[0]);
+          if (!hasEmptyRow) {
+            this.table.insertRow([...defaultRow]);
+          }
+        }
+      }
+
       function updateIOPortsTable(instance, textList, type) {
         const parsedNames = textList
           .split(',')

--- a/app/scripts/services/forms.js
+++ b/app/scripts/services/forms.js
@@ -1966,7 +1966,7 @@ angular
             { type: 'checkbox', title: 'Registered', width: 80 },
             { type: 'checkbox', title: 'Enable', width: 60 },
           ];
-          const data = [['', 'IN', 0, false, false, true]];
+          const data = [['', 'IN', 1, false, false, true]];
 
           let field7 = new GridField(7, 'ports-table', columns, data);
           this.addField(field7, modulePortsLabel);
@@ -2833,12 +2833,23 @@ angular
       //-- Private functions
       //------------------------------------------------------------------------
       function updateIOPortsTable(instance, textList, type) {
-        const newNames = textList
+        const parsedNames = textList
           .split(',')
-          .map((n) => n.trim())
-          .filter((n) => n !== '');
+          .map((n) => {
+            const trimmed = n.trim();
+            const match = trimmed.match(/^(\w+)\[(\d+):(\d+)\]$/);
+            if (match) {
+              const name = match[1];
+              const msb = parseInt(match[2], 10);
+              const lsb = parseInt(match[3], 10);
+              const busWidth = Math.abs(msb - lsb) + 1;
+              return { name, busWidth };
+            }
+            return { name: trimmed, busWidth: 1 };
+          })
+          .filter(({ name }) => name !== '');
 
-        const defaultRow = ['', 'IN', 0, false, false, true];
+        const defaultRow = ['', 'IN', 1, false, false, true];
         const data = instance.getData();
 
         const nameToRowIndex = new Map();
@@ -2851,12 +2862,16 @@ angular
           }
         });
 
-        newNames.forEach((name) => {
+        const newNames = parsedNames.map((p) => p.name);
+        parsedNames.forEach(({ name, busWidth }) => {
           if (nameToRowIndex.has(name)) {
             const i = nameToRowIndex.get(name);
             const row = instance.getData()[i];
             if (row[1] !== type) {
               instance.setValueFromCoords(1, i, type);
+            }
+            if (row[2] !== busWidth) {
+              instance.setValueFromCoords(2, i, busWidth);
             }
             usedIndexes.add(i);
           } else {
@@ -2870,13 +2885,14 @@ angular
                 existingName
               ) {
                 instance.setValueFromCoords(0, i, name);
+                instance.setValueFromCoords(2, i, busWidth);
                 usedIndexes.add(i);
                 reused = true;
                 break;
               }
             }
             if (!reused) {
-              instance.insertRow([name, type, 0, false, false, true]);
+              instance.insertRow([name, type, busWidth, false, false, true]);
             }
           }
         });

--- a/app/scripts/services/forms.js
+++ b/app/scripts/services/forms.js
@@ -786,7 +786,7 @@ angular
           if (editor) {
             editor.blur();
             if (typeof this.onEnter === 'function') {
-              this.onEnter();
+              this.onEnter(this);
             }
             return false;
           }
@@ -2879,10 +2879,11 @@ angular
       //------------------------------------------------------------------------
       //-- Private functions
       //------------------------------------------------------------------------
-      function onEnterIOPortsTable() {
-        const [col, row] = this.table.selectedCell || [];
-        const data = this.table.getData();
-        const rowData = this.table.getRowData(row);
+      function onEnterIOPortsTable(self) {
+        const coords = self.table.selectedCell || [];
+        const row = coords[0] || 0;
+        const data = self.table.getData();
+        const rowData = self.table.getRowData(row);
         const name = rowData[0];
         const totalRows = data.length;
 
@@ -2893,17 +2894,17 @@ angular
           const otherEmptyRowExists = data.some((r, i) => !r[0] && i !== row);
 
           if (otherEmptyRowExists || totalRows > 1) {
-            this.table.deleteRow(row);
+            self.table.deleteRow(row);
 
-            const stillHasEmptyRow = this.table.getData().some((r) => !r[0]);
+            const stillHasEmptyRow = self.table.getData().some((r) => !r[0]);
             if (!stillHasEmptyRow) {
-              this.table.insertRow([...defaultRow]);
+              self.table.insertRow([...defaultRow]);
             }
           }
         } else {
           const hasEmptyRow = data.some((r) => !r[0]);
           if (!hasEmptyRow) {
-            this.table.insertRow([...defaultRow]);
+            self.table.insertRow([...defaultRow]);
           }
         }
       }

--- a/app/scripts/services/forms.js
+++ b/app/scripts/services/forms.js
@@ -777,6 +777,17 @@ angular
         read() {
           return this.table.getData();
         }
+
+        allowEnter() {
+          const editor = document.querySelector(
+            `#${this.tableId} .editor input`
+          );
+          if (editor) {
+            editor.blur();
+            return false;
+          }
+          return true;
+        }
       }
 
       class Form {
@@ -1024,7 +1035,37 @@ angular
           dialog.setContent(html);
 
           //-- Set the callback for the OK button
-          dialog.set('onok', callback);
+          dialog.set('onok', function (evt) {
+            let allow = true;
+
+            if (Array.isArray(self.fields)) {
+              self.fields.forEach((field) => {
+                if (
+                  typeof field.allowEnter === 'function' &&
+                  !field.allowEnter()
+                ) {
+                  allow = false;
+                }
+              });
+            } else {
+              Object.keys(self.fields).forEach((tab) => {
+                self.fields[tab].forEach((field) => {
+                  if (
+                    typeof field.allowEnter === 'function' &&
+                    !field.allowEnter()
+                  ) {
+                    allow = false;
+                  }
+                });
+              });
+            }
+
+            if (allow) {
+              callback(evt);
+            } else {
+              evt.cancel = true;
+            }
+          });
 
           //-- Set the callback for the Cancel button:
           //--   Do nothing...

--- a/app/scripts/services/forms.js
+++ b/app/scripts/services/forms.js
@@ -2836,16 +2836,23 @@ angular
         const parsedNames = textList
           .split(',')
           .map((n) => {
-            const trimmed = n.trim();
+            let trimmed = n.trim();
+            let signed = false;
+
+            if (trimmed.startsWith('@')) {
+              signed = true;
+              trimmed = trimmed.slice(1);
+            }
+
             const match = trimmed.match(/^(\w+)\[(\d+):(\d+)\]$/);
             if (match) {
               const name = match[1];
               const msb = parseInt(match[2], 10);
               const lsb = parseInt(match[3], 10);
               const busWidth = Math.abs(msb - lsb) + 1;
-              return { name, busWidth };
+              return { name, busWidth, signed };
             }
-            return { name: trimmed, busWidth: 1 };
+            return { name: trimmed, busWidth: 1, signed };
           })
           .filter(({ name }) => name !== '');
 
@@ -2863,7 +2870,7 @@ angular
         });
 
         const newNames = parsedNames.map((p) => p.name);
-        parsedNames.forEach(({ name, busWidth }) => {
+        parsedNames.forEach(({ name, busWidth, signed }) => {
           if (nameToRowIndex.has(name)) {
             const i = nameToRowIndex.get(name);
             const row = instance.getData()[i];
@@ -2873,6 +2880,7 @@ angular
             if (row[2] !== busWidth) {
               instance.setValueFromCoords(2, i, busWidth);
             }
+            instance.setValueFromCoords(3, i, signed);
             usedIndexes.add(i);
           } else {
             let reused = false;
@@ -2886,13 +2894,14 @@ angular
               ) {
                 instance.setValueFromCoords(0, i, name);
                 instance.setValueFromCoords(2, i, busWidth);
+                instance.setValueFromCoords(3, i, signed);
                 usedIndexes.add(i);
                 reused = true;
                 break;
               }
             }
             if (!reused) {
-              instance.insertRow([name, type, busWidth, false, false, true]);
+              instance.insertRow([name, type, busWidth, signed, false, true]);
             }
           }
         });

--- a/app/scripts/services/forms.js
+++ b/app/scripts/services/forms.js
@@ -738,6 +738,7 @@ angular
           this.tableId = `table${formId}`;
           this.table = null;
           this.className = className;
+          this.onEnter = null;
 
           //-- Html template for building the grid
           this.htmlTemplate = `
@@ -784,6 +785,9 @@ angular
           );
           if (editor) {
             editor.blur();
+            if (typeof this.onEnter === 'function') {
+              this.onEnter();
+            }
             return false;
           }
           return true;

--- a/app/scripts/services/forms.js
+++ b/app/scripts/services/forms.js
@@ -766,6 +766,7 @@ angular
             allowManualInsertRow: false,
             tableOverflow: true,
             tableHeight: '200px',
+            contextMenu: false,
           });
         }
 
@@ -1954,11 +1955,11 @@ angular
           ];
 
           const columns = [
-            { type: 'text', title: 'Name', width: 150 },
+            { type: 'text', title: 'Name', width: 140 },
             {
               type: 'dropdown',
               title: 'Type',
-              width: 70,
+              width: 80,
               source: ['IN', 'OUT', 'BIDI'],
             },
             { type: 'numeric', title: 'Bus width', width: 80 },

--- a/app/scripts/services/forms.js
+++ b/app/scripts/services/forms.js
@@ -2889,13 +2889,20 @@ angular
         }
 
         const updated = instance.getData();
+        let hasEmptyRow = false;
+
         for (let i = updated.length - 1; i >= 0; i--) {
-          if (!updated[i][0]) {
+          const length = instance.getData().length;
+          if (!updated[i][0] && length > 1) {
             instance.deleteRow(i);
+          } else if (!updated[i][0]) {
+            hasEmptyRow = true;
           }
         }
 
-        instance.insertRow([...defaultRow]);
+        if (!hasEmptyRow) {
+          instance.insertRow([...defaultRow]);
+        }
       }
     }
   );

--- a/app/scripts/services/forms.js
+++ b/app/scripts/services/forms.js
@@ -127,7 +127,7 @@ angular
         //---------------------------------------------
         write(value) {
           //-- Write the value to the DOM
-          $(`#form${this.formId}`).val(value);
+          $(`#form${this.formId}`).val(value).trigger('input');
         }
 
         //------------------------------------------------

--- a/app/scripts/services/forms.js
+++ b/app/scripts/services/forms.js
@@ -768,6 +768,11 @@ angular
             tableOverflow: true,
             tableHeight: '200px',
             contextMenu: false,
+            onchange: () => {
+              if (typeof this.onEnter === 'function') {
+                this.onEnter(this);
+              }
+            },
           });
         }
 
@@ -2880,8 +2885,51 @@ angular
       //-- Private functions
       //------------------------------------------------------------------------
       function onEnterIOPortsTable(self) {
+        const grouped = {
+          IN: [],
+          OUT: [],
+          BIDI: [],
+        };
+
+        self.table.getData().forEach((row) => {
+          const enabled = row[5] !== false;
+          if (!enabled) {
+            return;
+          }
+          let name = row[0]?.trim();
+          const type = row[1]?.toUpperCase();
+          const busWidth = parseInt(row[2], 10);
+          const signed = row[3] === true;
+
+          if (!name || !type) {
+            return;
+          }
+
+          if (!isNaN(busWidth) && busWidth > 1) {
+            name += `[${busWidth - 1}:0]`;
+          }
+
+          if (signed) {
+            name = `@${name}`;
+          }
+
+          if (grouped[type]) {
+            grouped[type].push(name);
+          }
+        });
+
+        const inInput = document.querySelector('#form0');
+        const outInput = document.querySelector('#form1');
+        const bidiInput1 = document.querySelector('#form3');
+        const bidiInput2 = document.querySelector('#form4');
+
+        inInput.value = grouped.IN.join(', ');
+        outInput.value = grouped.OUT.join(', ');
+        bidiInput1.value = grouped.BIDI.join(', ');
+        bidiInput2.value = grouped.BIDI.join(', ');
+
         const coords = self.table.selectedCell || [];
-        const row = coords[0] || 0;
+        const row = coords[1] || 0;
         const data = self.table.getData();
         const rowData = self.table.getRowData(row);
         const name = rowData[0];


### PR DESCRIPTION
This PR builds on the existing GridField infrastructure to extend its behavior and ensure consistent synchronization between the I/O table and associated input fields:

- Enabled automatic sync from the I/O table to IN, OUT, and BIDI text fields when editing any cell or pressing Enter.
- Added support for signed port names using the @ prefix.
- Added support for bus ports using [msb:lsb] syntax.
- Ignored ports marked as disabled when generating the field content.
- Implemented an onEnter callback hook to allow per-table behavior such as inserting or deleting rows.
- Prevented dialog confirmation if a table cell is being edited.
- Ensured only one empty row remains visible to simplify new port entry.
- Triggered cell selection movement after row insertion to improve input flow.
