### PR TITLE
Add 'VSDSquadron-FM' to menu.json

### DIFF
--- a/app/resources/boards/menu.json
+++ b/app/resources/boards/menu.json
@@ -73,7 +73,8 @@
       "upduino2",
       "upduino21",
       "upduino3",
-      "upduino31"
+      "upduino31",
+      "VSDSquadron-FM"
     ]
   },
   {


### PR DESCRIPTION
Add VSDSquadron-FM to boards menu.json

Register the VSDSquadron-FM board in the iCEStudio board selection menu
so it appears under Select > Board after the board files are loaded.

Without this entry the board folder and pinout files are present but the
board remains invisible to the UI.