### PR TITLE
Update Soan-Papdi board apio ID

### DIFF
--- a/app/resources/boards/Soan-Papdi/info.json
+++ b/app/resources/boards/Soan-Papdi/info.json
@@ -11,5 +11,8 @@
     "brams": 30
   },
   "arch": "ice40",
-  "group": "UP5K"
+  "group": "UP5K",
+  "apio": {
+    "board": "soan-papdi"
+  }
 }


### PR DESCRIPTION
> **Explain the details for making this change. What existing problem does the pull request solve?**

This updates the `info.json` for the Soan-Papdi board to explicitly define the Apio board ID as `"soan-papdi"` while preserving the UI label as `"Soan-Papdi"`. 

Previously, without the explicit `apio.board` definition, the toolchain might fall back to using the directory name or the label, which can cause issues with the underlying Apio compilation and upload commands if they expect the exact lowercase identifier (`soan-papdi`). This change ensures the correct board ID is passed to Apio while keeping the display name in the Icestudio UI clean and properly capitalized.

> **Screenshots/GIFs**

Fixed this compilation issue saying 'Unknown board id 'Soan-Papdi' in apio.ini:
<img width="900" height="191" alt="WhatsApp Image 2026-08-20 at 20 37 00" src="https://github.com/user-attachments/assets/323d1897-3a5f-4b86-9354-0191383b0300" />

After this change compilation is successful.