### PR TITLE
Cmod A7-35T board addition

### DIFF
--- a/app/resources/boards/Cmod-A7-35T/info.json
+++ b/app/resources/boards/Cmod-A7-35T/info.json
@@ -1,0 +1,20 @@
+{
+  "label": "Cmod A7-35T",
+  "mode": "apio",
+  "SysClkMhz": 12,
+  "arch": "xc7",
+  "fpga": "xc7a35tcpg236c-1",
+  "interface": "FDTI",
+  "datasheet": "https://digilent.com/reference/_media/reference/programmable-logic/cmod-a7/reference-manual",
+  "group": "xilinx",
+  "apio": {
+    "board": "cmod-a7-35t",
+  },
+  "FPGAResources": {
+    "ffs": 41600,
+    "luts": 20800,
+    "pios": 106,
+    "plbs": 5200,
+    "brams": 50
+  }
+}

--- a/app/resources/boards/Cmod-A7-35T/pinout.json
+++ b/app/resources/boards/Cmod-A7-35T/pinout.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "CLK",
+    "value": "L14",
+    "type": "input"
+  },
+  {
+    "name": "LED_0_R",
+    "value": "C17",
+    "type": "output"
+  },
+  {
+    "name": "LED_0_G",
+    "value": "B16",
+    "type": "output"
+  },
+  {
+    "name": "LED_0_B",
+    "value": "B17",
+    "type": "output"
+  },
+  {
+    "name": "LED_1",
+    "value": "A17",
+    "type": "output"
+  },
+  {
+    "name": "LED_2",
+    "value": "C16",
+    "type": "output"
+  },
+  {
+    "name": "BTN_0",
+    "value": "A18",
+    "type": "input"
+  },
+  {
+    "name": "BTN_1",
+    "value": "B18",
+    "type": "input"
+  }
+]

--- a/app/resources/boards/Cmod-A7-35T/rules.json
+++ b/app/resources/boards/Cmod-A7-35T/rules.json
@@ -1,0 +1,9 @@
+{
+  "input": [
+    {
+      "port": "clk",
+      "pin": "L14"
+    }
+  ],
+  "output": []
+}

--- a/app/resources/boards/menu.json
+++ b/app/resources/boards/menu.json
@@ -134,7 +134,8 @@
   {
     "type": "XILINX",
     "boards": [
-      "basys3"
+      "basys3",
+      "cmod-a7-35t"
     ]
   }
 ]


### PR DESCRIPTION
Adds the Cmod A7-35T board, which is already supported in Apio.

Also, the contribution link provided (https://github.com/FPGAwars/icestudo/blob/develop/CONTRIBUTING.md) returns a 404

This is my first pull request so apologies if I messed something up.