### PR TITLE
boards: add Arty S7-25 (Digilent, xc7s25csga324-1)

### DIFF
--- a/app/resources/boards/Arty-S7-25/Arty-S7-25.xdc
+++ b/app/resources/boards/Arty-S7-25/Arty-S7-25.xdc
@@ -1,0 +1,33 @@
+
+#-- Arty S7-25 (Digilent)
+#-- Derived from Digilent's Arty-S7-25-Master.xdc:
+#-- https://github.com/Digilent/digilent-xdc/blob/master/Arty-S7-25-Master.xdc
+
+#-- System clock (12 MHz)
+set_property -dict { PACKAGE_PIN F14  IOSTANDARD LVCMOS33 } [get_ports {clk}]
+
+#-- LEDs (LD2-LD5)
+set_property -dict { PACKAGE_PIN E18  IOSTANDARD LVCMOS33 } [get_ports {leds[0]}]
+set_property -dict { PACKAGE_PIN F13  IOSTANDARD LVCMOS33 } [get_ports {leds[1]}]
+set_property -dict { PACKAGE_PIN E13  IOSTANDARD LVCMOS33 } [get_ports {leds[2]}]
+set_property -dict { PACKAGE_PIN H15  IOSTANDARD LVCMOS33 } [get_ports {leds[3]}]
+
+#-- Push buttons (BTN0-BTN3)
+set_property -dict { PACKAGE_PIN G15  IOSTANDARD LVCMOS33 } [get_ports {buttons[0]}]
+set_property -dict { PACKAGE_PIN K16  IOSTANDARD LVCMOS33 } [get_ports {buttons[1]}]
+set_property -dict { PACKAGE_PIN J16  IOSTANDARD LVCMOS33 } [get_ports {buttons[2]}]
+set_property -dict { PACKAGE_PIN H13  IOSTANDARD LVCMOS33 } [get_ports {buttons[3]}]
+
+#-- Slide switches (SW0-SW3)
+#-- SW3 sits in the DDR-adjacent bank and needs SSTL135, not LVCMOS33.
+set_property -dict { PACKAGE_PIN H14  IOSTANDARD LVCMOS33 } [get_ports {switches[0]}]
+set_property -dict { PACKAGE_PIN H18  IOSTANDARD LVCMOS33 } [get_ports {switches[1]}]
+set_property -dict { PACKAGE_PIN G18  IOSTANDARD LVCMOS33 } [get_ports {switches[2]}]
+set_property -dict { PACKAGE_PIN M5   IOSTANDARD SSTL135  } [get_ports {switches[3]}]
+
+#-- USB-UART bridge
+set_property -dict { PACKAGE_PIN R12  IOSTANDARD LVCMOS33 } [get_ports {uart_rx_async}]
+set_property -dict { PACKAGE_PIN V12  IOSTANDARD LVCMOS33 } [get_ports {uart_tx}]
+
+set_property CFGBVS VCCO [current_design]
+set_property CONFIG_VOLTAGE 3.3 [current_design]

--- a/app/resources/boards/Arty-S7-25/info.json
+++ b/app/resources/boards/Arty-S7-25/info.json
@@ -1,0 +1,20 @@
+{
+  "label": "Arty S7-25",
+  "mode": "apio",
+  "SysClkMhz": 12,
+  "arch": "xc7",
+  "fpga": "xc7s25csga324-1",
+  "interface": "FTDI",
+  "datasheet": "https://digilent.com/reference/programmable-logic/arty-s7/reference-manual",
+  "group": "XILINX",
+  "apio": {
+    "board": "arty-s7-25"
+  },
+  "FPGAResources": {
+    "ffs": 9999,
+    "luts": 9999,
+    "pios": 99,
+    "plbs": 99,
+    "brams": 99
+  }
+}

--- a/app/resources/boards/Arty-S7-25/pinout.json
+++ b/app/resources/boards/Arty-S7-25/pinout.json
@@ -1,0 +1,67 @@
+[
+  {
+    "name": "CLK",
+    "value": "F14",
+    "type": "input"
+  },
+  {
+    "name": "LED0",
+    "value": "E18",
+    "type": "output"
+  },
+  {
+    "name": "LED1",
+    "value": "F13",
+    "type": "output"
+  },
+  {
+    "name": "LED2",
+    "value": "E13",
+    "type": "output"
+  },
+  {
+    "name": "LED3",
+    "value": "H15",
+    "type": "output"
+  },
+  {
+    "name": "BTN0",
+    "value": "G15",
+    "type": "input"
+  },
+  {
+    "name": "BTN1",
+    "value": "K16",
+    "type": "input"
+  },
+  {
+    "name": "BTN2",
+    "value": "J16",
+    "type": "input"
+  },
+  {
+    "name": "BTN3",
+    "value": "H13",
+    "type": "input"
+  },
+  {
+    "name": "SW0",
+    "value": "H14",
+    "type": "input"
+  },
+  {
+    "name": "SW1",
+    "value": "H18",
+    "type": "input"
+  },
+  {
+    "name": "SW2",
+    "value": "G18",
+    "type": "input"
+  },
+  {
+    "name": "SW3",
+    "value": "M5",
+    "type": "input"
+  }
+]

--- a/app/resources/boards/Arty-S7-25/rules.json
+++ b/app/resources/boards/Arty-S7-25/rules.json
@@ -1,0 +1,9 @@
+{
+  "input": [
+    {
+      "port": "clk",
+      "pin": "F14"
+    }
+  ],
+  "output": []
+}

--- a/app/resources/boards/menu.json
+++ b/app/resources/boards/menu.json
@@ -134,7 +134,8 @@
   {
     "type": "XILINX",
     "boards": [
-      "basys3"
+      "basys3",
+      "Arty-S7-25"
     ]
   }
 ]


### PR DESCRIPTION
## Summary

Adds the Digilent Arty S7-25 (Xilinx Spartan-7, `xc7s25csga324-1`) as a supported board, mirroring the existing Basys3 entry (the only other Xilinx/apio board so far).

## Files

- `app/resources/boards/Arty-S7-25/info.json` - `mode: apio`, `arch: xc7`, `apio.board: arty-s7-25`.
- `app/resources/boards/Arty-S7-25/pinout.json` / `rules.json` - clock, 4 LEDs, 4 buttons, 4 switches.
- `app/resources/boards/Arty-S7-25/Arty-S7-25.xdc` - constraints derived from Digilent's own `Arty-S7-25-Master.xdc`.
- `app/resources/boards/menu.json` - registered under the existing `XILINX` group alongside `basys3`.

## Verification

Hardware-verified end to end:

- Built through the full `apio` pipeline (`yosys` -> `nextpnr-xilinx` -> `fasm2frames` -> `xc7frames2bit`), flashed to a real Arty S7-25, LED test confirmed correct.
- Verified through Icestudio's own GUI directly: selected this board, wired a simple `CLK` -> `LED` circuit in the visual editor, built, uploaded, and the LED lit as expected on real hardware.

## Context

This depends on the `xc7s25` device model being correct in the underlying `prjxray-db`/`apio` toolchain, which was fixed by `openXC7/prjxray-db#15` (now merged) and cross-checked independently against a full Vivado fuzzing campaign (`openXC7/prjxray-db#17`, byte-for-byte identical result). `FPGAwars/tools-openxc7#5` (the `chipdb-parts.json` manifest entry for this part) is the remaining piece before an official `apio` release can build for this board out of the box -- this PR just adds the Icestudio-side board definition so it's ready once that lands.
